### PR TITLE
Fixed ordering of types, constants, and globals

### DIFF
--- a/CSShaders/BackEnd/SpirVDummyEntryPointGenerator.cs
+++ b/CSShaders/BackEnd/SpirVDummyEntryPointGenerator.cs
@@ -7,10 +7,13 @@ namespace CSShaders
     public void CreateDummyEntryPoint(TypeDependencyCollector typeCollector, ShaderLibrary library, FrontEndTranslator frontEnd)
     {
       var unitTestTypes = new List<ShaderType>();
-      foreach (var type in typeCollector.mReferencedTypes)
+      foreach (var ir in typeCollector.mReferencedTypesConstantsAndGlobals)
       {
-        if (type.mMeta.mAttributes.Contains("UnitTest") && type.mEntryPoints.Count == 0)
-          unitTestTypes.Add(type);
+        if(ir is ShaderType type)
+        {
+          if (type.mMeta.mAttributes.Contains("UnitTest") && type.mEntryPoints.Count == 0)
+            unitTestTypes.Add(type);
+        }
       }
       foreach (var type in unitTestTypes)
         CreateDummyEntryPoint(typeCollector, library, frontEnd, type);

--- a/CSShaders/BackEnd/SpirVIdGenerator.cs
+++ b/CSShaders/BackEnd/SpirVIdGenerator.cs
@@ -27,17 +27,9 @@ namespace CSShaders
       {
         GenerateIds(extLibraryImport);
       }
-      foreach (var type in typeCollector.mReferencedTypes)
+      foreach (var ir in typeCollector.mReferencedTypesConstantsAndGlobals)
       {
-        GenerateIds(type);
-      }
-      foreach (var constantOp in typeCollector.mReferencedConstants)
-      {
-        GenerateIds(constantOp);
-      }
-      foreach (var staticOp in typeCollector.mReferencedStatics)
-      {
-        GenerateIds(staticOp);
+        GenerateIds(ir);
       }
       foreach (var function in typeCollector.mReferencedFunctions)
       {

--- a/CSShaders/BackEnd/TypeDependencyCollector.cs
+++ b/CSShaders/BackEnd/TypeDependencyCollector.cs
@@ -20,8 +20,8 @@ namespace CSShaders
       }
       foreach (var staticField in mOwningLibrary.mStaticGlobals.Values)
       {
-        mReferencedStatics.Add(staticField.InstanceOp);
         Visit(staticField.InstanceOp);
+        mReferencedTypesConstantsAndGlobals.Add(staticField.InstanceOp);
       }
       foreach (var type in mOwningLibrary.GetTypes())
       {
@@ -55,7 +55,7 @@ namespace CSShaders
       Visit(type.mParameters);
       Visit(type.mFields);
       // Only add this as a reference type once we finish walking fields/parameters. This is so we have guaranteed visit any nested types (or dereference types).
-      mReferencedTypes.Add(type);
+      mReferencedTypesConstantsAndGlobals.Add(type);
       VisitRequiredCapabilities(type);
 
       // Now visit the body of the functions and all of their ops
@@ -145,9 +145,10 @@ namespace CSShaders
 
     public void Visit(ShaderOp shaderOp)
     {
-      if (IsConstantOp(shaderOp))
-        mReferencedConstants.Add(shaderOp);
       Visit(shaderOp.mResultType);
+      if (IsConstantOp(shaderOp))
+        mReferencedTypesConstantsAndGlobals.Add(shaderOp);
+      
       foreach (var param in shaderOp.mParameters)
         Visit(param);
     }
@@ -161,9 +162,9 @@ namespace CSShaders
     {
       mEntryPoints.Add(entryPointInfo);
       foreach (var variable in entryPointInfo.mGlobalVariablesBlock.mLocalVariables)
-        mReferencedStatics.Add(variable as ShaderOp);
+        mReferencedTypesConstantsAndGlobals.Add(variable);
       foreach (var variable in entryPointInfo.mInterfaceVariables.mLocalVariables)
-        mReferencedStatics.Add(variable as ShaderOp);
+        mReferencedTypesConstantsAndGlobals.Add(variable);
       Visit(entryPointInfo.mGlobalVariablesBlock);
       Visit(entryPointInfo.mInterfaceVariables);
       Visit(entryPointInfo.mEntryPointFunction);
@@ -181,10 +182,8 @@ namespace CSShaders
 
     // Need a separate set to prevent infinite recursion but to not control the added order
     HashSet<ShaderType> mProcessedTypes = new HashSet<ShaderType>();
-    public OrderedSet<ShaderType> mReferencedTypes = new OrderedSet<ShaderType>();
     public OrderedSet<ShaderFunction> mReferencedFunctions = new OrderedSet<ShaderFunction>();
-    public OrderedSet<ShaderOp> mReferencedStatics = new OrderedSet<ShaderOp>();
-    public OrderedSet<ShaderOp> mReferencedConstants = new OrderedSet<ShaderOp>();
+    public OrderedSet<IShaderIR> mReferencedTypesConstantsAndGlobals = new OrderedSet<IShaderIR>();
     public OrderedSet<ExtensionLibraryImportOp> mReferencedExtensionLibraryImports = new OrderedSet<ExtensionLibraryImportOp>();
     public OrderedSet<ShaderEntryPointInfo> mEntryPoints = new OrderedSet<ShaderEntryPointInfo>();
     public OrderedSet<Spv.Capability> RequiredCapabilities = new OrderedSet<Spv.Capability>();

--- a/CSShaders/Core/Ops/ShaderType.cs
+++ b/CSShaders/Core/Ops/ShaderType.cs
@@ -76,6 +76,8 @@ namespace CSShaders
         var signedLiteral = mParameters[1] as ShaderConstantLiteral;
         return string.Format("{0}Int{1}", IsSignedInt(this) ? "" : "U", (uint)widthLiteral.mValue);
       }
+      if (mBaseType == OpType.Pointer)
+        return $"{mMeta.mName}*";
       return mMeta.mName;
     }
 

--- a/CSShadersTests/Tests/Fields/GetSetFields.expected.spvtxt
+++ b/CSShadersTests/Tests/Fields/GetSetFields.expected.spvtxt
@@ -29,26 +29,26 @@
                OpName %GetSetFields_Main_EntryPoint "GetSetFields_Main_EntryPoint"
                OpName %self_2 "self"
        %bool = OpTypeBool
+      %false = OpConstantFalse %bool
        %uint = OpTypeInt 32 0
+     %uint_0 = OpConstant %uint 0
         %int = OpTypeInt 32 1
+      %int_0 = OpConstant %int 0
+     %uint_1 = OpConstant %uint 1
+     %uint_2 = OpConstant %uint 2
       %float = OpTypeFloat 32
+    %float_0 = OpConstant %float 0
+     %uint_3 = OpConstant %uint 3
 %GetSetFields = OpTypeStruct %bool %int %uint %float
        %void = OpTypeVoid
 %_ptr_Function_GetSetFields = OpTypePointer Function %GetSetFields
-         %13 = OpTypeFunction %void %_ptr_Function_GetSetFields
+         %20 = OpTypeFunction %void %_ptr_Function_GetSetFields
 %_ptr_Function_bool = OpTypePointer Function %bool
 %_ptr_Function_int = OpTypePointer Function %int
 %_ptr_Function_uint = OpTypePointer Function %uint
 %_ptr_Function_float = OpTypePointer Function %float
-         %15 = OpTypeFunction %void
-      %false = OpConstantFalse %bool
-     %uint_0 = OpConstant %uint 0
-      %int_0 = OpConstant %int 0
-     %uint_1 = OpConstant %uint 1
-     %uint_2 = OpConstant %uint 2
-    %float_0 = OpConstant %float 0
-     %uint_3 = OpConstant %uint 3
-%GetSetFields_PreConstructor = OpFunction %void None %13
+         %22 = OpTypeFunction %void
+%GetSetFields_PreConstructor = OpFunction %void None %20
        %self = OpFunctionParameter %_ptr_Function_GetSetFields
          %27 = OpLabel
          %28 = OpAccessChain %_ptr_Function_bool %self %uint_0
@@ -61,13 +61,13 @@
                OpStore %34 %float_0
                OpReturn
                OpFunctionEnd
-%GetSetFields_DefaultConstructor = OpFunction %void None %13
+%GetSetFields_DefaultConstructor = OpFunction %void None %20
      %self_0 = OpFunctionParameter %_ptr_Function_GetSetFields
          %40 = OpLabel
          %41 = OpFunctionCall %void %GetSetFields_PreConstructor %self_0
                OpReturn
                OpFunctionEnd
-       %Main = OpFunction %void None %13
+       %Main = OpFunction %void None %20
      %self_1 = OpFunctionParameter %_ptr_Function_GetSetFields
          %46 = OpLabel
   %boolValue = OpVariable %_ptr_Function_bool Function
@@ -108,7 +108,7 @@
                OpStore %floatValue %81
                OpReturn
                OpFunctionEnd
-%GetSetFields_Main_EntryPoint = OpFunction %void None %15
+%GetSetFields_Main_EntryPoint = OpFunction %void None %22
          %86 = OpLabel
      %self_2 = OpVariable %_ptr_Function_GetSetFields Function
          %88 = OpFunctionCall %void %GetSetFields_DefaultConstructor %self_2

--- a/CSShadersTests/Tests/Fields/GetSetStaticFields.expected.spvtxt
+++ b/CSShadersTests/Tests/Fields/GetSetStaticFields.expected.spvtxt
@@ -9,6 +9,10 @@
                OpEntryPoint Fragment %GetSetStaticFields_Main_EntryPoint "GetSetStaticFields_Main_EntryPoint" %BoolValue %IntValue %UIntValue %FloatValue
                OpExecutionMode %GetSetStaticFields_Main_EntryPoint OriginUpperLeft
                OpSource Unknown 100
+               OpName %BoolValue "BoolValue"
+               OpName %IntValue "IntValue"
+               OpName %UIntValue "UIntValue"
+               OpName %FloatValue "FloatValue"
                OpName %GetSetStaticFields "GetSetStaticFields"
                OpName %GetSetStaticFields_PreConstructor "GetSetStaticFields_PreConstructor"
                OpName %self "self"
@@ -23,49 +27,45 @@
                OpName %GetSetStaticFields_InitGlobals "GetSetStaticFields_InitGlobals"
                OpName %GetSetStaticFields_Main_EntryPoint "GetSetStaticFields_Main_EntryPoint"
                OpName %self_2 "self"
-               OpName %BoolValue "BoolValue"
-               OpName %IntValue "IntValue"
-               OpName %UIntValue "UIntValue"
-               OpName %FloatValue "FloatValue"
                OpName %GetSetStaticFields_Main_EntryPoint "GetSetStaticFields_Main_EntryPoint"
                OpName %self_2 "self"
        %bool = OpTypeBool
+      %false = OpConstantFalse %bool
        %uint = OpTypeInt 32 0
         %int = OpTypeInt 32 1
+      %int_0 = OpConstant %int 0
+     %uint_0 = OpConstant %uint 0
       %float = OpTypeFloat 32
+    %float_0 = OpConstant %float 0
 %_ptr_Private_bool = OpTypePointer Private %bool
+  %BoolValue = OpVariable %_ptr_Private_bool Private
 %_ptr_Private_int = OpTypePointer Private %int
+   %IntValue = OpVariable %_ptr_Private_int Private
 %_ptr_Private_uint = OpTypePointer Private %uint
+  %UIntValue = OpVariable %_ptr_Private_uint Private
 %_ptr_Private_float = OpTypePointer Private %float
+ %FloatValue = OpVariable %_ptr_Private_float Private
 %GetSetStaticFields = OpTypeStruct
        %void = OpTypeVoid
 %_ptr_Function_GetSetStaticFields = OpTypePointer Function %GetSetStaticFields
-         %17 = OpTypeFunction %void %_ptr_Function_GetSetStaticFields
+         %25 = OpTypeFunction %void %_ptr_Function_GetSetStaticFields
 %_ptr_Function_bool = OpTypePointer Function %bool
 %_ptr_Function_int = OpTypePointer Function %int
 %_ptr_Function_uint = OpTypePointer Function %uint
 %_ptr_Function_float = OpTypePointer Function %float
-         %19 = OpTypeFunction %void
-      %false = OpConstantFalse %bool
-      %int_0 = OpConstant %int 0
-     %uint_0 = OpConstant %uint 0
-    %float_0 = OpConstant %float 0
-  %BoolValue = OpVariable %_ptr_Private_bool Private
-   %IntValue = OpVariable %_ptr_Private_int Private
-  %UIntValue = OpVariable %_ptr_Private_uint Private
- %FloatValue = OpVariable %_ptr_Private_float Private
-%GetSetStaticFields_PreConstructor = OpFunction %void None %17
+         %27 = OpTypeFunction %void
+%GetSetStaticFields_PreConstructor = OpFunction %void None %25
        %self = OpFunctionParameter %_ptr_Function_GetSetStaticFields
          %32 = OpLabel
                OpReturn
                OpFunctionEnd
-%GetSetStaticFields_DefaultConstructor = OpFunction %void None %17
+%GetSetStaticFields_DefaultConstructor = OpFunction %void None %25
      %self_0 = OpFunctionParameter %_ptr_Function_GetSetStaticFields
          %37 = OpLabel
          %38 = OpFunctionCall %void %GetSetStaticFields_PreConstructor %self_0
                OpReturn
                OpFunctionEnd
-       %Main = OpFunction %void None %17
+       %Main = OpFunction %void None %25
      %self_1 = OpFunctionParameter %_ptr_Function_GetSetStaticFields
          %43 = OpLabel
   %boolValue = OpVariable %_ptr_Function_bool Function
@@ -94,7 +94,7 @@
                OpStore %floatValue %66
                OpReturn
                OpFunctionEnd
-%GetSetStaticFields_InitGlobals = OpFunction %void None %19
+%GetSetStaticFields_InitGlobals = OpFunction %void None %27
          %71 = OpLabel
                OpStore %BoolValue %false
                OpStore %IntValue %int_0
@@ -102,7 +102,7 @@
                OpStore %FloatValue %float_0
                OpReturn
                OpFunctionEnd
-%GetSetStaticFields_Main_EntryPoint = OpFunction %void None %19
+%GetSetStaticFields_Main_EntryPoint = OpFunction %void None %27
          %79 = OpLabel
      %self_2 = OpVariable %_ptr_Function_GetSetStaticFields Function
          %81 = OpFunctionCall %void %GetSetStaticFields_InitGlobals

--- a/CSShadersTests/Tests/Fields/Initializers/PrimitiveFieldDefaultInitializers.expected.spvtxt
+++ b/CSShadersTests/Tests/Fields/Initializers/PrimitiveFieldDefaultInitializers.expected.spvtxt
@@ -25,26 +25,26 @@
                OpName %PrimitiveFieldDefaultInitializers_Main_EntryPoint "PrimitiveFieldDefaultInitializers_Main_EntryPoint"
                OpName %self_2 "self"
        %bool = OpTypeBool
+      %false = OpConstantFalse %bool
        %uint = OpTypeInt 32 0
+     %uint_0 = OpConstant %uint 0
         %int = OpTypeInt 32 1
+      %int_0 = OpConstant %int 0
+     %uint_1 = OpConstant %uint 1
+     %uint_2 = OpConstant %uint 2
       %float = OpTypeFloat 32
+    %float_0 = OpConstant %float 0
+     %uint_3 = OpConstant %uint 3
 %PrimitiveFieldDefaultInitializers = OpTypeStruct %bool %int %uint %float
        %void = OpTypeVoid
 %_ptr_Function_PrimitiveFieldDefaultInitializers = OpTypePointer Function %PrimitiveFieldDefaultInitializers
-         %13 = OpTypeFunction %void %_ptr_Function_PrimitiveFieldDefaultInitializers
+         %20 = OpTypeFunction %void %_ptr_Function_PrimitiveFieldDefaultInitializers
 %_ptr_Function_bool = OpTypePointer Function %bool
 %_ptr_Function_int = OpTypePointer Function %int
 %_ptr_Function_uint = OpTypePointer Function %uint
 %_ptr_Function_float = OpTypePointer Function %float
-         %15 = OpTypeFunction %void
-      %false = OpConstantFalse %bool
-     %uint_0 = OpConstant %uint 0
-      %int_0 = OpConstant %int 0
-     %uint_1 = OpConstant %uint 1
-     %uint_2 = OpConstant %uint 2
-    %float_0 = OpConstant %float 0
-     %uint_3 = OpConstant %uint 3
-%PrimitiveFieldDefaultInitializers_PreConstructor = OpFunction %void None %13
+         %22 = OpTypeFunction %void
+%PrimitiveFieldDefaultInitializers_PreConstructor = OpFunction %void None %20
        %self = OpFunctionParameter %_ptr_Function_PrimitiveFieldDefaultInitializers
          %27 = OpLabel
          %28 = OpAccessChain %_ptr_Function_bool %self %uint_0
@@ -57,18 +57,18 @@
                OpStore %34 %float_0
                OpReturn
                OpFunctionEnd
-%PrimitiveFieldDefaultInitializers_DefaultConstructor = OpFunction %void None %13
+%PrimitiveFieldDefaultInitializers_DefaultConstructor = OpFunction %void None %20
      %self_0 = OpFunctionParameter %_ptr_Function_PrimitiveFieldDefaultInitializers
          %40 = OpLabel
          %41 = OpFunctionCall %void %PrimitiveFieldDefaultInitializers_PreConstructor %self_0
                OpReturn
                OpFunctionEnd
-       %Main = OpFunction %void None %13
+       %Main = OpFunction %void None %20
      %self_1 = OpFunctionParameter %_ptr_Function_PrimitiveFieldDefaultInitializers
          %46 = OpLabel
                OpReturn
                OpFunctionEnd
-%PrimitiveFieldDefaultInitializers_Main_EntryPoint = OpFunction %void None %15
+%PrimitiveFieldDefaultInitializers_Main_EntryPoint = OpFunction %void None %22
          %50 = OpLabel
      %self_2 = OpVariable %_ptr_Function_PrimitiveFieldDefaultInitializers Function
          %52 = OpFunctionCall %void %PrimitiveFieldDefaultInitializers_DefaultConstructor %self_2

--- a/CSShadersTests/Tests/Fields/Initializers/PrimitiveFieldExplicitComplexInitializers.expected.spvtxt
+++ b/CSShadersTests/Tests/Fields/Initializers/PrimitiveFieldExplicitComplexInitializers.expected.spvtxt
@@ -34,60 +34,60 @@
                OpName %PrimitiveFieldExplicitComplexInitializers_Main_EntryPoint "PrimitiveFieldExplicitComplexInitializers_Main_EntryPoint"
                OpName %self_4 "self"
        %uint = OpTypeInt 32 0
-       %bool = OpTypeBool
-        %int = OpTypeInt 32 1
-      %float = OpTypeFloat 32
-%InitialValues = OpTypeStruct
-       %void = OpTypeVoid
-%_ptr_Function_InitialValues = OpTypePointer Function %InitialValues
-         %13 = OpTypeFunction %void %_ptr_Function_InitialValues
-         %15 = OpTypeFunction %bool
-         %17 = OpTypeFunction %int
-         %19 = OpTypeFunction %uint
-         %21 = OpTypeFunction %float
-%PrimitiveFieldExplicitComplexInitializers = OpTypeStruct %bool %int %uint %float
-%_ptr_Function_PrimitiveFieldExplicitComplexInitializers = OpTypePointer Function %PrimitiveFieldExplicitComplexInitializers
-         %25 = OpTypeFunction %void %_ptr_Function_PrimitiveFieldExplicitComplexInitializers
-%_ptr_Function_bool = OpTypePointer Function %bool
-%_ptr_Function_int = OpTypePointer Function %int
-%_ptr_Function_uint = OpTypePointer Function %uint
-%_ptr_Function_float = OpTypePointer Function %float
-         %27 = OpTypeFunction %void
      %uint_0 = OpConstant %uint 0
      %uint_1 = OpConstant %uint 1
      %uint_2 = OpConstant %uint 2
      %uint_3 = OpConstant %uint 3
+       %bool = OpTypeBool
       %false = OpConstantFalse %bool
+        %int = OpTypeInt 32 1
       %int_1 = OpConstant %int 1
+      %float = OpTypeFloat 32
     %float_3 = OpConstant %float 3
-%InitialValues_PreConstructor = OpFunction %void None %13
+%InitialValues = OpTypeStruct
+       %void = OpTypeVoid
+%_ptr_Function_InitialValues = OpTypePointer Function %InitialValues
+         %20 = OpTypeFunction %void %_ptr_Function_InitialValues
+         %22 = OpTypeFunction %bool
+         %24 = OpTypeFunction %int
+         %26 = OpTypeFunction %uint
+         %28 = OpTypeFunction %float
+%PrimitiveFieldExplicitComplexInitializers = OpTypeStruct %bool %int %uint %float
+%_ptr_Function_PrimitiveFieldExplicitComplexInitializers = OpTypePointer Function %PrimitiveFieldExplicitComplexInitializers
+         %32 = OpTypeFunction %void %_ptr_Function_PrimitiveFieldExplicitComplexInitializers
+%_ptr_Function_bool = OpTypePointer Function %bool
+%_ptr_Function_int = OpTypePointer Function %int
+%_ptr_Function_uint = OpTypePointer Function %uint
+%_ptr_Function_float = OpTypePointer Function %float
+         %34 = OpTypeFunction %void
+%InitialValues_PreConstructor = OpFunction %void None %20
        %self = OpFunctionParameter %_ptr_Function_InitialValues
          %39 = OpLabel
                OpReturn
                OpFunctionEnd
-%InitialValues_DefaultConstructor = OpFunction %void None %13
+%InitialValues_DefaultConstructor = OpFunction %void None %20
      %self_0 = OpFunctionParameter %_ptr_Function_InitialValues
          %44 = OpLabel
          %45 = OpFunctionCall %void %InitialValues_PreConstructor %self_0
                OpReturn
                OpFunctionEnd
-    %GetBool = OpFunction %bool None %15
+    %GetBool = OpFunction %bool None %22
          %49 = OpLabel
                OpReturnValue %false
                OpFunctionEnd
-     %GetInt = OpFunction %int None %17
+     %GetInt = OpFunction %int None %24
          %53 = OpLabel
                OpReturnValue %int_1
                OpFunctionEnd
-    %GetUint = OpFunction %uint None %19
+    %GetUint = OpFunction %uint None %26
          %57 = OpLabel
                OpReturnValue %uint_2
                OpFunctionEnd
-   %GetFloat = OpFunction %float None %21
+   %GetFloat = OpFunction %float None %28
          %61 = OpLabel
                OpReturnValue %float_3
                OpFunctionEnd
-%PrimitiveFieldExplicitComplexInitializers_PreConstructor = OpFunction %void None %25
+%PrimitiveFieldExplicitComplexInitializers_PreConstructor = OpFunction %void None %32
      %self_1 = OpFunctionParameter %_ptr_Function_PrimitiveFieldExplicitComplexInitializers
          %66 = OpLabel
          %67 = OpFunctionCall %bool %GetBool
@@ -104,18 +104,18 @@
                OpStore %77 %76
                OpReturn
                OpFunctionEnd
-%PrimitiveFieldExplicitComplexInitializers_DefaultConstructor = OpFunction %void None %25
+%PrimitiveFieldExplicitComplexInitializers_DefaultConstructor = OpFunction %void None %32
      %self_2 = OpFunctionParameter %_ptr_Function_PrimitiveFieldExplicitComplexInitializers
          %83 = OpLabel
          %84 = OpFunctionCall %void %PrimitiveFieldExplicitComplexInitializers_PreConstructor %self_2
                OpReturn
                OpFunctionEnd
-       %Main = OpFunction %void None %25
+       %Main = OpFunction %void None %32
      %self_3 = OpFunctionParameter %_ptr_Function_PrimitiveFieldExplicitComplexInitializers
          %89 = OpLabel
                OpReturn
                OpFunctionEnd
-%PrimitiveFieldExplicitComplexInitializers_Main_EntryPoint = OpFunction %void None %27
+%PrimitiveFieldExplicitComplexInitializers_Main_EntryPoint = OpFunction %void None %34
          %93 = OpLabel
      %self_4 = OpVariable %_ptr_Function_PrimitiveFieldExplicitComplexInitializers Function
          %95 = OpFunctionCall %void %PrimitiveFieldExplicitComplexInitializers_DefaultConstructor %self_4

--- a/CSShadersTests/Tests/Fields/Initializers/PrimitiveFieldExplicitSimpleInitializers.expected.spvtxt
+++ b/CSShadersTests/Tests/Fields/Initializers/PrimitiveFieldExplicitSimpleInitializers.expected.spvtxt
@@ -25,26 +25,26 @@
                OpName %PrimitiveFieldExplicitSimpleInitializers_Main_EntryPoint "PrimitiveFieldExplicitSimpleInitializers_Main_EntryPoint"
                OpName %self_2 "self"
        %bool = OpTypeBool
+       %true = OpConstantTrue %bool
        %uint = OpTypeInt 32 0
+     %uint_0 = OpConstant %uint 0
         %int = OpTypeInt 32 1
+      %int_1 = OpConstant %int 1
+     %uint_1 = OpConstant %uint 1
+     %uint_2 = OpConstant %uint 2
       %float = OpTypeFloat 32
+    %float_3 = OpConstant %float 3
+     %uint_3 = OpConstant %uint 3
 %PrimitiveFieldExplicitSimpleInitializers = OpTypeStruct %bool %int %uint %float
        %void = OpTypeVoid
 %_ptr_Function_PrimitiveFieldExplicitSimpleInitializers = OpTypePointer Function %PrimitiveFieldExplicitSimpleInitializers
-         %13 = OpTypeFunction %void %_ptr_Function_PrimitiveFieldExplicitSimpleInitializers
+         %20 = OpTypeFunction %void %_ptr_Function_PrimitiveFieldExplicitSimpleInitializers
 %_ptr_Function_bool = OpTypePointer Function %bool
 %_ptr_Function_int = OpTypePointer Function %int
 %_ptr_Function_uint = OpTypePointer Function %uint
 %_ptr_Function_float = OpTypePointer Function %float
-         %15 = OpTypeFunction %void
-       %true = OpConstantTrue %bool
-     %uint_0 = OpConstant %uint 0
-      %int_1 = OpConstant %int 1
-     %uint_1 = OpConstant %uint 1
-     %uint_2 = OpConstant %uint 2
-    %float_3 = OpConstant %float 3
-     %uint_3 = OpConstant %uint 3
-%PrimitiveFieldExplicitSimpleInitializers_PreConstructor = OpFunction %void None %13
+         %22 = OpTypeFunction %void
+%PrimitiveFieldExplicitSimpleInitializers_PreConstructor = OpFunction %void None %20
        %self = OpFunctionParameter %_ptr_Function_PrimitiveFieldExplicitSimpleInitializers
          %27 = OpLabel
          %28 = OpAccessChain %_ptr_Function_bool %self %uint_0
@@ -57,18 +57,18 @@
                OpStore %34 %float_3
                OpReturn
                OpFunctionEnd
-%PrimitiveFieldExplicitSimpleInitializers_DefaultConstructor = OpFunction %void None %13
+%PrimitiveFieldExplicitSimpleInitializers_DefaultConstructor = OpFunction %void None %20
      %self_0 = OpFunctionParameter %_ptr_Function_PrimitiveFieldExplicitSimpleInitializers
          %40 = OpLabel
          %41 = OpFunctionCall %void %PrimitiveFieldExplicitSimpleInitializers_PreConstructor %self_0
                OpReturn
                OpFunctionEnd
-       %Main = OpFunction %void None %13
+       %Main = OpFunction %void None %20
      %self_1 = OpFunctionParameter %_ptr_Function_PrimitiveFieldExplicitSimpleInitializers
          %46 = OpLabel
                OpReturn
                OpFunctionEnd
-%PrimitiveFieldExplicitSimpleInitializers_Main_EntryPoint = OpFunction %void None %15
+%PrimitiveFieldExplicitSimpleInitializers_Main_EntryPoint = OpFunction %void None %22
          %50 = OpLabel
      %self_2 = OpVariable %_ptr_Function_PrimitiveFieldExplicitSimpleInitializers Function
          %52 = OpFunctionCall %void %PrimitiveFieldExplicitSimpleInitializers_DefaultConstructor %self_2

--- a/CSShadersTests/Tests/Fields/Initializers/StructFieldConstructorInitializers.expected.spvtxt
+++ b/CSShadersTests/Tests/Fields/Initializers/StructFieldConstructorInitializers.expected.spvtxt
@@ -33,33 +33,33 @@
                OpName %self_5 "self"
        %uint = OpTypeInt 32 0
         %int = OpTypeInt 32 1
-  %SubStruct = OpTypeStruct %int
-       %void = OpTypeVoid
-%_ptr_Function_SubStruct = OpTypePointer Function %SubStruct
-          %9 = OpTypeFunction %void %_ptr_Function_SubStruct
-%_ptr_Function_int = OpTypePointer Function %int
-         %11 = OpTypeFunction %void %_ptr_Function_SubStruct %int
-%StructFieldConstructorInitializers = OpTypeStruct %SubStruct
-%_ptr_Function_StructFieldConstructorInitializers = OpTypePointer Function %StructFieldConstructorInitializers
-         %15 = OpTypeFunction %void %_ptr_Function_StructFieldConstructorInitializers
-         %17 = OpTypeFunction %void
       %int_0 = OpConstant %int 0
      %uint_0 = OpConstant %uint 0
       %int_1 = OpConstant %int 1
-%SubStruct_PreConstructor = OpFunction %void None %9
+  %SubStruct = OpTypeStruct %int
+       %void = OpTypeVoid
+%_ptr_Function_SubStruct = OpTypePointer Function %SubStruct
+         %12 = OpTypeFunction %void %_ptr_Function_SubStruct
+%_ptr_Function_int = OpTypePointer Function %int
+         %14 = OpTypeFunction %void %_ptr_Function_SubStruct %int
+%StructFieldConstructorInitializers = OpTypeStruct %SubStruct
+%_ptr_Function_StructFieldConstructorInitializers = OpTypePointer Function %StructFieldConstructorInitializers
+         %18 = OpTypeFunction %void %_ptr_Function_StructFieldConstructorInitializers
+         %20 = OpTypeFunction %void
+%SubStruct_PreConstructor = OpFunction %void None %12
        %self = OpFunctionParameter %_ptr_Function_SubStruct
          %25 = OpLabel
          %26 = OpAccessChain %_ptr_Function_int %self %uint_0
                OpStore %26 %int_0
                OpReturn
                OpFunctionEnd
-%SubStruct_DefaultConstructor = OpFunction %void None %9
+%SubStruct_DefaultConstructor = OpFunction %void None %12
      %self_0 = OpFunctionParameter %_ptr_Function_SubStruct
          %32 = OpLabel
          %33 = OpFunctionCall %void %SubStruct_PreConstructor %self_0
                OpReturn
                OpFunctionEnd
-%SubStruct_Constructor = OpFunction %void None %11
+%SubStruct_Constructor = OpFunction %void None %14
      %self_1 = OpFunctionParameter %_ptr_Function_SubStruct
       %value = OpFunctionParameter %int
          %39 = OpLabel
@@ -67,7 +67,7 @@
                OpStore %40 %value
                OpReturn
                OpFunctionEnd
-%StructFieldConstructorInitializers_PreConstructor = OpFunction %void None %15
+%StructFieldConstructorInitializers_PreConstructor = OpFunction %void None %18
      %self_2 = OpFunctionParameter %_ptr_Function_StructFieldConstructorInitializers
          %46 = OpLabel
 %tempSubStruct = OpVariable %_ptr_Function_SubStruct Function
@@ -77,18 +77,18 @@
                OpStore %50 %49
                OpReturn
                OpFunctionEnd
-%StructFieldConstructorInitializers_DefaultConstructor = OpFunction %void None %15
+%StructFieldConstructorInitializers_DefaultConstructor = OpFunction %void None %18
      %self_3 = OpFunctionParameter %_ptr_Function_StructFieldConstructorInitializers
          %56 = OpLabel
          %57 = OpFunctionCall %void %StructFieldConstructorInitializers_PreConstructor %self_3
                OpReturn
                OpFunctionEnd
-       %Main = OpFunction %void None %15
+       %Main = OpFunction %void None %18
      %self_4 = OpFunctionParameter %_ptr_Function_StructFieldConstructorInitializers
          %62 = OpLabel
                OpReturn
                OpFunctionEnd
-%StructFieldConstructorInitializers_Main_EntryPoint = OpFunction %void None %17
+%StructFieldConstructorInitializers_Main_EntryPoint = OpFunction %void None %20
          %66 = OpLabel
      %self_5 = OpVariable %_ptr_Function_StructFieldConstructorInitializers Function
          %68 = OpFunctionCall %void %StructFieldConstructorInitializers_DefaultConstructor %self_5

--- a/CSShadersTests/Tests/Fields/Initializers/StructFieldDefaultInitializers.expected.spvtxt
+++ b/CSShadersTests/Tests/Fields/Initializers/StructFieldDefaultInitializers.expected.spvtxt
@@ -30,31 +30,31 @@
                OpName %self_4 "self"
        %uint = OpTypeInt 32 0
         %int = OpTypeInt 32 1
+      %int_0 = OpConstant %int 0
+     %uint_0 = OpConstant %uint 0
   %SubStruct = OpTypeStruct %int
        %void = OpTypeVoid
 %_ptr_Function_SubStruct = OpTypePointer Function %SubStruct
-          %9 = OpTypeFunction %void %_ptr_Function_SubStruct
+         %11 = OpTypeFunction %void %_ptr_Function_SubStruct
 %_ptr_Function_int = OpTypePointer Function %int
 %StructFieldDefaultInitializers = OpTypeStruct %SubStruct
 %_ptr_Function_StructFieldDefaultInitializers = OpTypePointer Function %StructFieldDefaultInitializers
-         %13 = OpTypeFunction %void %_ptr_Function_StructFieldDefaultInitializers
-         %15 = OpTypeFunction %void
-      %int_0 = OpConstant %int 0
-     %uint_0 = OpConstant %uint 0
-%SubStruct_PreConstructor = OpFunction %void None %9
+         %15 = OpTypeFunction %void %_ptr_Function_StructFieldDefaultInitializers
+         %17 = OpTypeFunction %void
+%SubStruct_PreConstructor = OpFunction %void None %11
        %self = OpFunctionParameter %_ptr_Function_SubStruct
          %22 = OpLabel
          %23 = OpAccessChain %_ptr_Function_int %self %uint_0
                OpStore %23 %int_0
                OpReturn
                OpFunctionEnd
-%SubStruct_DefaultConstructor = OpFunction %void None %9
+%SubStruct_DefaultConstructor = OpFunction %void None %11
      %self_0 = OpFunctionParameter %_ptr_Function_SubStruct
          %29 = OpLabel
          %30 = OpFunctionCall %void %SubStruct_PreConstructor %self_0
                OpReturn
                OpFunctionEnd
-%StructFieldDefaultInitializers_PreConstructor = OpFunction %void None %13
+%StructFieldDefaultInitializers_PreConstructor = OpFunction %void None %15
      %self_1 = OpFunctionParameter %_ptr_Function_StructFieldDefaultInitializers
          %35 = OpLabel
 %tempSubStruct = OpVariable %_ptr_Function_SubStruct Function
@@ -64,18 +64,18 @@
                OpStore %39 %38
                OpReturn
                OpFunctionEnd
-%StructFieldDefaultInitializers_DefaultConstructor = OpFunction %void None %13
+%StructFieldDefaultInitializers_DefaultConstructor = OpFunction %void None %15
      %self_2 = OpFunctionParameter %_ptr_Function_StructFieldDefaultInitializers
          %45 = OpLabel
          %46 = OpFunctionCall %void %StructFieldDefaultInitializers_PreConstructor %self_2
                OpReturn
                OpFunctionEnd
-       %Main = OpFunction %void None %13
+       %Main = OpFunction %void None %15
      %self_3 = OpFunctionParameter %_ptr_Function_StructFieldDefaultInitializers
          %51 = OpLabel
                OpReturn
                OpFunctionEnd
-%StructFieldDefaultInitializers_Main_EntryPoint = OpFunction %void None %15
+%StructFieldDefaultInitializers_Main_EntryPoint = OpFunction %void None %17
          %55 = OpLabel
      %self_4 = OpVariable %_ptr_Function_StructFieldDefaultInitializers Function
          %57 = OpFunctionCall %void %StructFieldDefaultInitializers_DefaultConstructor %self_4

--- a/CSShadersTests/Tests/Fields/Initializers/StructFieldInitializerListInitializers.expected.spvtxt
+++ b/CSShadersTests/Tests/Fields/Initializers/StructFieldInitializerListInitializers.expected.spvtxt
@@ -31,24 +31,24 @@
                OpName %self_4 "self"
        %uint = OpTypeInt 32 0
         %int = OpTypeInt 32 1
-      %float = OpTypeFloat 32
-  %SubStruct = OpTypeStruct %int %float
-       %void = OpTypeVoid
-%_ptr_Function_SubStruct = OpTypePointer Function %SubStruct
-         %11 = OpTypeFunction %void %_ptr_Function_SubStruct
-%_ptr_Function_int = OpTypePointer Function %int
-%_ptr_Function_float = OpTypePointer Function %float
-%StructFieldConstructorInitializers = OpTypeStruct %SubStruct
-%_ptr_Function_StructFieldConstructorInitializers = OpTypePointer Function %StructFieldConstructorInitializers
-         %15 = OpTypeFunction %void %_ptr_Function_StructFieldConstructorInitializers
-         %17 = OpTypeFunction %void
       %int_0 = OpConstant %int 0
      %uint_0 = OpConstant %uint 0
+      %float = OpTypeFloat 32
     %float_1 = OpConstant %float 1
      %uint_1 = OpConstant %uint 1
       %int_3 = OpConstant %int 3
 %float_3_0999999 = OpConstant %float 3.0999999
-%SubStruct_PreConstructor = OpFunction %void None %11
+  %SubStruct = OpTypeStruct %int %float
+       %void = OpTypeVoid
+%_ptr_Function_SubStruct = OpTypePointer Function %SubStruct
+         %17 = OpTypeFunction %void %_ptr_Function_SubStruct
+%_ptr_Function_int = OpTypePointer Function %int
+%_ptr_Function_float = OpTypePointer Function %float
+%StructFieldConstructorInitializers = OpTypeStruct %SubStruct
+%_ptr_Function_StructFieldConstructorInitializers = OpTypePointer Function %StructFieldConstructorInitializers
+         %21 = OpTypeFunction %void %_ptr_Function_StructFieldConstructorInitializers
+         %23 = OpTypeFunction %void
+%SubStruct_PreConstructor = OpFunction %void None %17
        %self = OpFunctionParameter %_ptr_Function_SubStruct
          %28 = OpLabel
          %29 = OpAccessChain %_ptr_Function_int %self %uint_0
@@ -57,13 +57,13 @@
                OpStore %31 %float_1
                OpReturn
                OpFunctionEnd
-%SubStruct_DefaultConstructor = OpFunction %void None %11
+%SubStruct_DefaultConstructor = OpFunction %void None %17
      %self_0 = OpFunctionParameter %_ptr_Function_SubStruct
          %37 = OpLabel
          %38 = OpFunctionCall %void %SubStruct_PreConstructor %self_0
                OpReturn
                OpFunctionEnd
-%StructFieldConstructorInitializers_PreConstructor = OpFunction %void None %15
+%StructFieldConstructorInitializers_PreConstructor = OpFunction %void None %21
      %self_1 = OpFunctionParameter %_ptr_Function_StructFieldConstructorInitializers
          %43 = OpLabel
 %tempSubStruct = OpVariable %_ptr_Function_SubStruct Function
@@ -77,18 +77,18 @@
                OpStore %51 %50
                OpReturn
                OpFunctionEnd
-%StructFieldConstructorInitializers_DefaultConstructor = OpFunction %void None %15
+%StructFieldConstructorInitializers_DefaultConstructor = OpFunction %void None %21
      %self_2 = OpFunctionParameter %_ptr_Function_StructFieldConstructorInitializers
          %57 = OpLabel
          %58 = OpFunctionCall %void %StructFieldConstructorInitializers_PreConstructor %self_2
                OpReturn
                OpFunctionEnd
-       %Main = OpFunction %void None %15
+       %Main = OpFunction %void None %21
      %self_3 = OpFunctionParameter %_ptr_Function_StructFieldConstructorInitializers
          %63 = OpLabel
                OpReturn
                OpFunctionEnd
-%StructFieldConstructorInitializers_Main_EntryPoint = OpFunction %void None %17
+%StructFieldConstructorInitializers_Main_EntryPoint = OpFunction %void None %23
          %67 = OpLabel
      %self_4 = OpVariable %_ptr_Function_StructFieldConstructorInitializers Function
          %69 = OpFunctionCall %void %StructFieldConstructorInitializers_DefaultConstructor %self_4

--- a/CSShadersTests/Tests/Functions/InstanceFunctionRef.expected.spvtxt
+++ b/CSShadersTests/Tests/Functions/InstanceFunctionRef.expected.spvtxt
@@ -26,34 +26,34 @@
                OpName %self_3 "self"
        %uint = OpTypeInt 32 0
         %int = OpTypeInt 32 1
+      %int_3 = OpConstant %int 3
+      %int_1 = OpConstant %int 1
 %InstanceFunctionRef = OpTypeStruct
        %void = OpTypeVoid
 %_ptr_Function_InstanceFunctionRef = OpTypePointer Function %InstanceFunctionRef
-          %9 = OpTypeFunction %void %_ptr_Function_InstanceFunctionRef
+         %11 = OpTypeFunction %void %_ptr_Function_InstanceFunctionRef
 %_ptr_Function_int = OpTypePointer Function %int
-         %11 = OpTypeFunction %void %_ptr_Function_InstanceFunctionRef %_ptr_Function_int
-         %13 = OpTypeFunction %void
-      %int_3 = OpConstant %int 3
-      %int_1 = OpConstant %int 1
-%InstanceFunctionRef_PreConstructor = OpFunction %void None %9
+         %13 = OpTypeFunction %void %_ptr_Function_InstanceFunctionRef %_ptr_Function_int
+         %15 = OpTypeFunction %void
+%InstanceFunctionRef_PreConstructor = OpFunction %void None %11
        %self = OpFunctionParameter %_ptr_Function_InstanceFunctionRef
          %20 = OpLabel
                OpReturn
                OpFunctionEnd
-%InstanceFunctionRef_DefaultConstructor = OpFunction %void None %9
+%InstanceFunctionRef_DefaultConstructor = OpFunction %void None %11
      %self_0 = OpFunctionParameter %_ptr_Function_InstanceFunctionRef
          %25 = OpLabel
          %26 = OpFunctionCall %void %InstanceFunctionRef_PreConstructor %self_0
                OpReturn
                OpFunctionEnd
-    %TestFn1 = OpFunction %void None %11
+    %TestFn1 = OpFunction %void None %13
      %self_1 = OpFunctionParameter %_ptr_Function_InstanceFunctionRef
       %value = OpFunctionParameter %_ptr_Function_int
          %32 = OpLabel
                OpStore %value %int_3
                OpReturn
                OpFunctionEnd
-       %Main = OpFunction %void None %9
+       %Main = OpFunction %void None %11
      %self_2 = OpFunctionParameter %_ptr_Function_InstanceFunctionRef
          %38 = OpLabel
     %value_0 = OpVariable %_ptr_Function_int Function
@@ -61,7 +61,7 @@
          %41 = OpFunctionCall %void %TestFn1 %self_2 %value_0
                OpReturn
                OpFunctionEnd
-%InstanceFunctionRef_Main_EntryPoint = OpFunction %void None %13
+%InstanceFunctionRef_Main_EntryPoint = OpFunction %void None %15
          %45 = OpLabel
      %self_3 = OpVariable %_ptr_Function_InstanceFunctionRef Function
          %47 = OpFunctionCall %void %InstanceFunctionRef_DefaultConstructor %self_3

--- a/CSShadersTests/Tests/Functions/SimpleFunctionDeclaration2.expected.spvtxt
+++ b/CSShadersTests/Tests/Functions/SimpleFunctionDeclaration2.expected.spvtxt
@@ -26,32 +26,32 @@
                OpName %self_3 "self"
        %uint = OpTypeInt 32 0
         %int = OpTypeInt 32 1
+      %int_1 = OpConstant %int 1
 %SimpleFunctionDeclaration2 = OpTypeStruct
        %void = OpTypeVoid
 %_ptr_Function_SimpleFunctionDeclaration2 = OpTypePointer Function %SimpleFunctionDeclaration2
-          %9 = OpTypeFunction %void %_ptr_Function_SimpleFunctionDeclaration2
-         %11 = OpTypeFunction %int %_ptr_Function_SimpleFunctionDeclaration2 %int
+         %10 = OpTypeFunction %void %_ptr_Function_SimpleFunctionDeclaration2
+         %12 = OpTypeFunction %int %_ptr_Function_SimpleFunctionDeclaration2 %int
 %_ptr_Function_int = OpTypePointer Function %int
-         %13 = OpTypeFunction %void
-      %int_1 = OpConstant %int 1
-%SimpleFunctionDeclaration2_PreConstructor = OpFunction %void None %9
+         %14 = OpTypeFunction %void
+%SimpleFunctionDeclaration2_PreConstructor = OpFunction %void None %10
        %self = OpFunctionParameter %_ptr_Function_SimpleFunctionDeclaration2
          %19 = OpLabel
                OpReturn
                OpFunctionEnd
-%SimpleFunctionDeclaration2_DefaultConstructor = OpFunction %void None %9
+%SimpleFunctionDeclaration2_DefaultConstructor = OpFunction %void None %10
      %self_0 = OpFunctionParameter %_ptr_Function_SimpleFunctionDeclaration2
          %24 = OpLabel
          %25 = OpFunctionCall %void %SimpleFunctionDeclaration2_PreConstructor %self_0
                OpReturn
                OpFunctionEnd
-   %GetValue = OpFunction %int None %11
+   %GetValue = OpFunction %int None %12
      %self_1 = OpFunctionParameter %_ptr_Function_SimpleFunctionDeclaration2
       %value = OpFunctionParameter %int
          %31 = OpLabel
                OpReturnValue %value
                OpFunctionEnd
-       %Main = OpFunction %void None %9
+       %Main = OpFunction %void None %10
      %self_2 = OpFunctionParameter %_ptr_Function_SimpleFunctionDeclaration2
          %36 = OpLabel
     %value_0 = OpVariable %_ptr_Function_int Function
@@ -59,7 +59,7 @@
                OpStore %value_0 %38
                OpReturn
                OpFunctionEnd
-%SimpleFunctionDeclaration2_Main_EntryPoint = OpFunction %void None %13
+%SimpleFunctionDeclaration2_Main_EntryPoint = OpFunction %void None %14
          %43 = OpLabel
      %self_3 = OpVariable %_ptr_Function_SimpleFunctionDeclaration2 Function
          %45 = OpFunctionCall %void %SimpleFunctionDeclaration2_DefaultConstructor %self_3

--- a/CSShadersTests/Tests/Functions/SimpleStaticFunctionDeclaration2.expected.spvtxt
+++ b/CSShadersTests/Tests/Functions/SimpleStaticFunctionDeclaration2.expected.spvtxt
@@ -26,32 +26,32 @@
                OpName %self_2 "self"
        %uint = OpTypeInt 32 0
         %int = OpTypeInt 32 1
+      %int_1 = OpConstant %int 1
+      %int_2 = OpConstant %int 2
 %SimpleStaticFunctionDeclaration2 = OpTypeStruct
        %void = OpTypeVoid
 %_ptr_Function_SimpleStaticFunctionDeclaration2 = OpTypePointer Function %SimpleStaticFunctionDeclaration2
-          %9 = OpTypeFunction %void %_ptr_Function_SimpleStaticFunctionDeclaration2
-         %11 = OpTypeFunction %int %int
+         %11 = OpTypeFunction %void %_ptr_Function_SimpleStaticFunctionDeclaration2
+         %13 = OpTypeFunction %int %int
 %_ptr_Function_int = OpTypePointer Function %int
-         %13 = OpTypeFunction %void
-      %int_1 = OpConstant %int 1
-      %int_2 = OpConstant %int 2
-%SimpleStaticFunctionDeclaration2_PreConstructor = OpFunction %void None %9
+         %15 = OpTypeFunction %void
+%SimpleStaticFunctionDeclaration2_PreConstructor = OpFunction %void None %11
        %self = OpFunctionParameter %_ptr_Function_SimpleStaticFunctionDeclaration2
          %20 = OpLabel
                OpReturn
                OpFunctionEnd
-%SimpleStaticFunctionDeclaration2_DefaultConstructor = OpFunction %void None %9
+%SimpleStaticFunctionDeclaration2_DefaultConstructor = OpFunction %void None %11
      %self_0 = OpFunctionParameter %_ptr_Function_SimpleStaticFunctionDeclaration2
          %25 = OpLabel
          %26 = OpFunctionCall %void %SimpleStaticFunctionDeclaration2_PreConstructor %self_0
                OpReturn
                OpFunctionEnd
-   %GetValue = OpFunction %int None %11
+   %GetValue = OpFunction %int None %13
       %value = OpFunctionParameter %int
          %31 = OpLabel
                OpReturnValue %value
                OpFunctionEnd
-       %Main = OpFunction %void None %9
+       %Main = OpFunction %void None %11
      %self_1 = OpFunctionParameter %_ptr_Function_SimpleStaticFunctionDeclaration2
          %36 = OpLabel
      %value1 = OpVariable %_ptr_Function_int Function
@@ -62,7 +62,7 @@
                OpStore %value2 %41
                OpReturn
                OpFunctionEnd
-%SimpleStaticFunctionDeclaration2_Main_EntryPoint = OpFunction %void None %13
+%SimpleStaticFunctionDeclaration2_Main_EntryPoint = OpFunction %void None %15
          %46 = OpLabel
      %self_2 = OpVariable %_ptr_Function_SimpleStaticFunctionDeclaration2 Function
          %48 = OpFunctionCall %void %SimpleStaticFunctionDeclaration2_DefaultConstructor %self_2

--- a/CSShadersTests/Tests/IntrinsicFunctions/Arithmetic Intrinsics/OpDot_IntrinsicTest.expected.spvtxt
+++ b/CSShadersTests/Tests/IntrinsicFunctions/Arithmetic Intrinsics/OpDot_IntrinsicTest.expected.spvtxt
@@ -29,10 +29,11 @@
                OpName %self_2 "self"
        %uint = OpTypeInt 32 0
       %float = OpTypeFloat 32
+    %float_0 = OpConstant %float 0
   %OpDotTest = OpTypeStruct
        %void = OpTypeVoid
 %_ptr_Function_OpDotTest = OpTypePointer Function %OpDotTest
-          %9 = OpTypeFunction %void %_ptr_Function_OpDotTest
+         %10 = OpTypeFunction %void %_ptr_Function_OpDotTest
 %_ptr_Function_float = OpTypePointer Function %float
     %Vector2 = OpTypeVector %float 2
 %_ptr_Function_Vector2 = OpTypePointer Function %Vector2
@@ -40,20 +41,19 @@
 %_ptr_Function_Vector3 = OpTypePointer Function %Vector3
     %Vector4 = OpTypeVector %float 4
 %_ptr_Function_Vector4 = OpTypePointer Function %Vector4
-         %17 = OpTypeFunction %void
-    %float_0 = OpConstant %float 0
-%OpDotTest_PreConstructor = OpFunction %void None %9
+         %18 = OpTypeFunction %void
+%OpDotTest_PreConstructor = OpFunction %void None %10
        %self = OpFunctionParameter %_ptr_Function_OpDotTest
          %23 = OpLabel
                OpReturn
                OpFunctionEnd
-%OpDotTest_DefaultConstructor = OpFunction %void None %9
+%OpDotTest_DefaultConstructor = OpFunction %void None %10
      %self_0 = OpFunctionParameter %_ptr_Function_OpDotTest
          %28 = OpLabel
          %29 = OpFunctionCall %void %OpDotTest_PreConstructor %self_0
                OpReturn
                OpFunctionEnd
-       %Main = OpFunction %void None %9
+       %Main = OpFunction %void None %10
      %self_1 = OpFunctionParameter %_ptr_Function_OpDotTest
          %34 = OpLabel
    %floatVal = OpVariable %_ptr_Function_float Function
@@ -81,7 +81,7 @@
                OpStore %floatVal %56
                OpReturn
                OpFunctionEnd
-%OpDotTest_Main_EntryPoint = OpFunction %void None %17
+%OpDotTest_Main_EntryPoint = OpFunction %void None %18
          %61 = OpLabel
      %self_2 = OpVariable %_ptr_Function_OpDotTest Function
          %63 = OpFunctionCall %void %OpDotTest_DefaultConstructor %self_2

--- a/CSShadersTests/Tests/IntrinsicFunctions/Arithmetic Intrinsics/OpFAdd_IntrinsicTest.expected.spvtxt
+++ b/CSShadersTests/Tests/IntrinsicFunctions/Arithmetic Intrinsics/OpFAdd_IntrinsicTest.expected.spvtxt
@@ -29,10 +29,11 @@
                OpName %self_2 "self"
        %uint = OpTypeInt 32 0
       %float = OpTypeFloat 32
+    %float_0 = OpConstant %float 0
  %OpFAddTest = OpTypeStruct
        %void = OpTypeVoid
 %_ptr_Function_OpFAddTest = OpTypePointer Function %OpFAddTest
-          %9 = OpTypeFunction %void %_ptr_Function_OpFAddTest
+         %10 = OpTypeFunction %void %_ptr_Function_OpFAddTest
 %_ptr_Function_float = OpTypePointer Function %float
     %Vector2 = OpTypeVector %float 2
 %_ptr_Function_Vector2 = OpTypePointer Function %Vector2
@@ -40,20 +41,19 @@
 %_ptr_Function_Vector3 = OpTypePointer Function %Vector3
     %Vector4 = OpTypeVector %float 4
 %_ptr_Function_Vector4 = OpTypePointer Function %Vector4
-         %17 = OpTypeFunction %void
-    %float_0 = OpConstant %float 0
-%OpFAddTest_PreConstructor = OpFunction %void None %9
+         %18 = OpTypeFunction %void
+%OpFAddTest_PreConstructor = OpFunction %void None %10
        %self = OpFunctionParameter %_ptr_Function_OpFAddTest
          %23 = OpLabel
                OpReturn
                OpFunctionEnd
-%OpFAddTest_DefaultConstructor = OpFunction %void None %9
+%OpFAddTest_DefaultConstructor = OpFunction %void None %10
      %self_0 = OpFunctionParameter %_ptr_Function_OpFAddTest
          %28 = OpLabel
          %29 = OpFunctionCall %void %OpFAddTest_PreConstructor %self_0
                OpReturn
                OpFunctionEnd
-       %Main = OpFunction %void None %9
+       %Main = OpFunction %void None %10
      %self_1 = OpFunctionParameter %_ptr_Function_OpFAddTest
          %34 = OpLabel
    %floatVal = OpVariable %_ptr_Function_float Function
@@ -85,7 +85,7 @@
                OpStore %vector4Val %60
                OpReturn
                OpFunctionEnd
-%OpFAddTest_Main_EntryPoint = OpFunction %void None %17
+%OpFAddTest_Main_EntryPoint = OpFunction %void None %18
          %65 = OpLabel
      %self_2 = OpVariable %_ptr_Function_OpFAddTest Function
          %67 = OpFunctionCall %void %OpFAddTest_DefaultConstructor %self_2

--- a/CSShadersTests/Tests/IntrinsicFunctions/Arithmetic Intrinsics/OpFDiv_IntrinsicTest.expected.spvtxt
+++ b/CSShadersTests/Tests/IntrinsicFunctions/Arithmetic Intrinsics/OpFDiv_IntrinsicTest.expected.spvtxt
@@ -29,10 +29,11 @@
                OpName %self_2 "self"
        %uint = OpTypeInt 32 0
       %float = OpTypeFloat 32
+    %float_0 = OpConstant %float 0
  %OpFDivTest = OpTypeStruct
        %void = OpTypeVoid
 %_ptr_Function_OpFDivTest = OpTypePointer Function %OpFDivTest
-          %9 = OpTypeFunction %void %_ptr_Function_OpFDivTest
+         %10 = OpTypeFunction %void %_ptr_Function_OpFDivTest
 %_ptr_Function_float = OpTypePointer Function %float
     %Vector2 = OpTypeVector %float 2
 %_ptr_Function_Vector2 = OpTypePointer Function %Vector2
@@ -40,20 +41,19 @@
 %_ptr_Function_Vector3 = OpTypePointer Function %Vector3
     %Vector4 = OpTypeVector %float 4
 %_ptr_Function_Vector4 = OpTypePointer Function %Vector4
-         %17 = OpTypeFunction %void
-    %float_0 = OpConstant %float 0
-%OpFDivTest_PreConstructor = OpFunction %void None %9
+         %18 = OpTypeFunction %void
+%OpFDivTest_PreConstructor = OpFunction %void None %10
        %self = OpFunctionParameter %_ptr_Function_OpFDivTest
          %23 = OpLabel
                OpReturn
                OpFunctionEnd
-%OpFDivTest_DefaultConstructor = OpFunction %void None %9
+%OpFDivTest_DefaultConstructor = OpFunction %void None %10
      %self_0 = OpFunctionParameter %_ptr_Function_OpFDivTest
          %28 = OpLabel
          %29 = OpFunctionCall %void %OpFDivTest_PreConstructor %self_0
                OpReturn
                OpFunctionEnd
-       %Main = OpFunction %void None %9
+       %Main = OpFunction %void None %10
      %self_1 = OpFunctionParameter %_ptr_Function_OpFDivTest
          %34 = OpLabel
    %floatVal = OpVariable %_ptr_Function_float Function
@@ -85,7 +85,7 @@
                OpStore %vector4Val %60
                OpReturn
                OpFunctionEnd
-%OpFDivTest_Main_EntryPoint = OpFunction %void None %17
+%OpFDivTest_Main_EntryPoint = OpFunction %void None %18
          %65 = OpLabel
      %self_2 = OpVariable %_ptr_Function_OpFDivTest Function
          %67 = OpFunctionCall %void %OpFDivTest_DefaultConstructor %self_2

--- a/CSShadersTests/Tests/IntrinsicFunctions/Arithmetic Intrinsics/OpFMod_IntrinsicTest.expected.spvtxt
+++ b/CSShadersTests/Tests/IntrinsicFunctions/Arithmetic Intrinsics/OpFMod_IntrinsicTest.expected.spvtxt
@@ -29,10 +29,11 @@
                OpName %self_2 "self"
        %uint = OpTypeInt 32 0
       %float = OpTypeFloat 32
+    %float_0 = OpConstant %float 0
  %OpFModTest = OpTypeStruct
        %void = OpTypeVoid
 %_ptr_Function_OpFModTest = OpTypePointer Function %OpFModTest
-          %9 = OpTypeFunction %void %_ptr_Function_OpFModTest
+         %10 = OpTypeFunction %void %_ptr_Function_OpFModTest
 %_ptr_Function_float = OpTypePointer Function %float
     %Vector2 = OpTypeVector %float 2
 %_ptr_Function_Vector2 = OpTypePointer Function %Vector2
@@ -40,20 +41,19 @@
 %_ptr_Function_Vector3 = OpTypePointer Function %Vector3
     %Vector4 = OpTypeVector %float 4
 %_ptr_Function_Vector4 = OpTypePointer Function %Vector4
-         %17 = OpTypeFunction %void
-    %float_0 = OpConstant %float 0
-%OpFModTest_PreConstructor = OpFunction %void None %9
+         %18 = OpTypeFunction %void
+%OpFModTest_PreConstructor = OpFunction %void None %10
        %self = OpFunctionParameter %_ptr_Function_OpFModTest
          %23 = OpLabel
                OpReturn
                OpFunctionEnd
-%OpFModTest_DefaultConstructor = OpFunction %void None %9
+%OpFModTest_DefaultConstructor = OpFunction %void None %10
      %self_0 = OpFunctionParameter %_ptr_Function_OpFModTest
          %28 = OpLabel
          %29 = OpFunctionCall %void %OpFModTest_PreConstructor %self_0
                OpReturn
                OpFunctionEnd
-       %Main = OpFunction %void None %9
+       %Main = OpFunction %void None %10
      %self_1 = OpFunctionParameter %_ptr_Function_OpFModTest
          %34 = OpLabel
    %floatVal = OpVariable %_ptr_Function_float Function
@@ -85,7 +85,7 @@
                OpStore %vector4Val %60
                OpReturn
                OpFunctionEnd
-%OpFModTest_Main_EntryPoint = OpFunction %void None %17
+%OpFModTest_Main_EntryPoint = OpFunction %void None %18
          %65 = OpLabel
      %self_2 = OpVariable %_ptr_Function_OpFModTest Function
          %67 = OpFunctionCall %void %OpFModTest_DefaultConstructor %self_2

--- a/CSShadersTests/Tests/IntrinsicFunctions/Arithmetic Intrinsics/OpFMul_IntrinsicTest.expected.spvtxt
+++ b/CSShadersTests/Tests/IntrinsicFunctions/Arithmetic Intrinsics/OpFMul_IntrinsicTest.expected.spvtxt
@@ -29,10 +29,11 @@
                OpName %self_2 "self"
        %uint = OpTypeInt 32 0
       %float = OpTypeFloat 32
+    %float_0 = OpConstant %float 0
  %OpFMulTest = OpTypeStruct
        %void = OpTypeVoid
 %_ptr_Function_OpFMulTest = OpTypePointer Function %OpFMulTest
-          %9 = OpTypeFunction %void %_ptr_Function_OpFMulTest
+         %10 = OpTypeFunction %void %_ptr_Function_OpFMulTest
 %_ptr_Function_float = OpTypePointer Function %float
     %Vector2 = OpTypeVector %float 2
 %_ptr_Function_Vector2 = OpTypePointer Function %Vector2
@@ -40,20 +41,19 @@
 %_ptr_Function_Vector3 = OpTypePointer Function %Vector3
     %Vector4 = OpTypeVector %float 4
 %_ptr_Function_Vector4 = OpTypePointer Function %Vector4
-         %17 = OpTypeFunction %void
-    %float_0 = OpConstant %float 0
-%OpFMulTest_PreConstructor = OpFunction %void None %9
+         %18 = OpTypeFunction %void
+%OpFMulTest_PreConstructor = OpFunction %void None %10
        %self = OpFunctionParameter %_ptr_Function_OpFMulTest
          %23 = OpLabel
                OpReturn
                OpFunctionEnd
-%OpFMulTest_DefaultConstructor = OpFunction %void None %9
+%OpFMulTest_DefaultConstructor = OpFunction %void None %10
      %self_0 = OpFunctionParameter %_ptr_Function_OpFMulTest
          %28 = OpLabel
          %29 = OpFunctionCall %void %OpFMulTest_PreConstructor %self_0
                OpReturn
                OpFunctionEnd
-       %Main = OpFunction %void None %9
+       %Main = OpFunction %void None %10
      %self_1 = OpFunctionParameter %_ptr_Function_OpFMulTest
          %34 = OpLabel
    %floatVal = OpVariable %_ptr_Function_float Function
@@ -85,7 +85,7 @@
                OpStore %vector4Val %60
                OpReturn
                OpFunctionEnd
-%OpFMulTest_Main_EntryPoint = OpFunction %void None %17
+%OpFMulTest_Main_EntryPoint = OpFunction %void None %18
          %65 = OpLabel
      %self_2 = OpVariable %_ptr_Function_OpFMulTest Function
          %67 = OpFunctionCall %void %OpFMulTest_DefaultConstructor %self_2

--- a/CSShadersTests/Tests/IntrinsicFunctions/Arithmetic Intrinsics/OpFNegate_IntrinsicTest.expected.spvtxt
+++ b/CSShadersTests/Tests/IntrinsicFunctions/Arithmetic Intrinsics/OpFNegate_IntrinsicTest.expected.spvtxt
@@ -29,10 +29,11 @@
                OpName %self_2 "self"
        %uint = OpTypeInt 32 0
       %float = OpTypeFloat 32
+    %float_0 = OpConstant %float 0
 %OpFNegateTest = OpTypeStruct
        %void = OpTypeVoid
 %_ptr_Function_OpFNegateTest = OpTypePointer Function %OpFNegateTest
-          %9 = OpTypeFunction %void %_ptr_Function_OpFNegateTest
+         %10 = OpTypeFunction %void %_ptr_Function_OpFNegateTest
 %_ptr_Function_float = OpTypePointer Function %float
     %Vector2 = OpTypeVector %float 2
 %_ptr_Function_Vector2 = OpTypePointer Function %Vector2
@@ -40,20 +41,19 @@
 %_ptr_Function_Vector3 = OpTypePointer Function %Vector3
     %Vector4 = OpTypeVector %float 4
 %_ptr_Function_Vector4 = OpTypePointer Function %Vector4
-         %17 = OpTypeFunction %void
-    %float_0 = OpConstant %float 0
-%OpFNegateTest_PreConstructor = OpFunction %void None %9
+         %18 = OpTypeFunction %void
+%OpFNegateTest_PreConstructor = OpFunction %void None %10
        %self = OpFunctionParameter %_ptr_Function_OpFNegateTest
          %23 = OpLabel
                OpReturn
                OpFunctionEnd
-%OpFNegateTest_DefaultConstructor = OpFunction %void None %9
+%OpFNegateTest_DefaultConstructor = OpFunction %void None %10
      %self_0 = OpFunctionParameter %_ptr_Function_OpFNegateTest
          %28 = OpLabel
          %29 = OpFunctionCall %void %OpFNegateTest_PreConstructor %self_0
                OpReturn
                OpFunctionEnd
-       %Main = OpFunction %void None %9
+       %Main = OpFunction %void None %10
      %self_1 = OpFunctionParameter %_ptr_Function_OpFNegateTest
          %34 = OpLabel
    %floatVal = OpVariable %_ptr_Function_float Function
@@ -81,7 +81,7 @@
                OpStore %vector4Val %56
                OpReturn
                OpFunctionEnd
-%OpFNegateTest_Main_EntryPoint = OpFunction %void None %17
+%OpFNegateTest_Main_EntryPoint = OpFunction %void None %18
          %61 = OpLabel
      %self_2 = OpVariable %_ptr_Function_OpFNegateTest Function
          %63 = OpFunctionCall %void %OpFNegateTest_DefaultConstructor %self_2

--- a/CSShadersTests/Tests/IntrinsicFunctions/Arithmetic Intrinsics/OpFRem_IntrinsicTest.expected.spvtxt
+++ b/CSShadersTests/Tests/IntrinsicFunctions/Arithmetic Intrinsics/OpFRem_IntrinsicTest.expected.spvtxt
@@ -29,10 +29,11 @@
                OpName %self_2 "self"
        %uint = OpTypeInt 32 0
       %float = OpTypeFloat 32
+    %float_0 = OpConstant %float 0
  %OpFRemTest = OpTypeStruct
        %void = OpTypeVoid
 %_ptr_Function_OpFRemTest = OpTypePointer Function %OpFRemTest
-          %9 = OpTypeFunction %void %_ptr_Function_OpFRemTest
+         %10 = OpTypeFunction %void %_ptr_Function_OpFRemTest
 %_ptr_Function_float = OpTypePointer Function %float
     %Vector2 = OpTypeVector %float 2
 %_ptr_Function_Vector2 = OpTypePointer Function %Vector2
@@ -40,20 +41,19 @@
 %_ptr_Function_Vector3 = OpTypePointer Function %Vector3
     %Vector4 = OpTypeVector %float 4
 %_ptr_Function_Vector4 = OpTypePointer Function %Vector4
-         %17 = OpTypeFunction %void
-    %float_0 = OpConstant %float 0
-%OpFRemTest_PreConstructor = OpFunction %void None %9
+         %18 = OpTypeFunction %void
+%OpFRemTest_PreConstructor = OpFunction %void None %10
        %self = OpFunctionParameter %_ptr_Function_OpFRemTest
          %23 = OpLabel
                OpReturn
                OpFunctionEnd
-%OpFRemTest_DefaultConstructor = OpFunction %void None %9
+%OpFRemTest_DefaultConstructor = OpFunction %void None %10
      %self_0 = OpFunctionParameter %_ptr_Function_OpFRemTest
          %28 = OpLabel
          %29 = OpFunctionCall %void %OpFRemTest_PreConstructor %self_0
                OpReturn
                OpFunctionEnd
-       %Main = OpFunction %void None %9
+       %Main = OpFunction %void None %10
      %self_1 = OpFunctionParameter %_ptr_Function_OpFRemTest
          %34 = OpLabel
    %floatVal = OpVariable %_ptr_Function_float Function
@@ -85,7 +85,7 @@
                OpStore %vector4Val %60
                OpReturn
                OpFunctionEnd
-%OpFRemTest_Main_EntryPoint = OpFunction %void None %17
+%OpFRemTest_Main_EntryPoint = OpFunction %void None %18
          %65 = OpLabel
      %self_2 = OpVariable %_ptr_Function_OpFRemTest Function
          %67 = OpFunctionCall %void %OpFRemTest_DefaultConstructor %self_2

--- a/CSShadersTests/Tests/IntrinsicFunctions/Arithmetic Intrinsics/OpFSub_IntrinsicTest.expected.spvtxt
+++ b/CSShadersTests/Tests/IntrinsicFunctions/Arithmetic Intrinsics/OpFSub_IntrinsicTest.expected.spvtxt
@@ -29,10 +29,11 @@
                OpName %self_2 "self"
        %uint = OpTypeInt 32 0
       %float = OpTypeFloat 32
+    %float_0 = OpConstant %float 0
  %OpFSubTest = OpTypeStruct
        %void = OpTypeVoid
 %_ptr_Function_OpFSubTest = OpTypePointer Function %OpFSubTest
-          %9 = OpTypeFunction %void %_ptr_Function_OpFSubTest
+         %10 = OpTypeFunction %void %_ptr_Function_OpFSubTest
 %_ptr_Function_float = OpTypePointer Function %float
     %Vector2 = OpTypeVector %float 2
 %_ptr_Function_Vector2 = OpTypePointer Function %Vector2
@@ -40,20 +41,19 @@
 %_ptr_Function_Vector3 = OpTypePointer Function %Vector3
     %Vector4 = OpTypeVector %float 4
 %_ptr_Function_Vector4 = OpTypePointer Function %Vector4
-         %17 = OpTypeFunction %void
-    %float_0 = OpConstant %float 0
-%OpFSubTest_PreConstructor = OpFunction %void None %9
+         %18 = OpTypeFunction %void
+%OpFSubTest_PreConstructor = OpFunction %void None %10
        %self = OpFunctionParameter %_ptr_Function_OpFSubTest
          %23 = OpLabel
                OpReturn
                OpFunctionEnd
-%OpFSubTest_DefaultConstructor = OpFunction %void None %9
+%OpFSubTest_DefaultConstructor = OpFunction %void None %10
      %self_0 = OpFunctionParameter %_ptr_Function_OpFSubTest
          %28 = OpLabel
          %29 = OpFunctionCall %void %OpFSubTest_PreConstructor %self_0
                OpReturn
                OpFunctionEnd
-       %Main = OpFunction %void None %9
+       %Main = OpFunction %void None %10
      %self_1 = OpFunctionParameter %_ptr_Function_OpFSubTest
          %34 = OpLabel
    %floatVal = OpVariable %_ptr_Function_float Function
@@ -85,7 +85,7 @@
                OpStore %vector4Val %60
                OpReturn
                OpFunctionEnd
-%OpFSubTest_Main_EntryPoint = OpFunction %void None %17
+%OpFSubTest_Main_EntryPoint = OpFunction %void None %18
          %65 = OpLabel
      %self_2 = OpVariable %_ptr_Function_OpFSubTest Function
          %67 = OpFunctionCall %void %OpFSubTest_DefaultConstructor %self_2

--- a/CSShadersTests/Tests/IntrinsicFunctions/Arithmetic Intrinsics/OpIAdd_IntrinsicTest.expected.spvtxt
+++ b/CSShadersTests/Tests/IntrinsicFunctions/Arithmetic Intrinsics/OpIAdd_IntrinsicTest.expected.spvtxt
@@ -29,10 +29,11 @@
                OpName %self_2 "self"
        %uint = OpTypeInt 32 0
         %int = OpTypeInt 32 1
+      %int_0 = OpConstant %int 0
  %OpIAddTest = OpTypeStruct
        %void = OpTypeVoid
 %_ptr_Function_OpIAddTest = OpTypePointer Function %OpIAddTest
-          %9 = OpTypeFunction %void %_ptr_Function_OpIAddTest
+         %10 = OpTypeFunction %void %_ptr_Function_OpIAddTest
 %_ptr_Function_int = OpTypePointer Function %int
    %Integer2 = OpTypeVector %int 2
 %_ptr_Function_Integer2 = OpTypePointer Function %Integer2
@@ -40,20 +41,19 @@
 %_ptr_Function_Integer3 = OpTypePointer Function %Integer3
    %Integer4 = OpTypeVector %int 4
 %_ptr_Function_Integer4 = OpTypePointer Function %Integer4
-         %17 = OpTypeFunction %void
-      %int_0 = OpConstant %int 0
-%OpIAddTest_PreConstructor = OpFunction %void None %9
+         %18 = OpTypeFunction %void
+%OpIAddTest_PreConstructor = OpFunction %void None %10
        %self = OpFunctionParameter %_ptr_Function_OpIAddTest
          %23 = OpLabel
                OpReturn
                OpFunctionEnd
-%OpIAddTest_DefaultConstructor = OpFunction %void None %9
+%OpIAddTest_DefaultConstructor = OpFunction %void None %10
      %self_0 = OpFunctionParameter %_ptr_Function_OpIAddTest
          %28 = OpLabel
          %29 = OpFunctionCall %void %OpIAddTest_PreConstructor %self_0
                OpReturn
                OpFunctionEnd
-       %Main = OpFunction %void None %9
+       %Main = OpFunction %void None %10
      %self_1 = OpFunctionParameter %_ptr_Function_OpIAddTest
          %34 = OpLabel
      %intVal = OpVariable %_ptr_Function_int Function
@@ -85,7 +85,7 @@
                OpStore %integer4Val %60
                OpReturn
                OpFunctionEnd
-%OpIAddTest_Main_EntryPoint = OpFunction %void None %17
+%OpIAddTest_Main_EntryPoint = OpFunction %void None %18
          %65 = OpLabel
      %self_2 = OpVariable %_ptr_Function_OpIAddTest Function
          %67 = OpFunctionCall %void %OpIAddTest_DefaultConstructor %self_2

--- a/CSShadersTests/Tests/IntrinsicFunctions/Arithmetic Intrinsics/OpIMul_IntrinsicTest.expected.spvtxt
+++ b/CSShadersTests/Tests/IntrinsicFunctions/Arithmetic Intrinsics/OpIMul_IntrinsicTest.expected.spvtxt
@@ -29,10 +29,11 @@
                OpName %self_2 "self"
        %uint = OpTypeInt 32 0
         %int = OpTypeInt 32 1
+      %int_0 = OpConstant %int 0
  %OpIMulTest = OpTypeStruct
        %void = OpTypeVoid
 %_ptr_Function_OpIMulTest = OpTypePointer Function %OpIMulTest
-          %9 = OpTypeFunction %void %_ptr_Function_OpIMulTest
+         %10 = OpTypeFunction %void %_ptr_Function_OpIMulTest
 %_ptr_Function_int = OpTypePointer Function %int
    %Integer2 = OpTypeVector %int 2
 %_ptr_Function_Integer2 = OpTypePointer Function %Integer2
@@ -40,20 +41,19 @@
 %_ptr_Function_Integer3 = OpTypePointer Function %Integer3
    %Integer4 = OpTypeVector %int 4
 %_ptr_Function_Integer4 = OpTypePointer Function %Integer4
-         %17 = OpTypeFunction %void
-      %int_0 = OpConstant %int 0
-%OpIMulTest_PreConstructor = OpFunction %void None %9
+         %18 = OpTypeFunction %void
+%OpIMulTest_PreConstructor = OpFunction %void None %10
        %self = OpFunctionParameter %_ptr_Function_OpIMulTest
          %23 = OpLabel
                OpReturn
                OpFunctionEnd
-%OpIMulTest_DefaultConstructor = OpFunction %void None %9
+%OpIMulTest_DefaultConstructor = OpFunction %void None %10
      %self_0 = OpFunctionParameter %_ptr_Function_OpIMulTest
          %28 = OpLabel
          %29 = OpFunctionCall %void %OpIMulTest_PreConstructor %self_0
                OpReturn
                OpFunctionEnd
-       %Main = OpFunction %void None %9
+       %Main = OpFunction %void None %10
      %self_1 = OpFunctionParameter %_ptr_Function_OpIMulTest
          %34 = OpLabel
      %intVal = OpVariable %_ptr_Function_int Function
@@ -85,7 +85,7 @@
                OpStore %integer4Val %60
                OpReturn
                OpFunctionEnd
-%OpIMulTest_Main_EntryPoint = OpFunction %void None %17
+%OpIMulTest_Main_EntryPoint = OpFunction %void None %18
          %65 = OpLabel
      %self_2 = OpVariable %_ptr_Function_OpIMulTest Function
          %67 = OpFunctionCall %void %OpIMulTest_DefaultConstructor %self_2

--- a/CSShadersTests/Tests/IntrinsicFunctions/Arithmetic Intrinsics/OpISub_IntrinsicTest.expected.spvtxt
+++ b/CSShadersTests/Tests/IntrinsicFunctions/Arithmetic Intrinsics/OpISub_IntrinsicTest.expected.spvtxt
@@ -29,10 +29,11 @@
                OpName %self_2 "self"
        %uint = OpTypeInt 32 0
         %int = OpTypeInt 32 1
+      %int_0 = OpConstant %int 0
  %OpISubTest = OpTypeStruct
        %void = OpTypeVoid
 %_ptr_Function_OpISubTest = OpTypePointer Function %OpISubTest
-          %9 = OpTypeFunction %void %_ptr_Function_OpISubTest
+         %10 = OpTypeFunction %void %_ptr_Function_OpISubTest
 %_ptr_Function_int = OpTypePointer Function %int
    %Integer2 = OpTypeVector %int 2
 %_ptr_Function_Integer2 = OpTypePointer Function %Integer2
@@ -40,20 +41,19 @@
 %_ptr_Function_Integer3 = OpTypePointer Function %Integer3
    %Integer4 = OpTypeVector %int 4
 %_ptr_Function_Integer4 = OpTypePointer Function %Integer4
-         %17 = OpTypeFunction %void
-      %int_0 = OpConstant %int 0
-%OpISubTest_PreConstructor = OpFunction %void None %9
+         %18 = OpTypeFunction %void
+%OpISubTest_PreConstructor = OpFunction %void None %10
        %self = OpFunctionParameter %_ptr_Function_OpISubTest
          %23 = OpLabel
                OpReturn
                OpFunctionEnd
-%OpISubTest_DefaultConstructor = OpFunction %void None %9
+%OpISubTest_DefaultConstructor = OpFunction %void None %10
      %self_0 = OpFunctionParameter %_ptr_Function_OpISubTest
          %28 = OpLabel
          %29 = OpFunctionCall %void %OpISubTest_PreConstructor %self_0
                OpReturn
                OpFunctionEnd
-       %Main = OpFunction %void None %9
+       %Main = OpFunction %void None %10
      %self_1 = OpFunctionParameter %_ptr_Function_OpISubTest
          %34 = OpLabel
      %intVal = OpVariable %_ptr_Function_int Function
@@ -85,7 +85,7 @@
                OpStore %integer4Val %60
                OpReturn
                OpFunctionEnd
-%OpISubTest_Main_EntryPoint = OpFunction %void None %17
+%OpISubTest_Main_EntryPoint = OpFunction %void None %18
          %65 = OpLabel
      %self_2 = OpVariable %_ptr_Function_OpISubTest Function
          %67 = OpFunctionCall %void %OpISubTest_DefaultConstructor %self_2

--- a/CSShadersTests/Tests/IntrinsicFunctions/Arithmetic Intrinsics/OpMatrixTimesMatrix_IntrinsicTest.expected.spvtxt
+++ b/CSShadersTests/Tests/IntrinsicFunctions/Arithmetic Intrinsics/OpMatrixTimesMatrix_IntrinsicTest.expected.spvtxt
@@ -35,30 +35,30 @@
                OpName %self_4 "self"
        %uint = OpTypeInt 32 0
       %float = OpTypeFloat 32
+    %float_0 = OpConstant %float 0
 %OpMatrixTimesMatrixTest = OpTypeStruct
        %void = OpTypeVoid
 %_ptr_Function_OpMatrixTimesMatrixTest = OpTypePointer Function %OpMatrixTimesMatrixTest
-          %9 = OpTypeFunction %void %_ptr_Function_OpMatrixTimesMatrixTest
+         %10 = OpTypeFunction %void %_ptr_Function_OpMatrixTimesMatrixTest
     %Vector2 = OpTypeVector %float 2
    %Float2x2 = OpTypeMatrix %Vector2 2
 %_ptr_Function_Float2x2 = OpTypePointer Function %Float2x2
-         %15 = OpTypeFunction %void %_ptr_Function_Float2x2 %float
+         %16 = OpTypeFunction %void %_ptr_Function_Float2x2 %float
 %_ptr_Function_Vector2 = OpTypePointer Function %Vector2
-         %17 = OpTypeFunction %void %_ptr_Function_Float2x2 %float %float %float %float
-         %19 = OpTypeFunction %void
-    %float_0 = OpConstant %float 0
-%OpMatrixTimesMatrixTest_PreConstructor = OpFunction %void None %9
+         %18 = OpTypeFunction %void %_ptr_Function_Float2x2 %float %float %float %float
+         %20 = OpTypeFunction %void
+%OpMatrixTimesMatrixTest_PreConstructor = OpFunction %void None %10
        %self = OpFunctionParameter %_ptr_Function_OpMatrixTimesMatrixTest
          %25 = OpLabel
                OpReturn
                OpFunctionEnd
-%OpMatrixTimesMatrixTest_DefaultConstructor = OpFunction %void None %9
+%OpMatrixTimesMatrixTest_DefaultConstructor = OpFunction %void None %10
      %self_0 = OpFunctionParameter %_ptr_Function_OpMatrixTimesMatrixTest
          %30 = OpLabel
          %31 = OpFunctionCall %void %OpMatrixTimesMatrixTest_PreConstructor %self_0
                OpReturn
                OpFunctionEnd
-       %Main = OpFunction %void None %9
+       %Main = OpFunction %void None %10
      %self_1 = OpFunctionParameter %_ptr_Function_OpMatrixTimesMatrixTest
          %36 = OpLabel
 %float2x2Val = OpVariable %_ptr_Function_Float2x2 Function
@@ -71,7 +71,7 @@
                OpStore %float2x2Val %43
                OpReturn
                OpFunctionEnd
-%Float2x2_Constructor = OpFunction %void None %15
+%Float2x2_Constructor = OpFunction %void None %16
      %self_2 = OpFunctionParameter %_ptr_Function_Float2x2
       %value = OpFunctionParameter %float
          %50 = OpLabel
@@ -84,7 +84,7 @@
                OpStore %self_2 %56
                OpReturn
                OpFunctionEnd
-%Float2x2_Constructor_0 = OpFunction %void None %17
+%Float2x2_Constructor_0 = OpFunction %void None %18
      %self_3 = OpFunctionParameter %_ptr_Function_Float2x2
         %m00 = OpFunctionParameter %float
         %m01 = OpFunctionParameter %float
@@ -97,7 +97,7 @@
                OpStore %self_3 %69
                OpReturn
                OpFunctionEnd
-%OpMatrixTimesMatrixTest_Main_EntryPoint = OpFunction %void None %19
+%OpMatrixTimesMatrixTest_Main_EntryPoint = OpFunction %void None %20
          %74 = OpLabel
      %self_4 = OpVariable %_ptr_Function_OpMatrixTimesMatrixTest Function
          %76 = OpFunctionCall %void %OpMatrixTimesMatrixTest_DefaultConstructor %self_4

--- a/CSShadersTests/Tests/IntrinsicFunctions/Arithmetic Intrinsics/OpMatrixTimesScalar_IntrinsicTest.expected.spvtxt
+++ b/CSShadersTests/Tests/IntrinsicFunctions/Arithmetic Intrinsics/OpMatrixTimesScalar_IntrinsicTest.expected.spvtxt
@@ -36,31 +36,31 @@
                OpName %self_4 "self"
        %uint = OpTypeInt 32 0
       %float = OpTypeFloat 32
+    %float_0 = OpConstant %float 0
 %OpMatrixTimesScalarTest = OpTypeStruct
        %void = OpTypeVoid
 %_ptr_Function_OpMatrixTimesScalarTest = OpTypePointer Function %OpMatrixTimesScalarTest
-          %9 = OpTypeFunction %void %_ptr_Function_OpMatrixTimesScalarTest
+         %10 = OpTypeFunction %void %_ptr_Function_OpMatrixTimesScalarTest
     %Vector2 = OpTypeVector %float 2
    %Float2x2 = OpTypeMatrix %Vector2 2
 %_ptr_Function_Float2x2 = OpTypePointer Function %Float2x2
-         %15 = OpTypeFunction %void %_ptr_Function_Float2x2 %float
+         %16 = OpTypeFunction %void %_ptr_Function_Float2x2 %float
 %_ptr_Function_Vector2 = OpTypePointer Function %Vector2
-         %17 = OpTypeFunction %void %_ptr_Function_Float2x2 %float %float %float %float
+         %18 = OpTypeFunction %void %_ptr_Function_Float2x2 %float %float %float %float
 %_ptr_Function_float = OpTypePointer Function %float
-         %19 = OpTypeFunction %void
-    %float_0 = OpConstant %float 0
-%OpMatrixTimesScalarTest_PreConstructor = OpFunction %void None %9
+         %20 = OpTypeFunction %void
+%OpMatrixTimesScalarTest_PreConstructor = OpFunction %void None %10
        %self = OpFunctionParameter %_ptr_Function_OpMatrixTimesScalarTest
          %25 = OpLabel
                OpReturn
                OpFunctionEnd
-%OpMatrixTimesScalarTest_DefaultConstructor = OpFunction %void None %9
+%OpMatrixTimesScalarTest_DefaultConstructor = OpFunction %void None %10
      %self_0 = OpFunctionParameter %_ptr_Function_OpMatrixTimesScalarTest
          %30 = OpLabel
          %31 = OpFunctionCall %void %OpMatrixTimesScalarTest_PreConstructor %self_0
                OpReturn
                OpFunctionEnd
-       %Main = OpFunction %void None %9
+       %Main = OpFunction %void None %10
      %self_1 = OpFunctionParameter %_ptr_Function_OpMatrixTimesScalarTest
          %36 = OpLabel
 %float2x2Val = OpVariable %_ptr_Function_Float2x2 Function
@@ -75,7 +75,7 @@
                OpStore %float2x2Val %45
                OpReturn
                OpFunctionEnd
-%Float2x2_Constructor = OpFunction %void None %15
+%Float2x2_Constructor = OpFunction %void None %16
      %self_2 = OpFunctionParameter %_ptr_Function_Float2x2
       %value = OpFunctionParameter %float
          %52 = OpLabel
@@ -88,7 +88,7 @@
                OpStore %self_2 %58
                OpReturn
                OpFunctionEnd
-%Float2x2_Constructor_0 = OpFunction %void None %17
+%Float2x2_Constructor_0 = OpFunction %void None %18
      %self_3 = OpFunctionParameter %_ptr_Function_Float2x2
         %m00 = OpFunctionParameter %float
         %m01 = OpFunctionParameter %float
@@ -101,7 +101,7 @@
                OpStore %self_3 %71
                OpReturn
                OpFunctionEnd
-%OpMatrixTimesScalarTest_Main_EntryPoint = OpFunction %void None %19
+%OpMatrixTimesScalarTest_Main_EntryPoint = OpFunction %void None %20
          %76 = OpLabel
      %self_4 = OpVariable %_ptr_Function_OpMatrixTimesScalarTest Function
          %78 = OpFunctionCall %void %OpMatrixTimesScalarTest_DefaultConstructor %self_4

--- a/CSShadersTests/Tests/IntrinsicFunctions/Arithmetic Intrinsics/OpMatrixTimesVector_IntrinsicTest.expected.spvtxt
+++ b/CSShadersTests/Tests/IntrinsicFunctions/Arithmetic Intrinsics/OpMatrixTimesVector_IntrinsicTest.expected.spvtxt
@@ -36,30 +36,30 @@
                OpName %self_4 "self"
        %uint = OpTypeInt 32 0
       %float = OpTypeFloat 32
+    %float_0 = OpConstant %float 0
 %OpMatrixTimesVectorTest = OpTypeStruct
        %void = OpTypeVoid
 %_ptr_Function_OpMatrixTimesVectorTest = OpTypePointer Function %OpMatrixTimesVectorTest
-          %9 = OpTypeFunction %void %_ptr_Function_OpMatrixTimesVectorTest
+         %10 = OpTypeFunction %void %_ptr_Function_OpMatrixTimesVectorTest
     %Vector2 = OpTypeVector %float 2
 %_ptr_Function_Vector2 = OpTypePointer Function %Vector2
    %Float2x2 = OpTypeMatrix %Vector2 2
 %_ptr_Function_Float2x2 = OpTypePointer Function %Float2x2
-         %15 = OpTypeFunction %void %_ptr_Function_Float2x2 %float
-         %17 = OpTypeFunction %void %_ptr_Function_Float2x2 %float %float %float %float
-         %19 = OpTypeFunction %void
-    %float_0 = OpConstant %float 0
-%OpMatrixTimesVectorTest_PreConstructor = OpFunction %void None %9
+         %16 = OpTypeFunction %void %_ptr_Function_Float2x2 %float
+         %18 = OpTypeFunction %void %_ptr_Function_Float2x2 %float %float %float %float
+         %20 = OpTypeFunction %void
+%OpMatrixTimesVectorTest_PreConstructor = OpFunction %void None %10
        %self = OpFunctionParameter %_ptr_Function_OpMatrixTimesVectorTest
          %25 = OpLabel
                OpReturn
                OpFunctionEnd
-%OpMatrixTimesVectorTest_DefaultConstructor = OpFunction %void None %9
+%OpMatrixTimesVectorTest_DefaultConstructor = OpFunction %void None %10
      %self_0 = OpFunctionParameter %_ptr_Function_OpMatrixTimesVectorTest
          %30 = OpLabel
          %31 = OpFunctionCall %void %OpMatrixTimesVectorTest_PreConstructor %self_0
                OpReturn
                OpFunctionEnd
-       %Main = OpFunction %void None %9
+       %Main = OpFunction %void None %10
      %self_1 = OpFunctionParameter %_ptr_Function_OpMatrixTimesVectorTest
          %36 = OpLabel
  %vector2Val = OpVariable %_ptr_Function_Vector2 Function
@@ -75,7 +75,7 @@
                OpStore %vector2Val %46
                OpReturn
                OpFunctionEnd
-%Float2x2_Constructor = OpFunction %void None %15
+%Float2x2_Constructor = OpFunction %void None %16
      %self_2 = OpFunctionParameter %_ptr_Function_Float2x2
       %value = OpFunctionParameter %float
          %53 = OpLabel
@@ -88,7 +88,7 @@
                OpStore %self_2 %59
                OpReturn
                OpFunctionEnd
-%Float2x2_Constructor_0 = OpFunction %void None %17
+%Float2x2_Constructor_0 = OpFunction %void None %18
      %self_3 = OpFunctionParameter %_ptr_Function_Float2x2
         %m00 = OpFunctionParameter %float
         %m01 = OpFunctionParameter %float
@@ -101,7 +101,7 @@
                OpStore %self_3 %72
                OpReturn
                OpFunctionEnd
-%OpMatrixTimesVectorTest_Main_EntryPoint = OpFunction %void None %19
+%OpMatrixTimesVectorTest_Main_EntryPoint = OpFunction %void None %20
          %77 = OpLabel
      %self_4 = OpVariable %_ptr_Function_OpMatrixTimesVectorTest Function
          %79 = OpFunctionCall %void %OpMatrixTimesVectorTest_DefaultConstructor %self_4

--- a/CSShadersTests/Tests/IntrinsicFunctions/Arithmetic Intrinsics/OpOuterProduct_IntrinsicTest.expected.spvtxt
+++ b/CSShadersTests/Tests/IntrinsicFunctions/Arithmetic Intrinsics/OpOuterProduct_IntrinsicTest.expected.spvtxt
@@ -36,30 +36,30 @@
                OpName %self_4 "self"
        %uint = OpTypeInt 32 0
       %float = OpTypeFloat 32
+    %float_0 = OpConstant %float 0
 %OpOuterProductTest = OpTypeStruct
        %void = OpTypeVoid
 %_ptr_Function_OpOuterProductTest = OpTypePointer Function %OpOuterProductTest
-          %9 = OpTypeFunction %void %_ptr_Function_OpOuterProductTest
+         %10 = OpTypeFunction %void %_ptr_Function_OpOuterProductTest
     %Vector2 = OpTypeVector %float 2
    %Float2x2 = OpTypeMatrix %Vector2 2
 %_ptr_Function_Float2x2 = OpTypePointer Function %Float2x2
-         %15 = OpTypeFunction %void %_ptr_Function_Float2x2 %float
+         %16 = OpTypeFunction %void %_ptr_Function_Float2x2 %float
 %_ptr_Function_Vector2 = OpTypePointer Function %Vector2
-         %17 = OpTypeFunction %void %_ptr_Function_Float2x2 %float %float %float %float
-         %19 = OpTypeFunction %void
-    %float_0 = OpConstant %float 0
-%OpOuterProductTest_PreConstructor = OpFunction %void None %9
+         %18 = OpTypeFunction %void %_ptr_Function_Float2x2 %float %float %float %float
+         %20 = OpTypeFunction %void
+%OpOuterProductTest_PreConstructor = OpFunction %void None %10
        %self = OpFunctionParameter %_ptr_Function_OpOuterProductTest
          %25 = OpLabel
                OpReturn
                OpFunctionEnd
-%OpOuterProductTest_DefaultConstructor = OpFunction %void None %9
+%OpOuterProductTest_DefaultConstructor = OpFunction %void None %10
      %self_0 = OpFunctionParameter %_ptr_Function_OpOuterProductTest
          %30 = OpLabel
          %31 = OpFunctionCall %void %OpOuterProductTest_PreConstructor %self_0
                OpReturn
                OpFunctionEnd
-       %Main = OpFunction %void None %9
+       %Main = OpFunction %void None %10
      %self_1 = OpFunctionParameter %_ptr_Function_OpOuterProductTest
          %36 = OpLabel
 %float2x2Val = OpVariable %_ptr_Function_Float2x2 Function
@@ -75,7 +75,7 @@
                OpStore %float2x2Val %46
                OpReturn
                OpFunctionEnd
-%Float2x2_Constructor = OpFunction %void None %15
+%Float2x2_Constructor = OpFunction %void None %16
      %self_2 = OpFunctionParameter %_ptr_Function_Float2x2
       %value = OpFunctionParameter %float
          %53 = OpLabel
@@ -88,7 +88,7 @@
                OpStore %self_2 %59
                OpReturn
                OpFunctionEnd
-%Float2x2_Constructor_0 = OpFunction %void None %17
+%Float2x2_Constructor_0 = OpFunction %void None %18
      %self_3 = OpFunctionParameter %_ptr_Function_Float2x2
         %m00 = OpFunctionParameter %float
         %m01 = OpFunctionParameter %float
@@ -101,7 +101,7 @@
                OpStore %self_3 %72
                OpReturn
                OpFunctionEnd
-%OpOuterProductTest_Main_EntryPoint = OpFunction %void None %19
+%OpOuterProductTest_Main_EntryPoint = OpFunction %void None %20
          %77 = OpLabel
      %self_4 = OpVariable %_ptr_Function_OpOuterProductTest Function
          %79 = OpFunctionCall %void %OpOuterProductTest_DefaultConstructor %self_4

--- a/CSShadersTests/Tests/IntrinsicFunctions/Arithmetic Intrinsics/OpSDiv_IntrinsicTest.expected.spvtxt
+++ b/CSShadersTests/Tests/IntrinsicFunctions/Arithmetic Intrinsics/OpSDiv_IntrinsicTest.expected.spvtxt
@@ -29,10 +29,11 @@
                OpName %self_2 "self"
        %uint = OpTypeInt 32 0
         %int = OpTypeInt 32 1
+      %int_0 = OpConstant %int 0
  %OpSDivTest = OpTypeStruct
        %void = OpTypeVoid
 %_ptr_Function_OpSDivTest = OpTypePointer Function %OpSDivTest
-          %9 = OpTypeFunction %void %_ptr_Function_OpSDivTest
+         %10 = OpTypeFunction %void %_ptr_Function_OpSDivTest
 %_ptr_Function_int = OpTypePointer Function %int
    %Integer2 = OpTypeVector %int 2
 %_ptr_Function_Integer2 = OpTypePointer Function %Integer2
@@ -40,20 +41,19 @@
 %_ptr_Function_Integer3 = OpTypePointer Function %Integer3
    %Integer4 = OpTypeVector %int 4
 %_ptr_Function_Integer4 = OpTypePointer Function %Integer4
-         %17 = OpTypeFunction %void
-      %int_0 = OpConstant %int 0
-%OpSDivTest_PreConstructor = OpFunction %void None %9
+         %18 = OpTypeFunction %void
+%OpSDivTest_PreConstructor = OpFunction %void None %10
        %self = OpFunctionParameter %_ptr_Function_OpSDivTest
          %23 = OpLabel
                OpReturn
                OpFunctionEnd
-%OpSDivTest_DefaultConstructor = OpFunction %void None %9
+%OpSDivTest_DefaultConstructor = OpFunction %void None %10
      %self_0 = OpFunctionParameter %_ptr_Function_OpSDivTest
          %28 = OpLabel
          %29 = OpFunctionCall %void %OpSDivTest_PreConstructor %self_0
                OpReturn
                OpFunctionEnd
-       %Main = OpFunction %void None %9
+       %Main = OpFunction %void None %10
      %self_1 = OpFunctionParameter %_ptr_Function_OpSDivTest
          %34 = OpLabel
      %intVal = OpVariable %_ptr_Function_int Function
@@ -85,7 +85,7 @@
                OpStore %integer4Val %60
                OpReturn
                OpFunctionEnd
-%OpSDivTest_Main_EntryPoint = OpFunction %void None %17
+%OpSDivTest_Main_EntryPoint = OpFunction %void None %18
          %65 = OpLabel
      %self_2 = OpVariable %_ptr_Function_OpSDivTest Function
          %67 = OpFunctionCall %void %OpSDivTest_DefaultConstructor %self_2

--- a/CSShadersTests/Tests/IntrinsicFunctions/Arithmetic Intrinsics/OpSMod_IntrinsicTest.expected.spvtxt
+++ b/CSShadersTests/Tests/IntrinsicFunctions/Arithmetic Intrinsics/OpSMod_IntrinsicTest.expected.spvtxt
@@ -29,10 +29,11 @@
                OpName %self_2 "self"
        %uint = OpTypeInt 32 0
         %int = OpTypeInt 32 1
+      %int_0 = OpConstant %int 0
  %OpSModTest = OpTypeStruct
        %void = OpTypeVoid
 %_ptr_Function_OpSModTest = OpTypePointer Function %OpSModTest
-          %9 = OpTypeFunction %void %_ptr_Function_OpSModTest
+         %10 = OpTypeFunction %void %_ptr_Function_OpSModTest
 %_ptr_Function_int = OpTypePointer Function %int
    %Integer2 = OpTypeVector %int 2
 %_ptr_Function_Integer2 = OpTypePointer Function %Integer2
@@ -40,20 +41,19 @@
 %_ptr_Function_Integer3 = OpTypePointer Function %Integer3
    %Integer4 = OpTypeVector %int 4
 %_ptr_Function_Integer4 = OpTypePointer Function %Integer4
-         %17 = OpTypeFunction %void
-      %int_0 = OpConstant %int 0
-%OpSModTest_PreConstructor = OpFunction %void None %9
+         %18 = OpTypeFunction %void
+%OpSModTest_PreConstructor = OpFunction %void None %10
        %self = OpFunctionParameter %_ptr_Function_OpSModTest
          %23 = OpLabel
                OpReturn
                OpFunctionEnd
-%OpSModTest_DefaultConstructor = OpFunction %void None %9
+%OpSModTest_DefaultConstructor = OpFunction %void None %10
      %self_0 = OpFunctionParameter %_ptr_Function_OpSModTest
          %28 = OpLabel
          %29 = OpFunctionCall %void %OpSModTest_PreConstructor %self_0
                OpReturn
                OpFunctionEnd
-       %Main = OpFunction %void None %9
+       %Main = OpFunction %void None %10
      %self_1 = OpFunctionParameter %_ptr_Function_OpSModTest
          %34 = OpLabel
      %intVal = OpVariable %_ptr_Function_int Function
@@ -85,7 +85,7 @@
                OpStore %integer4Val %60
                OpReturn
                OpFunctionEnd
-%OpSModTest_Main_EntryPoint = OpFunction %void None %17
+%OpSModTest_Main_EntryPoint = OpFunction %void None %18
          %65 = OpLabel
      %self_2 = OpVariable %_ptr_Function_OpSModTest Function
          %67 = OpFunctionCall %void %OpSModTest_DefaultConstructor %self_2

--- a/CSShadersTests/Tests/IntrinsicFunctions/Arithmetic Intrinsics/OpSNegate_IntrinsicTest.expected.spvtxt
+++ b/CSShadersTests/Tests/IntrinsicFunctions/Arithmetic Intrinsics/OpSNegate_IntrinsicTest.expected.spvtxt
@@ -29,10 +29,11 @@
                OpName %self_2 "self"
        %uint = OpTypeInt 32 0
         %int = OpTypeInt 32 1
+      %int_0 = OpConstant %int 0
 %OpSNegateTest = OpTypeStruct
        %void = OpTypeVoid
 %_ptr_Function_OpSNegateTest = OpTypePointer Function %OpSNegateTest
-          %9 = OpTypeFunction %void %_ptr_Function_OpSNegateTest
+         %10 = OpTypeFunction %void %_ptr_Function_OpSNegateTest
 %_ptr_Function_int = OpTypePointer Function %int
    %Integer2 = OpTypeVector %int 2
 %_ptr_Function_Integer2 = OpTypePointer Function %Integer2
@@ -40,20 +41,19 @@
 %_ptr_Function_Integer3 = OpTypePointer Function %Integer3
    %Integer4 = OpTypeVector %int 4
 %_ptr_Function_Integer4 = OpTypePointer Function %Integer4
-         %17 = OpTypeFunction %void
-      %int_0 = OpConstant %int 0
-%OpSNegateTest_PreConstructor = OpFunction %void None %9
+         %18 = OpTypeFunction %void
+%OpSNegateTest_PreConstructor = OpFunction %void None %10
        %self = OpFunctionParameter %_ptr_Function_OpSNegateTest
          %23 = OpLabel
                OpReturn
                OpFunctionEnd
-%OpSNegateTest_DefaultConstructor = OpFunction %void None %9
+%OpSNegateTest_DefaultConstructor = OpFunction %void None %10
      %self_0 = OpFunctionParameter %_ptr_Function_OpSNegateTest
          %28 = OpLabel
          %29 = OpFunctionCall %void %OpSNegateTest_PreConstructor %self_0
                OpReturn
                OpFunctionEnd
-       %Main = OpFunction %void None %9
+       %Main = OpFunction %void None %10
      %self_1 = OpFunctionParameter %_ptr_Function_OpSNegateTest
          %34 = OpLabel
      %intVal = OpVariable %_ptr_Function_int Function
@@ -81,7 +81,7 @@
                OpStore %integer4Val %56
                OpReturn
                OpFunctionEnd
-%OpSNegateTest_Main_EntryPoint = OpFunction %void None %17
+%OpSNegateTest_Main_EntryPoint = OpFunction %void None %18
          %61 = OpLabel
      %self_2 = OpVariable %_ptr_Function_OpSNegateTest Function
          %63 = OpFunctionCall %void %OpSNegateTest_DefaultConstructor %self_2

--- a/CSShadersTests/Tests/IntrinsicFunctions/Arithmetic Intrinsics/OpSRem_IntrinsicTest.expected.spvtxt
+++ b/CSShadersTests/Tests/IntrinsicFunctions/Arithmetic Intrinsics/OpSRem_IntrinsicTest.expected.spvtxt
@@ -29,10 +29,11 @@
                OpName %self_2 "self"
        %uint = OpTypeInt 32 0
         %int = OpTypeInt 32 1
+      %int_0 = OpConstant %int 0
  %OpSRemTest = OpTypeStruct
        %void = OpTypeVoid
 %_ptr_Function_OpSRemTest = OpTypePointer Function %OpSRemTest
-          %9 = OpTypeFunction %void %_ptr_Function_OpSRemTest
+         %10 = OpTypeFunction %void %_ptr_Function_OpSRemTest
 %_ptr_Function_int = OpTypePointer Function %int
    %Integer2 = OpTypeVector %int 2
 %_ptr_Function_Integer2 = OpTypePointer Function %Integer2
@@ -40,20 +41,19 @@
 %_ptr_Function_Integer3 = OpTypePointer Function %Integer3
    %Integer4 = OpTypeVector %int 4
 %_ptr_Function_Integer4 = OpTypePointer Function %Integer4
-         %17 = OpTypeFunction %void
-      %int_0 = OpConstant %int 0
-%OpSRemTest_PreConstructor = OpFunction %void None %9
+         %18 = OpTypeFunction %void
+%OpSRemTest_PreConstructor = OpFunction %void None %10
        %self = OpFunctionParameter %_ptr_Function_OpSRemTest
          %23 = OpLabel
                OpReturn
                OpFunctionEnd
-%OpSRemTest_DefaultConstructor = OpFunction %void None %9
+%OpSRemTest_DefaultConstructor = OpFunction %void None %10
      %self_0 = OpFunctionParameter %_ptr_Function_OpSRemTest
          %28 = OpLabel
          %29 = OpFunctionCall %void %OpSRemTest_PreConstructor %self_0
                OpReturn
                OpFunctionEnd
-       %Main = OpFunction %void None %9
+       %Main = OpFunction %void None %10
      %self_1 = OpFunctionParameter %_ptr_Function_OpSRemTest
          %34 = OpLabel
      %intVal = OpVariable %_ptr_Function_int Function
@@ -85,7 +85,7 @@
                OpStore %integer4Val %60
                OpReturn
                OpFunctionEnd
-%OpSRemTest_Main_EntryPoint = OpFunction %void None %17
+%OpSRemTest_Main_EntryPoint = OpFunction %void None %18
          %65 = OpLabel
      %self_2 = OpVariable %_ptr_Function_OpSRemTest Function
          %67 = OpFunctionCall %void %OpSRemTest_DefaultConstructor %self_2

--- a/CSShadersTests/Tests/IntrinsicFunctions/Arithmetic Intrinsics/OpVectorTimesMatrix_IntrinsicTest.expected.spvtxt
+++ b/CSShadersTests/Tests/IntrinsicFunctions/Arithmetic Intrinsics/OpVectorTimesMatrix_IntrinsicTest.expected.spvtxt
@@ -36,30 +36,30 @@
                OpName %self_4 "self"
        %uint = OpTypeInt 32 0
       %float = OpTypeFloat 32
+    %float_0 = OpConstant %float 0
 %OpVectorTimesMatrixTest = OpTypeStruct
        %void = OpTypeVoid
 %_ptr_Function_OpVectorTimesMatrixTest = OpTypePointer Function %OpVectorTimesMatrixTest
-          %9 = OpTypeFunction %void %_ptr_Function_OpVectorTimesMatrixTest
+         %10 = OpTypeFunction %void %_ptr_Function_OpVectorTimesMatrixTest
     %Vector2 = OpTypeVector %float 2
 %_ptr_Function_Vector2 = OpTypePointer Function %Vector2
    %Float2x2 = OpTypeMatrix %Vector2 2
 %_ptr_Function_Float2x2 = OpTypePointer Function %Float2x2
-         %15 = OpTypeFunction %void %_ptr_Function_Float2x2 %float
-         %17 = OpTypeFunction %void %_ptr_Function_Float2x2 %float %float %float %float
-         %19 = OpTypeFunction %void
-    %float_0 = OpConstant %float 0
-%OpVectorTimesMatrixTest_PreConstructor = OpFunction %void None %9
+         %16 = OpTypeFunction %void %_ptr_Function_Float2x2 %float
+         %18 = OpTypeFunction %void %_ptr_Function_Float2x2 %float %float %float %float
+         %20 = OpTypeFunction %void
+%OpVectorTimesMatrixTest_PreConstructor = OpFunction %void None %10
        %self = OpFunctionParameter %_ptr_Function_OpVectorTimesMatrixTest
          %25 = OpLabel
                OpReturn
                OpFunctionEnd
-%OpVectorTimesMatrixTest_DefaultConstructor = OpFunction %void None %9
+%OpVectorTimesMatrixTest_DefaultConstructor = OpFunction %void None %10
      %self_0 = OpFunctionParameter %_ptr_Function_OpVectorTimesMatrixTest
          %30 = OpLabel
          %31 = OpFunctionCall %void %OpVectorTimesMatrixTest_PreConstructor %self_0
                OpReturn
                OpFunctionEnd
-       %Main = OpFunction %void None %9
+       %Main = OpFunction %void None %10
      %self_1 = OpFunctionParameter %_ptr_Function_OpVectorTimesMatrixTest
          %36 = OpLabel
  %vector2Val = OpVariable %_ptr_Function_Vector2 Function
@@ -75,7 +75,7 @@
                OpStore %vector2Val %46
                OpReturn
                OpFunctionEnd
-%Float2x2_Constructor = OpFunction %void None %15
+%Float2x2_Constructor = OpFunction %void None %16
      %self_2 = OpFunctionParameter %_ptr_Function_Float2x2
       %value = OpFunctionParameter %float
          %53 = OpLabel
@@ -88,7 +88,7 @@
                OpStore %self_2 %59
                OpReturn
                OpFunctionEnd
-%Float2x2_Constructor_0 = OpFunction %void None %17
+%Float2x2_Constructor_0 = OpFunction %void None %18
      %self_3 = OpFunctionParameter %_ptr_Function_Float2x2
         %m00 = OpFunctionParameter %float
         %m01 = OpFunctionParameter %float
@@ -101,7 +101,7 @@
                OpStore %self_3 %72
                OpReturn
                OpFunctionEnd
-%OpVectorTimesMatrixTest_Main_EntryPoint = OpFunction %void None %19
+%OpVectorTimesMatrixTest_Main_EntryPoint = OpFunction %void None %20
          %77 = OpLabel
      %self_4 = OpVariable %_ptr_Function_OpVectorTimesMatrixTest Function
          %79 = OpFunctionCall %void %OpVectorTimesMatrixTest_DefaultConstructor %self_4

--- a/CSShadersTests/Tests/IntrinsicFunctions/Arithmetic Intrinsics/OpVectorTimesScalar_IntrinsicTest.expected.spvtxt
+++ b/CSShadersTests/Tests/IntrinsicFunctions/Arithmetic Intrinsics/OpVectorTimesScalar_IntrinsicTest.expected.spvtxt
@@ -29,10 +29,11 @@
                OpName %self_2 "self"
        %uint = OpTypeInt 32 0
       %float = OpTypeFloat 32
+    %float_0 = OpConstant %float 0
 %OpVectorTimesScalarTest = OpTypeStruct
        %void = OpTypeVoid
 %_ptr_Function_OpVectorTimesScalarTest = OpTypePointer Function %OpVectorTimesScalarTest
-          %9 = OpTypeFunction %void %_ptr_Function_OpVectorTimesScalarTest
+         %10 = OpTypeFunction %void %_ptr_Function_OpVectorTimesScalarTest
     %Vector2 = OpTypeVector %float 2
 %_ptr_Function_Vector2 = OpTypePointer Function %Vector2
 %_ptr_Function_float = OpTypePointer Function %float
@@ -40,20 +41,19 @@
 %_ptr_Function_Vector3 = OpTypePointer Function %Vector3
     %Vector4 = OpTypeVector %float 4
 %_ptr_Function_Vector4 = OpTypePointer Function %Vector4
-         %17 = OpTypeFunction %void
-    %float_0 = OpConstant %float 0
-%OpVectorTimesScalarTest_PreConstructor = OpFunction %void None %9
+         %18 = OpTypeFunction %void
+%OpVectorTimesScalarTest_PreConstructor = OpFunction %void None %10
        %self = OpFunctionParameter %_ptr_Function_OpVectorTimesScalarTest
          %23 = OpLabel
                OpReturn
                OpFunctionEnd
-%OpVectorTimesScalarTest_DefaultConstructor = OpFunction %void None %9
+%OpVectorTimesScalarTest_DefaultConstructor = OpFunction %void None %10
      %self_0 = OpFunctionParameter %_ptr_Function_OpVectorTimesScalarTest
          %28 = OpLabel
          %29 = OpFunctionCall %void %OpVectorTimesScalarTest_PreConstructor %self_0
                OpReturn
                OpFunctionEnd
-       %Main = OpFunction %void None %9
+       %Main = OpFunction %void None %10
      %self_1 = OpFunctionParameter %_ptr_Function_OpVectorTimesScalarTest
          %34 = OpLabel
  %vector2Val = OpVariable %_ptr_Function_Vector2 Function
@@ -81,7 +81,7 @@
                OpStore %vector4Val %56
                OpReturn
                OpFunctionEnd
-%OpVectorTimesScalarTest_Main_EntryPoint = OpFunction %void None %17
+%OpVectorTimesScalarTest_Main_EntryPoint = OpFunction %void None %18
          %61 = OpLabel
      %self_2 = OpVariable %_ptr_Function_OpVectorTimesScalarTest Function
          %63 = OpFunctionCall %void %OpVectorTimesScalarTest_DefaultConstructor %self_2

--- a/CSShadersTests/Tests/IntrinsicFunctions/Bit Intrinsics/OpBitCount_IntrinsicTest.expected.spvtxt
+++ b/CSShadersTests/Tests/IntrinsicFunctions/Bit Intrinsics/OpBitCount_IntrinsicTest.expected.spvtxt
@@ -29,10 +29,11 @@
                OpName %self_2 "self"
        %uint = OpTypeInt 32 0
         %int = OpTypeInt 32 1
+      %int_0 = OpConstant %int 0
 %OpBitCountTest = OpTypeStruct
        %void = OpTypeVoid
 %_ptr_Function_OpBitCountTest = OpTypePointer Function %OpBitCountTest
-          %9 = OpTypeFunction %void %_ptr_Function_OpBitCountTest
+         %10 = OpTypeFunction %void %_ptr_Function_OpBitCountTest
 %_ptr_Function_int = OpTypePointer Function %int
    %Integer2 = OpTypeVector %int 2
 %_ptr_Function_Integer2 = OpTypePointer Function %Integer2
@@ -40,20 +41,19 @@
 %_ptr_Function_Integer3 = OpTypePointer Function %Integer3
    %Integer4 = OpTypeVector %int 4
 %_ptr_Function_Integer4 = OpTypePointer Function %Integer4
-         %17 = OpTypeFunction %void
-      %int_0 = OpConstant %int 0
-%OpBitCountTest_PreConstructor = OpFunction %void None %9
+         %18 = OpTypeFunction %void
+%OpBitCountTest_PreConstructor = OpFunction %void None %10
        %self = OpFunctionParameter %_ptr_Function_OpBitCountTest
          %23 = OpLabel
                OpReturn
                OpFunctionEnd
-%OpBitCountTest_DefaultConstructor = OpFunction %void None %9
+%OpBitCountTest_DefaultConstructor = OpFunction %void None %10
      %self_0 = OpFunctionParameter %_ptr_Function_OpBitCountTest
          %28 = OpLabel
          %29 = OpFunctionCall %void %OpBitCountTest_PreConstructor %self_0
                OpReturn
                OpFunctionEnd
-       %Main = OpFunction %void None %9
+       %Main = OpFunction %void None %10
      %self_1 = OpFunctionParameter %_ptr_Function_OpBitCountTest
          %34 = OpLabel
      %intVal = OpVariable %_ptr_Function_int Function
@@ -81,7 +81,7 @@
                OpStore %integer4Val %56
                OpReturn
                OpFunctionEnd
-%OpBitCountTest_Main_EntryPoint = OpFunction %void None %17
+%OpBitCountTest_Main_EntryPoint = OpFunction %void None %18
          %61 = OpLabel
      %self_2 = OpVariable %_ptr_Function_OpBitCountTest Function
          %63 = OpFunctionCall %void %OpBitCountTest_DefaultConstructor %self_2

--- a/CSShadersTests/Tests/IntrinsicFunctions/Bit Intrinsics/OpBitReverse_IntrinsicTest.expected.spvtxt
+++ b/CSShadersTests/Tests/IntrinsicFunctions/Bit Intrinsics/OpBitReverse_IntrinsicTest.expected.spvtxt
@@ -29,10 +29,11 @@
                OpName %self_2 "self"
        %uint = OpTypeInt 32 0
         %int = OpTypeInt 32 1
+      %int_0 = OpConstant %int 0
 %OpBitReverseTest = OpTypeStruct
        %void = OpTypeVoid
 %_ptr_Function_OpBitReverseTest = OpTypePointer Function %OpBitReverseTest
-          %9 = OpTypeFunction %void %_ptr_Function_OpBitReverseTest
+         %10 = OpTypeFunction %void %_ptr_Function_OpBitReverseTest
 %_ptr_Function_int = OpTypePointer Function %int
    %Integer2 = OpTypeVector %int 2
 %_ptr_Function_Integer2 = OpTypePointer Function %Integer2
@@ -40,20 +41,19 @@
 %_ptr_Function_Integer3 = OpTypePointer Function %Integer3
    %Integer4 = OpTypeVector %int 4
 %_ptr_Function_Integer4 = OpTypePointer Function %Integer4
-         %17 = OpTypeFunction %void
-      %int_0 = OpConstant %int 0
-%OpBitReverseTest_PreConstructor = OpFunction %void None %9
+         %18 = OpTypeFunction %void
+%OpBitReverseTest_PreConstructor = OpFunction %void None %10
        %self = OpFunctionParameter %_ptr_Function_OpBitReverseTest
          %23 = OpLabel
                OpReturn
                OpFunctionEnd
-%OpBitReverseTest_DefaultConstructor = OpFunction %void None %9
+%OpBitReverseTest_DefaultConstructor = OpFunction %void None %10
      %self_0 = OpFunctionParameter %_ptr_Function_OpBitReverseTest
          %28 = OpLabel
          %29 = OpFunctionCall %void %OpBitReverseTest_PreConstructor %self_0
                OpReturn
                OpFunctionEnd
-       %Main = OpFunction %void None %9
+       %Main = OpFunction %void None %10
      %self_1 = OpFunctionParameter %_ptr_Function_OpBitReverseTest
          %34 = OpLabel
      %intVal = OpVariable %_ptr_Function_int Function
@@ -81,7 +81,7 @@
                OpStore %integer4Val %56
                OpReturn
                OpFunctionEnd
-%OpBitReverseTest_Main_EntryPoint = OpFunction %void None %17
+%OpBitReverseTest_Main_EntryPoint = OpFunction %void None %18
          %61 = OpLabel
      %self_2 = OpVariable %_ptr_Function_OpBitReverseTest Function
          %63 = OpFunctionCall %void %OpBitReverseTest_DefaultConstructor %self_2

--- a/CSShadersTests/Tests/IntrinsicFunctions/Bit Intrinsics/OpBitwiseAnd_IntrinsicTest.expected.spvtxt
+++ b/CSShadersTests/Tests/IntrinsicFunctions/Bit Intrinsics/OpBitwiseAnd_IntrinsicTest.expected.spvtxt
@@ -29,10 +29,11 @@
                OpName %self_2 "self"
        %uint = OpTypeInt 32 0
         %int = OpTypeInt 32 1
+      %int_0 = OpConstant %int 0
 %OpBitwiseAndTest = OpTypeStruct
        %void = OpTypeVoid
 %_ptr_Function_OpBitwiseAndTest = OpTypePointer Function %OpBitwiseAndTest
-          %9 = OpTypeFunction %void %_ptr_Function_OpBitwiseAndTest
+         %10 = OpTypeFunction %void %_ptr_Function_OpBitwiseAndTest
 %_ptr_Function_int = OpTypePointer Function %int
    %Integer2 = OpTypeVector %int 2
 %_ptr_Function_Integer2 = OpTypePointer Function %Integer2
@@ -40,20 +41,19 @@
 %_ptr_Function_Integer3 = OpTypePointer Function %Integer3
    %Integer4 = OpTypeVector %int 4
 %_ptr_Function_Integer4 = OpTypePointer Function %Integer4
-         %17 = OpTypeFunction %void
-      %int_0 = OpConstant %int 0
-%OpBitwiseAndTest_PreConstructor = OpFunction %void None %9
+         %18 = OpTypeFunction %void
+%OpBitwiseAndTest_PreConstructor = OpFunction %void None %10
        %self = OpFunctionParameter %_ptr_Function_OpBitwiseAndTest
          %23 = OpLabel
                OpReturn
                OpFunctionEnd
-%OpBitwiseAndTest_DefaultConstructor = OpFunction %void None %9
+%OpBitwiseAndTest_DefaultConstructor = OpFunction %void None %10
      %self_0 = OpFunctionParameter %_ptr_Function_OpBitwiseAndTest
          %28 = OpLabel
          %29 = OpFunctionCall %void %OpBitwiseAndTest_PreConstructor %self_0
                OpReturn
                OpFunctionEnd
-       %Main = OpFunction %void None %9
+       %Main = OpFunction %void None %10
      %self_1 = OpFunctionParameter %_ptr_Function_OpBitwiseAndTest
          %34 = OpLabel
      %intVal = OpVariable %_ptr_Function_int Function
@@ -85,7 +85,7 @@
                OpStore %integer4Val %60
                OpReturn
                OpFunctionEnd
-%OpBitwiseAndTest_Main_EntryPoint = OpFunction %void None %17
+%OpBitwiseAndTest_Main_EntryPoint = OpFunction %void None %18
          %65 = OpLabel
      %self_2 = OpVariable %_ptr_Function_OpBitwiseAndTest Function
          %67 = OpFunctionCall %void %OpBitwiseAndTest_DefaultConstructor %self_2

--- a/CSShadersTests/Tests/IntrinsicFunctions/Bit Intrinsics/OpBitwiseOr_IntrinsicTest.expected.spvtxt
+++ b/CSShadersTests/Tests/IntrinsicFunctions/Bit Intrinsics/OpBitwiseOr_IntrinsicTest.expected.spvtxt
@@ -29,10 +29,11 @@
                OpName %self_2 "self"
        %uint = OpTypeInt 32 0
         %int = OpTypeInt 32 1
+      %int_0 = OpConstant %int 0
 %OpBitwiseOrTest = OpTypeStruct
        %void = OpTypeVoid
 %_ptr_Function_OpBitwiseOrTest = OpTypePointer Function %OpBitwiseOrTest
-          %9 = OpTypeFunction %void %_ptr_Function_OpBitwiseOrTest
+         %10 = OpTypeFunction %void %_ptr_Function_OpBitwiseOrTest
 %_ptr_Function_int = OpTypePointer Function %int
    %Integer2 = OpTypeVector %int 2
 %_ptr_Function_Integer2 = OpTypePointer Function %Integer2
@@ -40,20 +41,19 @@
 %_ptr_Function_Integer3 = OpTypePointer Function %Integer3
    %Integer4 = OpTypeVector %int 4
 %_ptr_Function_Integer4 = OpTypePointer Function %Integer4
-         %17 = OpTypeFunction %void
-      %int_0 = OpConstant %int 0
-%OpBitwiseOrTest_PreConstructor = OpFunction %void None %9
+         %18 = OpTypeFunction %void
+%OpBitwiseOrTest_PreConstructor = OpFunction %void None %10
        %self = OpFunctionParameter %_ptr_Function_OpBitwiseOrTest
          %23 = OpLabel
                OpReturn
                OpFunctionEnd
-%OpBitwiseOrTest_DefaultConstructor = OpFunction %void None %9
+%OpBitwiseOrTest_DefaultConstructor = OpFunction %void None %10
      %self_0 = OpFunctionParameter %_ptr_Function_OpBitwiseOrTest
          %28 = OpLabel
          %29 = OpFunctionCall %void %OpBitwiseOrTest_PreConstructor %self_0
                OpReturn
                OpFunctionEnd
-       %Main = OpFunction %void None %9
+       %Main = OpFunction %void None %10
      %self_1 = OpFunctionParameter %_ptr_Function_OpBitwiseOrTest
          %34 = OpLabel
      %intVal = OpVariable %_ptr_Function_int Function
@@ -85,7 +85,7 @@
                OpStore %integer4Val %60
                OpReturn
                OpFunctionEnd
-%OpBitwiseOrTest_Main_EntryPoint = OpFunction %void None %17
+%OpBitwiseOrTest_Main_EntryPoint = OpFunction %void None %18
          %65 = OpLabel
      %self_2 = OpVariable %_ptr_Function_OpBitwiseOrTest Function
          %67 = OpFunctionCall %void %OpBitwiseOrTest_DefaultConstructor %self_2

--- a/CSShadersTests/Tests/IntrinsicFunctions/Bit Intrinsics/OpBitwiseXor_IntrinsicTest.expected.spvtxt
+++ b/CSShadersTests/Tests/IntrinsicFunctions/Bit Intrinsics/OpBitwiseXor_IntrinsicTest.expected.spvtxt
@@ -29,10 +29,11 @@
                OpName %self_2 "self"
        %uint = OpTypeInt 32 0
         %int = OpTypeInt 32 1
+      %int_0 = OpConstant %int 0
 %OpBitwiseXorTest = OpTypeStruct
        %void = OpTypeVoid
 %_ptr_Function_OpBitwiseXorTest = OpTypePointer Function %OpBitwiseXorTest
-          %9 = OpTypeFunction %void %_ptr_Function_OpBitwiseXorTest
+         %10 = OpTypeFunction %void %_ptr_Function_OpBitwiseXorTest
 %_ptr_Function_int = OpTypePointer Function %int
    %Integer2 = OpTypeVector %int 2
 %_ptr_Function_Integer2 = OpTypePointer Function %Integer2
@@ -40,20 +41,19 @@
 %_ptr_Function_Integer3 = OpTypePointer Function %Integer3
    %Integer4 = OpTypeVector %int 4
 %_ptr_Function_Integer4 = OpTypePointer Function %Integer4
-         %17 = OpTypeFunction %void
-      %int_0 = OpConstant %int 0
-%OpBitwiseXorTest_PreConstructor = OpFunction %void None %9
+         %18 = OpTypeFunction %void
+%OpBitwiseXorTest_PreConstructor = OpFunction %void None %10
        %self = OpFunctionParameter %_ptr_Function_OpBitwiseXorTest
          %23 = OpLabel
                OpReturn
                OpFunctionEnd
-%OpBitwiseXorTest_DefaultConstructor = OpFunction %void None %9
+%OpBitwiseXorTest_DefaultConstructor = OpFunction %void None %10
      %self_0 = OpFunctionParameter %_ptr_Function_OpBitwiseXorTest
          %28 = OpLabel
          %29 = OpFunctionCall %void %OpBitwiseXorTest_PreConstructor %self_0
                OpReturn
                OpFunctionEnd
-       %Main = OpFunction %void None %9
+       %Main = OpFunction %void None %10
      %self_1 = OpFunctionParameter %_ptr_Function_OpBitwiseXorTest
          %34 = OpLabel
      %intVal = OpVariable %_ptr_Function_int Function
@@ -85,7 +85,7 @@
                OpStore %integer4Val %60
                OpReturn
                OpFunctionEnd
-%OpBitwiseXorTest_Main_EntryPoint = OpFunction %void None %17
+%OpBitwiseXorTest_Main_EntryPoint = OpFunction %void None %18
          %65 = OpLabel
      %self_2 = OpVariable %_ptr_Function_OpBitwiseXorTest Function
          %67 = OpFunctionCall %void %OpBitwiseXorTest_DefaultConstructor %self_2

--- a/CSShadersTests/Tests/IntrinsicFunctions/Bit Intrinsics/OpNot_IntrinsicTest.expected.spvtxt
+++ b/CSShadersTests/Tests/IntrinsicFunctions/Bit Intrinsics/OpNot_IntrinsicTest.expected.spvtxt
@@ -29,10 +29,11 @@
                OpName %self_2 "self"
        %uint = OpTypeInt 32 0
         %int = OpTypeInt 32 1
+      %int_0 = OpConstant %int 0
   %OpNotTest = OpTypeStruct
        %void = OpTypeVoid
 %_ptr_Function_OpNotTest = OpTypePointer Function %OpNotTest
-          %9 = OpTypeFunction %void %_ptr_Function_OpNotTest
+         %10 = OpTypeFunction %void %_ptr_Function_OpNotTest
 %_ptr_Function_int = OpTypePointer Function %int
    %Integer2 = OpTypeVector %int 2
 %_ptr_Function_Integer2 = OpTypePointer Function %Integer2
@@ -40,20 +41,19 @@
 %_ptr_Function_Integer3 = OpTypePointer Function %Integer3
    %Integer4 = OpTypeVector %int 4
 %_ptr_Function_Integer4 = OpTypePointer Function %Integer4
-         %17 = OpTypeFunction %void
-      %int_0 = OpConstant %int 0
-%OpNotTest_PreConstructor = OpFunction %void None %9
+         %18 = OpTypeFunction %void
+%OpNotTest_PreConstructor = OpFunction %void None %10
        %self = OpFunctionParameter %_ptr_Function_OpNotTest
          %23 = OpLabel
                OpReturn
                OpFunctionEnd
-%OpNotTest_DefaultConstructor = OpFunction %void None %9
+%OpNotTest_DefaultConstructor = OpFunction %void None %10
      %self_0 = OpFunctionParameter %_ptr_Function_OpNotTest
          %28 = OpLabel
          %29 = OpFunctionCall %void %OpNotTest_PreConstructor %self_0
                OpReturn
                OpFunctionEnd
-       %Main = OpFunction %void None %9
+       %Main = OpFunction %void None %10
      %self_1 = OpFunctionParameter %_ptr_Function_OpNotTest
          %34 = OpLabel
      %intVal = OpVariable %_ptr_Function_int Function
@@ -81,7 +81,7 @@
                OpStore %integer4Val %56
                OpReturn
                OpFunctionEnd
-%OpNotTest_Main_EntryPoint = OpFunction %void None %17
+%OpNotTest_Main_EntryPoint = OpFunction %void None %18
          %61 = OpLabel
      %self_2 = OpVariable %_ptr_Function_OpNotTest Function
          %63 = OpFunctionCall %void %OpNotTest_DefaultConstructor %self_2

--- a/CSShadersTests/Tests/IntrinsicFunctions/Bit Intrinsics/OpShiftLeftLogical_IntrinsicTest.expected.spvtxt
+++ b/CSShadersTests/Tests/IntrinsicFunctions/Bit Intrinsics/OpShiftLeftLogical_IntrinsicTest.expected.spvtxt
@@ -29,10 +29,11 @@
                OpName %self_2 "self"
        %uint = OpTypeInt 32 0
         %int = OpTypeInt 32 1
+      %int_0 = OpConstant %int 0
 %OpShiftLeftLogicalTest = OpTypeStruct
        %void = OpTypeVoid
 %_ptr_Function_OpShiftLeftLogicalTest = OpTypePointer Function %OpShiftLeftLogicalTest
-          %9 = OpTypeFunction %void %_ptr_Function_OpShiftLeftLogicalTest
+         %10 = OpTypeFunction %void %_ptr_Function_OpShiftLeftLogicalTest
 %_ptr_Function_int = OpTypePointer Function %int
    %Integer2 = OpTypeVector %int 2
 %_ptr_Function_Integer2 = OpTypePointer Function %Integer2
@@ -40,20 +41,19 @@
 %_ptr_Function_Integer3 = OpTypePointer Function %Integer3
    %Integer4 = OpTypeVector %int 4
 %_ptr_Function_Integer4 = OpTypePointer Function %Integer4
-         %17 = OpTypeFunction %void
-      %int_0 = OpConstant %int 0
-%OpShiftLeftLogicalTest_PreConstructor = OpFunction %void None %9
+         %18 = OpTypeFunction %void
+%OpShiftLeftLogicalTest_PreConstructor = OpFunction %void None %10
        %self = OpFunctionParameter %_ptr_Function_OpShiftLeftLogicalTest
          %23 = OpLabel
                OpReturn
                OpFunctionEnd
-%OpShiftLeftLogicalTest_DefaultConstructor = OpFunction %void None %9
+%OpShiftLeftLogicalTest_DefaultConstructor = OpFunction %void None %10
      %self_0 = OpFunctionParameter %_ptr_Function_OpShiftLeftLogicalTest
          %28 = OpLabel
          %29 = OpFunctionCall %void %OpShiftLeftLogicalTest_PreConstructor %self_0
                OpReturn
                OpFunctionEnd
-       %Main = OpFunction %void None %9
+       %Main = OpFunction %void None %10
      %self_1 = OpFunctionParameter %_ptr_Function_OpShiftLeftLogicalTest
          %34 = OpLabel
      %intVal = OpVariable %_ptr_Function_int Function
@@ -85,7 +85,7 @@
                OpStore %integer4Val %60
                OpReturn
                OpFunctionEnd
-%OpShiftLeftLogicalTest_Main_EntryPoint = OpFunction %void None %17
+%OpShiftLeftLogicalTest_Main_EntryPoint = OpFunction %void None %18
          %65 = OpLabel
      %self_2 = OpVariable %_ptr_Function_OpShiftLeftLogicalTest Function
          %67 = OpFunctionCall %void %OpShiftLeftLogicalTest_DefaultConstructor %self_2

--- a/CSShadersTests/Tests/IntrinsicFunctions/Bit Intrinsics/OpShiftRightArithmetic_IntrinsicTest.expected.spvtxt
+++ b/CSShadersTests/Tests/IntrinsicFunctions/Bit Intrinsics/OpShiftRightArithmetic_IntrinsicTest.expected.spvtxt
@@ -29,10 +29,11 @@
                OpName %self_2 "self"
        %uint = OpTypeInt 32 0
         %int = OpTypeInt 32 1
+      %int_0 = OpConstant %int 0
 %OpShiftRightArithmeticTest = OpTypeStruct
        %void = OpTypeVoid
 %_ptr_Function_OpShiftRightArithmeticTest = OpTypePointer Function %OpShiftRightArithmeticTest
-          %9 = OpTypeFunction %void %_ptr_Function_OpShiftRightArithmeticTest
+         %10 = OpTypeFunction %void %_ptr_Function_OpShiftRightArithmeticTest
 %_ptr_Function_int = OpTypePointer Function %int
    %Integer2 = OpTypeVector %int 2
 %_ptr_Function_Integer2 = OpTypePointer Function %Integer2
@@ -40,20 +41,19 @@
 %_ptr_Function_Integer3 = OpTypePointer Function %Integer3
    %Integer4 = OpTypeVector %int 4
 %_ptr_Function_Integer4 = OpTypePointer Function %Integer4
-         %17 = OpTypeFunction %void
-      %int_0 = OpConstant %int 0
-%OpShiftRightArithmeticTest_PreConstructor = OpFunction %void None %9
+         %18 = OpTypeFunction %void
+%OpShiftRightArithmeticTest_PreConstructor = OpFunction %void None %10
        %self = OpFunctionParameter %_ptr_Function_OpShiftRightArithmeticTest
          %23 = OpLabel
                OpReturn
                OpFunctionEnd
-%OpShiftRightArithmeticTest_DefaultConstructor = OpFunction %void None %9
+%OpShiftRightArithmeticTest_DefaultConstructor = OpFunction %void None %10
      %self_0 = OpFunctionParameter %_ptr_Function_OpShiftRightArithmeticTest
          %28 = OpLabel
          %29 = OpFunctionCall %void %OpShiftRightArithmeticTest_PreConstructor %self_0
                OpReturn
                OpFunctionEnd
-       %Main = OpFunction %void None %9
+       %Main = OpFunction %void None %10
      %self_1 = OpFunctionParameter %_ptr_Function_OpShiftRightArithmeticTest
          %34 = OpLabel
      %intVal = OpVariable %_ptr_Function_int Function
@@ -85,7 +85,7 @@
                OpStore %integer4Val %60
                OpReturn
                OpFunctionEnd
-%OpShiftRightArithmeticTest_Main_EntryPoint = OpFunction %void None %17
+%OpShiftRightArithmeticTest_Main_EntryPoint = OpFunction %void None %18
          %65 = OpLabel
      %self_2 = OpVariable %_ptr_Function_OpShiftRightArithmeticTest Function
          %67 = OpFunctionCall %void %OpShiftRightArithmeticTest_DefaultConstructor %self_2

--- a/CSShadersTests/Tests/IntrinsicFunctions/Bit Intrinsics/OpShiftRightLogical_IntrinsicTest.expected.spvtxt
+++ b/CSShadersTests/Tests/IntrinsicFunctions/Bit Intrinsics/OpShiftRightLogical_IntrinsicTest.expected.spvtxt
@@ -29,10 +29,11 @@
                OpName %self_2 "self"
        %uint = OpTypeInt 32 0
         %int = OpTypeInt 32 1
+      %int_0 = OpConstant %int 0
 %OpShiftRightLogicalTest = OpTypeStruct
        %void = OpTypeVoid
 %_ptr_Function_OpShiftRightLogicalTest = OpTypePointer Function %OpShiftRightLogicalTest
-          %9 = OpTypeFunction %void %_ptr_Function_OpShiftRightLogicalTest
+         %10 = OpTypeFunction %void %_ptr_Function_OpShiftRightLogicalTest
 %_ptr_Function_int = OpTypePointer Function %int
    %Integer2 = OpTypeVector %int 2
 %_ptr_Function_Integer2 = OpTypePointer Function %Integer2
@@ -40,20 +41,19 @@
 %_ptr_Function_Integer3 = OpTypePointer Function %Integer3
    %Integer4 = OpTypeVector %int 4
 %_ptr_Function_Integer4 = OpTypePointer Function %Integer4
-         %17 = OpTypeFunction %void
-      %int_0 = OpConstant %int 0
-%OpShiftRightLogicalTest_PreConstructor = OpFunction %void None %9
+         %18 = OpTypeFunction %void
+%OpShiftRightLogicalTest_PreConstructor = OpFunction %void None %10
        %self = OpFunctionParameter %_ptr_Function_OpShiftRightLogicalTest
          %23 = OpLabel
                OpReturn
                OpFunctionEnd
-%OpShiftRightLogicalTest_DefaultConstructor = OpFunction %void None %9
+%OpShiftRightLogicalTest_DefaultConstructor = OpFunction %void None %10
      %self_0 = OpFunctionParameter %_ptr_Function_OpShiftRightLogicalTest
          %28 = OpLabel
          %29 = OpFunctionCall %void %OpShiftRightLogicalTest_PreConstructor %self_0
                OpReturn
                OpFunctionEnd
-       %Main = OpFunction %void None %9
+       %Main = OpFunction %void None %10
      %self_1 = OpFunctionParameter %_ptr_Function_OpShiftRightLogicalTest
          %34 = OpLabel
      %intVal = OpVariable %_ptr_Function_int Function
@@ -85,7 +85,7 @@
                OpStore %integer4Val %60
                OpReturn
                OpFunctionEnd
-%OpShiftRightLogicalTest_Main_EntryPoint = OpFunction %void None %17
+%OpShiftRightLogicalTest_Main_EntryPoint = OpFunction %void None %18
          %65 = OpLabel
      %self_2 = OpVariable %_ptr_Function_OpShiftRightLogicalTest Function
          %67 = OpFunctionCall %void %OpShiftRightLogicalTest_DefaultConstructor %self_2

--- a/CSShadersTests/Tests/IntrinsicFunctions/Composite Intrinsics/OpTranspose_IntrinsicTest.expected.spvtxt
+++ b/CSShadersTests/Tests/IntrinsicFunctions/Composite Intrinsics/OpTranspose_IntrinsicTest.expected.spvtxt
@@ -35,30 +35,30 @@
                OpName %self_4 "self"
        %uint = OpTypeInt 32 0
       %float = OpTypeFloat 32
+    %float_0 = OpConstant %float 0
 %OpTransposeTest = OpTypeStruct
        %void = OpTypeVoid
 %_ptr_Function_OpTransposeTest = OpTypePointer Function %OpTransposeTest
-          %9 = OpTypeFunction %void %_ptr_Function_OpTransposeTest
+         %10 = OpTypeFunction %void %_ptr_Function_OpTransposeTest
     %Vector2 = OpTypeVector %float 2
    %Float2x2 = OpTypeMatrix %Vector2 2
 %_ptr_Function_Float2x2 = OpTypePointer Function %Float2x2
-         %15 = OpTypeFunction %void %_ptr_Function_Float2x2 %float
+         %16 = OpTypeFunction %void %_ptr_Function_Float2x2 %float
 %_ptr_Function_Vector2 = OpTypePointer Function %Vector2
-         %17 = OpTypeFunction %void %_ptr_Function_Float2x2 %float %float %float %float
-         %19 = OpTypeFunction %void
-    %float_0 = OpConstant %float 0
-%OpTransposeTest_PreConstructor = OpFunction %void None %9
+         %18 = OpTypeFunction %void %_ptr_Function_Float2x2 %float %float %float %float
+         %20 = OpTypeFunction %void
+%OpTransposeTest_PreConstructor = OpFunction %void None %10
        %self = OpFunctionParameter %_ptr_Function_OpTransposeTest
          %25 = OpLabel
                OpReturn
                OpFunctionEnd
-%OpTransposeTest_DefaultConstructor = OpFunction %void None %9
+%OpTransposeTest_DefaultConstructor = OpFunction %void None %10
      %self_0 = OpFunctionParameter %_ptr_Function_OpTransposeTest
          %30 = OpLabel
          %31 = OpFunctionCall %void %OpTransposeTest_PreConstructor %self_0
                OpReturn
                OpFunctionEnd
-       %Main = OpFunction %void None %9
+       %Main = OpFunction %void None %10
      %self_1 = OpFunctionParameter %_ptr_Function_OpTransposeTest
          %36 = OpLabel
 %float2x2Val = OpVariable %_ptr_Function_Float2x2 Function
@@ -70,7 +70,7 @@
                OpStore %float2x2Val %42
                OpReturn
                OpFunctionEnd
-%Float2x2_Constructor = OpFunction %void None %15
+%Float2x2_Constructor = OpFunction %void None %16
      %self_2 = OpFunctionParameter %_ptr_Function_Float2x2
       %value = OpFunctionParameter %float
          %49 = OpLabel
@@ -83,7 +83,7 @@
                OpStore %self_2 %55
                OpReturn
                OpFunctionEnd
-%Float2x2_Constructor_0 = OpFunction %void None %17
+%Float2x2_Constructor_0 = OpFunction %void None %18
      %self_3 = OpFunctionParameter %_ptr_Function_Float2x2
         %m00 = OpFunctionParameter %float
         %m01 = OpFunctionParameter %float
@@ -96,7 +96,7 @@
                OpStore %self_3 %68
                OpReturn
                OpFunctionEnd
-%OpTransposeTest_Main_EntryPoint = OpFunction %void None %19
+%OpTransposeTest_Main_EntryPoint = OpFunction %void None %20
          %73 = OpLabel
      %self_4 = OpVariable %_ptr_Function_OpTransposeTest Function
          %75 = OpFunctionCall %void %OpTransposeTest_DefaultConstructor %self_4

--- a/CSShadersTests/Tests/IntrinsicFunctions/Conversion Intrinsics/OpBitcast_IntrinsicTest.expected.spvtxt
+++ b/CSShadersTests/Tests/IntrinsicFunctions/Conversion Intrinsics/OpBitcast_IntrinsicTest.expected.spvtxt
@@ -36,11 +36,13 @@
                OpName %self_2 "self"
        %uint = OpTypeInt 32 0
       %float = OpTypeFloat 32
+    %float_0 = OpConstant %float 0
         %int = OpTypeInt 32 1
+      %int_0 = OpConstant %int 0
 %OpBitcastTest = OpTypeStruct
        %void = OpTypeVoid
 %_ptr_Function_OpBitcastTest = OpTypePointer Function %OpBitcastTest
-         %11 = OpTypeFunction %void %_ptr_Function_OpBitcastTest
+         %13 = OpTypeFunction %void %_ptr_Function_OpBitcastTest
 %_ptr_Function_float = OpTypePointer Function %float
 %_ptr_Function_int = OpTypePointer Function %int
     %Vector2 = OpTypeVector %float 2
@@ -55,21 +57,19 @@
 %_ptr_Function_Vector4 = OpTypePointer Function %Vector4
    %Integer4 = OpTypeVector %int 4
 %_ptr_Function_Integer4 = OpTypePointer Function %Integer4
-         %25 = OpTypeFunction %void
-    %float_0 = OpConstant %float 0
-      %int_0 = OpConstant %int 0
-%OpBitcastTest_PreConstructor = OpFunction %void None %11
+         %27 = OpTypeFunction %void
+%OpBitcastTest_PreConstructor = OpFunction %void None %13
        %self = OpFunctionParameter %_ptr_Function_OpBitcastTest
          %32 = OpLabel
                OpReturn
                OpFunctionEnd
-%OpBitcastTest_DefaultConstructor = OpFunction %void None %11
+%OpBitcastTest_DefaultConstructor = OpFunction %void None %13
      %self_0 = OpFunctionParameter %_ptr_Function_OpBitcastTest
          %37 = OpLabel
          %38 = OpFunctionCall %void %OpBitcastTest_PreConstructor %self_0
                OpReturn
                OpFunctionEnd
-       %Main = OpFunction %void None %11
+       %Main = OpFunction %void None %13
      %self_1 = OpFunctionParameter %_ptr_Function_OpBitcastTest
          %43 = OpLabel
    %floatVal = OpVariable %_ptr_Function_float Function
@@ -108,7 +108,7 @@
                OpStore %vector4Val %76
                OpReturn
                OpFunctionEnd
-%OpBitcastTest_Main_EntryPoint = OpFunction %void None %25
+%OpBitcastTest_Main_EntryPoint = OpFunction %void None %27
          %81 = OpLabel
      %self_2 = OpVariable %_ptr_Function_OpBitcastTest Function
          %83 = OpFunctionCall %void %OpBitcastTest_DefaultConstructor %self_2

--- a/CSShadersTests/Tests/IntrinsicFunctions/Conversion Intrinsics/OpConvertFToS_IntrinsicTest.expected.spvtxt
+++ b/CSShadersTests/Tests/IntrinsicFunctions/Conversion Intrinsics/OpConvertFToS_IntrinsicTest.expected.spvtxt
@@ -36,11 +36,13 @@
                OpName %self_2 "self"
        %uint = OpTypeInt 32 0
         %int = OpTypeInt 32 1
+      %int_0 = OpConstant %int 0
       %float = OpTypeFloat 32
+    %float_0 = OpConstant %float 0
 %OpConvertFToSTest = OpTypeStruct
        %void = OpTypeVoid
 %_ptr_Function_OpConvertFToSTest = OpTypePointer Function %OpConvertFToSTest
-         %11 = OpTypeFunction %void %_ptr_Function_OpConvertFToSTest
+         %13 = OpTypeFunction %void %_ptr_Function_OpConvertFToSTest
 %_ptr_Function_int = OpTypePointer Function %int
 %_ptr_Function_float = OpTypePointer Function %float
    %Integer2 = OpTypeVector %int 2
@@ -55,21 +57,19 @@
 %_ptr_Function_Integer4 = OpTypePointer Function %Integer4
     %Vector4 = OpTypeVector %float 4
 %_ptr_Function_Vector4 = OpTypePointer Function %Vector4
-         %25 = OpTypeFunction %void
-      %int_0 = OpConstant %int 0
-    %float_0 = OpConstant %float 0
-%OpConvertFToSTest_PreConstructor = OpFunction %void None %11
+         %27 = OpTypeFunction %void
+%OpConvertFToSTest_PreConstructor = OpFunction %void None %13
        %self = OpFunctionParameter %_ptr_Function_OpConvertFToSTest
          %32 = OpLabel
                OpReturn
                OpFunctionEnd
-%OpConvertFToSTest_DefaultConstructor = OpFunction %void None %11
+%OpConvertFToSTest_DefaultConstructor = OpFunction %void None %13
      %self_0 = OpFunctionParameter %_ptr_Function_OpConvertFToSTest
          %37 = OpLabel
          %38 = OpFunctionCall %void %OpConvertFToSTest_PreConstructor %self_0
                OpReturn
                OpFunctionEnd
-       %Main = OpFunction %void None %11
+       %Main = OpFunction %void None %13
      %self_1 = OpFunctionParameter %_ptr_Function_OpConvertFToSTest
          %43 = OpLabel
      %intVal = OpVariable %_ptr_Function_int Function
@@ -108,7 +108,7 @@
                OpStore %integer4Val %76
                OpReturn
                OpFunctionEnd
-%OpConvertFToSTest_Main_EntryPoint = OpFunction %void None %25
+%OpConvertFToSTest_Main_EntryPoint = OpFunction %void None %27
          %81 = OpLabel
      %self_2 = OpVariable %_ptr_Function_OpConvertFToSTest Function
          %83 = OpFunctionCall %void %OpConvertFToSTest_DefaultConstructor %self_2

--- a/CSShadersTests/Tests/IntrinsicFunctions/Conversion Intrinsics/OpConvertSToF_IntrinsicTest.expected.spvtxt
+++ b/CSShadersTests/Tests/IntrinsicFunctions/Conversion Intrinsics/OpConvertSToF_IntrinsicTest.expected.spvtxt
@@ -36,11 +36,13 @@
                OpName %self_2 "self"
        %uint = OpTypeInt 32 0
       %float = OpTypeFloat 32
+    %float_0 = OpConstant %float 0
         %int = OpTypeInt 32 1
+      %int_0 = OpConstant %int 0
 %OpConvertSToFTest = OpTypeStruct
        %void = OpTypeVoid
 %_ptr_Function_OpConvertSToFTest = OpTypePointer Function %OpConvertSToFTest
-         %11 = OpTypeFunction %void %_ptr_Function_OpConvertSToFTest
+         %13 = OpTypeFunction %void %_ptr_Function_OpConvertSToFTest
 %_ptr_Function_float = OpTypePointer Function %float
 %_ptr_Function_int = OpTypePointer Function %int
     %Vector2 = OpTypeVector %float 2
@@ -55,21 +57,19 @@
 %_ptr_Function_Vector4 = OpTypePointer Function %Vector4
    %Integer4 = OpTypeVector %int 4
 %_ptr_Function_Integer4 = OpTypePointer Function %Integer4
-         %25 = OpTypeFunction %void
-    %float_0 = OpConstant %float 0
-      %int_0 = OpConstant %int 0
-%OpConvertSToFTest_PreConstructor = OpFunction %void None %11
+         %27 = OpTypeFunction %void
+%OpConvertSToFTest_PreConstructor = OpFunction %void None %13
        %self = OpFunctionParameter %_ptr_Function_OpConvertSToFTest
          %32 = OpLabel
                OpReturn
                OpFunctionEnd
-%OpConvertSToFTest_DefaultConstructor = OpFunction %void None %11
+%OpConvertSToFTest_DefaultConstructor = OpFunction %void None %13
      %self_0 = OpFunctionParameter %_ptr_Function_OpConvertSToFTest
          %37 = OpLabel
          %38 = OpFunctionCall %void %OpConvertSToFTest_PreConstructor %self_0
                OpReturn
                OpFunctionEnd
-       %Main = OpFunction %void None %11
+       %Main = OpFunction %void None %13
      %self_1 = OpFunctionParameter %_ptr_Function_OpConvertSToFTest
          %43 = OpLabel
    %floatVal = OpVariable %_ptr_Function_float Function
@@ -108,7 +108,7 @@
                OpStore %vector4Val %76
                OpReturn
                OpFunctionEnd
-%OpConvertSToFTest_Main_EntryPoint = OpFunction %void None %25
+%OpConvertSToFTest_Main_EntryPoint = OpFunction %void None %27
          %81 = OpLabel
      %self_2 = OpVariable %_ptr_Function_OpConvertSToFTest Function
          %83 = OpFunctionCall %void %OpConvertSToFTest_DefaultConstructor %self_2

--- a/CSShadersTests/Tests/IntrinsicFunctions/Derivative Intrinsics/OpDPdx_IntrinsicTest.expected.spvtxt
+++ b/CSShadersTests/Tests/IntrinsicFunctions/Derivative Intrinsics/OpDPdx_IntrinsicTest.expected.spvtxt
@@ -29,10 +29,11 @@
                OpName %self_2 "self"
        %uint = OpTypeInt 32 0
       %float = OpTypeFloat 32
+    %float_0 = OpConstant %float 0
  %OpDPdxTest = OpTypeStruct
        %void = OpTypeVoid
 %_ptr_Function_OpDPdxTest = OpTypePointer Function %OpDPdxTest
-          %9 = OpTypeFunction %void %_ptr_Function_OpDPdxTest
+         %10 = OpTypeFunction %void %_ptr_Function_OpDPdxTest
 %_ptr_Function_float = OpTypePointer Function %float
     %Vector2 = OpTypeVector %float 2
 %_ptr_Function_Vector2 = OpTypePointer Function %Vector2
@@ -40,20 +41,19 @@
 %_ptr_Function_Vector3 = OpTypePointer Function %Vector3
     %Vector4 = OpTypeVector %float 4
 %_ptr_Function_Vector4 = OpTypePointer Function %Vector4
-         %17 = OpTypeFunction %void
-    %float_0 = OpConstant %float 0
-%OpDPdxTest_PreConstructor = OpFunction %void None %9
+         %18 = OpTypeFunction %void
+%OpDPdxTest_PreConstructor = OpFunction %void None %10
        %self = OpFunctionParameter %_ptr_Function_OpDPdxTest
          %23 = OpLabel
                OpReturn
                OpFunctionEnd
-%OpDPdxTest_DefaultConstructor = OpFunction %void None %9
+%OpDPdxTest_DefaultConstructor = OpFunction %void None %10
      %self_0 = OpFunctionParameter %_ptr_Function_OpDPdxTest
          %28 = OpLabel
          %29 = OpFunctionCall %void %OpDPdxTest_PreConstructor %self_0
                OpReturn
                OpFunctionEnd
-       %Main = OpFunction %void None %9
+       %Main = OpFunction %void None %10
      %self_1 = OpFunctionParameter %_ptr_Function_OpDPdxTest
          %34 = OpLabel
    %floatVal = OpVariable %_ptr_Function_float Function
@@ -81,7 +81,7 @@
                OpStore %vector4Val %56
                OpReturn
                OpFunctionEnd
-%OpDPdxTest_Main_EntryPoint = OpFunction %void None %17
+%OpDPdxTest_Main_EntryPoint = OpFunction %void None %18
          %61 = OpLabel
      %self_2 = OpVariable %_ptr_Function_OpDPdxTest Function
          %63 = OpFunctionCall %void %OpDPdxTest_DefaultConstructor %self_2

--- a/CSShadersTests/Tests/IntrinsicFunctions/Derivative Intrinsics/OpDPdy_IntrinsicTest.expected.spvtxt
+++ b/CSShadersTests/Tests/IntrinsicFunctions/Derivative Intrinsics/OpDPdy_IntrinsicTest.expected.spvtxt
@@ -29,10 +29,11 @@
                OpName %self_2 "self"
        %uint = OpTypeInt 32 0
       %float = OpTypeFloat 32
+    %float_0 = OpConstant %float 0
  %OpDPdyTest = OpTypeStruct
        %void = OpTypeVoid
 %_ptr_Function_OpDPdyTest = OpTypePointer Function %OpDPdyTest
-          %9 = OpTypeFunction %void %_ptr_Function_OpDPdyTest
+         %10 = OpTypeFunction %void %_ptr_Function_OpDPdyTest
 %_ptr_Function_float = OpTypePointer Function %float
     %Vector2 = OpTypeVector %float 2
 %_ptr_Function_Vector2 = OpTypePointer Function %Vector2
@@ -40,20 +41,19 @@
 %_ptr_Function_Vector3 = OpTypePointer Function %Vector3
     %Vector4 = OpTypeVector %float 4
 %_ptr_Function_Vector4 = OpTypePointer Function %Vector4
-         %17 = OpTypeFunction %void
-    %float_0 = OpConstant %float 0
-%OpDPdyTest_PreConstructor = OpFunction %void None %9
+         %18 = OpTypeFunction %void
+%OpDPdyTest_PreConstructor = OpFunction %void None %10
        %self = OpFunctionParameter %_ptr_Function_OpDPdyTest
          %23 = OpLabel
                OpReturn
                OpFunctionEnd
-%OpDPdyTest_DefaultConstructor = OpFunction %void None %9
+%OpDPdyTest_DefaultConstructor = OpFunction %void None %10
      %self_0 = OpFunctionParameter %_ptr_Function_OpDPdyTest
          %28 = OpLabel
          %29 = OpFunctionCall %void %OpDPdyTest_PreConstructor %self_0
                OpReturn
                OpFunctionEnd
-       %Main = OpFunction %void None %9
+       %Main = OpFunction %void None %10
      %self_1 = OpFunctionParameter %_ptr_Function_OpDPdyTest
          %34 = OpLabel
    %floatVal = OpVariable %_ptr_Function_float Function
@@ -81,7 +81,7 @@
                OpStore %vector4Val %56
                OpReturn
                OpFunctionEnd
-%OpDPdyTest_Main_EntryPoint = OpFunction %void None %17
+%OpDPdyTest_Main_EntryPoint = OpFunction %void None %18
          %61 = OpLabel
      %self_2 = OpVariable %_ptr_Function_OpDPdyTest Function
          %63 = OpFunctionCall %void %OpDPdyTest_DefaultConstructor %self_2

--- a/CSShadersTests/Tests/IntrinsicFunctions/Derivative Intrinsics/OpFwidth_IntrinsicTest.expected.spvtxt
+++ b/CSShadersTests/Tests/IntrinsicFunctions/Derivative Intrinsics/OpFwidth_IntrinsicTest.expected.spvtxt
@@ -29,10 +29,11 @@
                OpName %self_2 "self"
        %uint = OpTypeInt 32 0
       %float = OpTypeFloat 32
+    %float_0 = OpConstant %float 0
 %OpFwidthTest = OpTypeStruct
        %void = OpTypeVoid
 %_ptr_Function_OpFwidthTest = OpTypePointer Function %OpFwidthTest
-          %9 = OpTypeFunction %void %_ptr_Function_OpFwidthTest
+         %10 = OpTypeFunction %void %_ptr_Function_OpFwidthTest
 %_ptr_Function_float = OpTypePointer Function %float
     %Vector2 = OpTypeVector %float 2
 %_ptr_Function_Vector2 = OpTypePointer Function %Vector2
@@ -40,20 +41,19 @@
 %_ptr_Function_Vector3 = OpTypePointer Function %Vector3
     %Vector4 = OpTypeVector %float 4
 %_ptr_Function_Vector4 = OpTypePointer Function %Vector4
-         %17 = OpTypeFunction %void
-    %float_0 = OpConstant %float 0
-%OpFwidthTest_PreConstructor = OpFunction %void None %9
+         %18 = OpTypeFunction %void
+%OpFwidthTest_PreConstructor = OpFunction %void None %10
        %self = OpFunctionParameter %_ptr_Function_OpFwidthTest
          %23 = OpLabel
                OpReturn
                OpFunctionEnd
-%OpFwidthTest_DefaultConstructor = OpFunction %void None %9
+%OpFwidthTest_DefaultConstructor = OpFunction %void None %10
      %self_0 = OpFunctionParameter %_ptr_Function_OpFwidthTest
          %28 = OpLabel
          %29 = OpFunctionCall %void %OpFwidthTest_PreConstructor %self_0
                OpReturn
                OpFunctionEnd
-       %Main = OpFunction %void None %9
+       %Main = OpFunction %void None %10
      %self_1 = OpFunctionParameter %_ptr_Function_OpFwidthTest
          %34 = OpLabel
    %floatVal = OpVariable %_ptr_Function_float Function
@@ -81,7 +81,7 @@
                OpStore %vector4Val %56
                OpReturn
                OpFunctionEnd
-%OpFwidthTest_Main_EntryPoint = OpFunction %void None %17
+%OpFwidthTest_Main_EntryPoint = OpFunction %void None %18
          %61 = OpLabel
      %self_2 = OpVariable %_ptr_Function_OpFwidthTest Function
          %63 = OpFunctionCall %void %OpFwidthTest_DefaultConstructor %self_2

--- a/CSShadersTests/Tests/IntrinsicFunctions/Glsl.std.450 Intrinsics/Acos_IntrinsicTest.expected.spvtxt
+++ b/CSShadersTests/Tests/IntrinsicFunctions/Glsl.std.450 Intrinsics/Acos_IntrinsicTest.expected.spvtxt
@@ -30,10 +30,11 @@
                OpName %self_2 "self"
        %uint = OpTypeInt 32 0
       %float = OpTypeFloat 32
+    %float_0 = OpConstant %float 0
    %AcosTest = OpTypeStruct
        %void = OpTypeVoid
 %_ptr_Function_AcosTest = OpTypePointer Function %AcosTest
-         %10 = OpTypeFunction %void %_ptr_Function_AcosTest
+         %11 = OpTypeFunction %void %_ptr_Function_AcosTest
 %_ptr_Function_float = OpTypePointer Function %float
     %Vector2 = OpTypeVector %float 2
 %_ptr_Function_Vector2 = OpTypePointer Function %Vector2
@@ -42,20 +43,19 @@
     %Vector4 = OpTypeVector %float 4
 %_ptr_Function_Vector4 = OpTypePointer Function %Vector4
         %int = OpTypeInt 32 1
-         %20 = OpTypeFunction %void
-    %float_0 = OpConstant %float 0
-%AcosTest_PreConstructor = OpFunction %void None %10
+         %21 = OpTypeFunction %void
+%AcosTest_PreConstructor = OpFunction %void None %11
        %self = OpFunctionParameter %_ptr_Function_AcosTest
          %26 = OpLabel
                OpReturn
                OpFunctionEnd
-%AcosTest_DefaultConstructor = OpFunction %void None %10
+%AcosTest_DefaultConstructor = OpFunction %void None %11
      %self_0 = OpFunctionParameter %_ptr_Function_AcosTest
          %31 = OpLabel
          %32 = OpFunctionCall %void %AcosTest_PreConstructor %self_0
                OpReturn
                OpFunctionEnd
-       %Main = OpFunction %void None %10
+       %Main = OpFunction %void None %11
      %self_1 = OpFunctionParameter %_ptr_Function_AcosTest
          %37 = OpLabel
    %floatVal = OpVariable %_ptr_Function_float Function
@@ -83,7 +83,7 @@
                OpStore %vector4Val %59
                OpReturn
                OpFunctionEnd
-%AcosTest_Main_EntryPoint = OpFunction %void None %20
+%AcosTest_Main_EntryPoint = OpFunction %void None %21
          %64 = OpLabel
      %self_2 = OpVariable %_ptr_Function_AcosTest Function
          %66 = OpFunctionCall %void %AcosTest_DefaultConstructor %self_2

--- a/CSShadersTests/Tests/IntrinsicFunctions/Glsl.std.450 Intrinsics/Acosh_IntrinsicTest.expected.spvtxt
+++ b/CSShadersTests/Tests/IntrinsicFunctions/Glsl.std.450 Intrinsics/Acosh_IntrinsicTest.expected.spvtxt
@@ -30,10 +30,11 @@
                OpName %self_2 "self"
        %uint = OpTypeInt 32 0
       %float = OpTypeFloat 32
+    %float_0 = OpConstant %float 0
   %AcoshTest = OpTypeStruct
        %void = OpTypeVoid
 %_ptr_Function_AcoshTest = OpTypePointer Function %AcoshTest
-         %10 = OpTypeFunction %void %_ptr_Function_AcoshTest
+         %11 = OpTypeFunction %void %_ptr_Function_AcoshTest
 %_ptr_Function_float = OpTypePointer Function %float
     %Vector2 = OpTypeVector %float 2
 %_ptr_Function_Vector2 = OpTypePointer Function %Vector2
@@ -42,20 +43,19 @@
     %Vector4 = OpTypeVector %float 4
 %_ptr_Function_Vector4 = OpTypePointer Function %Vector4
         %int = OpTypeInt 32 1
-         %20 = OpTypeFunction %void
-    %float_0 = OpConstant %float 0
-%AcoshTest_PreConstructor = OpFunction %void None %10
+         %21 = OpTypeFunction %void
+%AcoshTest_PreConstructor = OpFunction %void None %11
        %self = OpFunctionParameter %_ptr_Function_AcoshTest
          %26 = OpLabel
                OpReturn
                OpFunctionEnd
-%AcoshTest_DefaultConstructor = OpFunction %void None %10
+%AcoshTest_DefaultConstructor = OpFunction %void None %11
      %self_0 = OpFunctionParameter %_ptr_Function_AcoshTest
          %31 = OpLabel
          %32 = OpFunctionCall %void %AcoshTest_PreConstructor %self_0
                OpReturn
                OpFunctionEnd
-       %Main = OpFunction %void None %10
+       %Main = OpFunction %void None %11
      %self_1 = OpFunctionParameter %_ptr_Function_AcoshTest
          %37 = OpLabel
    %floatVal = OpVariable %_ptr_Function_float Function
@@ -83,7 +83,7 @@
                OpStore %vector4Val %59
                OpReturn
                OpFunctionEnd
-%AcoshTest_Main_EntryPoint = OpFunction %void None %20
+%AcoshTest_Main_EntryPoint = OpFunction %void None %21
          %64 = OpLabel
      %self_2 = OpVariable %_ptr_Function_AcoshTest Function
          %66 = OpFunctionCall %void %AcoshTest_DefaultConstructor %self_2

--- a/CSShadersTests/Tests/IntrinsicFunctions/Glsl.std.450 Intrinsics/Asin_IntrinsicTest.expected.spvtxt
+++ b/CSShadersTests/Tests/IntrinsicFunctions/Glsl.std.450 Intrinsics/Asin_IntrinsicTest.expected.spvtxt
@@ -30,10 +30,11 @@
                OpName %self_2 "self"
        %uint = OpTypeInt 32 0
       %float = OpTypeFloat 32
+    %float_0 = OpConstant %float 0
    %AsinTest = OpTypeStruct
        %void = OpTypeVoid
 %_ptr_Function_AsinTest = OpTypePointer Function %AsinTest
-         %10 = OpTypeFunction %void %_ptr_Function_AsinTest
+         %11 = OpTypeFunction %void %_ptr_Function_AsinTest
 %_ptr_Function_float = OpTypePointer Function %float
     %Vector2 = OpTypeVector %float 2
 %_ptr_Function_Vector2 = OpTypePointer Function %Vector2
@@ -42,20 +43,19 @@
     %Vector4 = OpTypeVector %float 4
 %_ptr_Function_Vector4 = OpTypePointer Function %Vector4
         %int = OpTypeInt 32 1
-         %20 = OpTypeFunction %void
-    %float_0 = OpConstant %float 0
-%AsinTest_PreConstructor = OpFunction %void None %10
+         %21 = OpTypeFunction %void
+%AsinTest_PreConstructor = OpFunction %void None %11
        %self = OpFunctionParameter %_ptr_Function_AsinTest
          %26 = OpLabel
                OpReturn
                OpFunctionEnd
-%AsinTest_DefaultConstructor = OpFunction %void None %10
+%AsinTest_DefaultConstructor = OpFunction %void None %11
      %self_0 = OpFunctionParameter %_ptr_Function_AsinTest
          %31 = OpLabel
          %32 = OpFunctionCall %void %AsinTest_PreConstructor %self_0
                OpReturn
                OpFunctionEnd
-       %Main = OpFunction %void None %10
+       %Main = OpFunction %void None %11
      %self_1 = OpFunctionParameter %_ptr_Function_AsinTest
          %37 = OpLabel
    %floatVal = OpVariable %_ptr_Function_float Function
@@ -83,7 +83,7 @@
                OpStore %vector4Val %59
                OpReturn
                OpFunctionEnd
-%AsinTest_Main_EntryPoint = OpFunction %void None %20
+%AsinTest_Main_EntryPoint = OpFunction %void None %21
          %64 = OpLabel
      %self_2 = OpVariable %_ptr_Function_AsinTest Function
          %66 = OpFunctionCall %void %AsinTest_DefaultConstructor %self_2

--- a/CSShadersTests/Tests/IntrinsicFunctions/Glsl.std.450 Intrinsics/Asinh_IntrinsicTest.expected.spvtxt
+++ b/CSShadersTests/Tests/IntrinsicFunctions/Glsl.std.450 Intrinsics/Asinh_IntrinsicTest.expected.spvtxt
@@ -30,10 +30,11 @@
                OpName %self_2 "self"
        %uint = OpTypeInt 32 0
       %float = OpTypeFloat 32
+    %float_0 = OpConstant %float 0
   %AsinhTest = OpTypeStruct
        %void = OpTypeVoid
 %_ptr_Function_AsinhTest = OpTypePointer Function %AsinhTest
-         %10 = OpTypeFunction %void %_ptr_Function_AsinhTest
+         %11 = OpTypeFunction %void %_ptr_Function_AsinhTest
 %_ptr_Function_float = OpTypePointer Function %float
     %Vector2 = OpTypeVector %float 2
 %_ptr_Function_Vector2 = OpTypePointer Function %Vector2
@@ -42,20 +43,19 @@
     %Vector4 = OpTypeVector %float 4
 %_ptr_Function_Vector4 = OpTypePointer Function %Vector4
         %int = OpTypeInt 32 1
-         %20 = OpTypeFunction %void
-    %float_0 = OpConstant %float 0
-%AsinhTest_PreConstructor = OpFunction %void None %10
+         %21 = OpTypeFunction %void
+%AsinhTest_PreConstructor = OpFunction %void None %11
        %self = OpFunctionParameter %_ptr_Function_AsinhTest
          %26 = OpLabel
                OpReturn
                OpFunctionEnd
-%AsinhTest_DefaultConstructor = OpFunction %void None %10
+%AsinhTest_DefaultConstructor = OpFunction %void None %11
      %self_0 = OpFunctionParameter %_ptr_Function_AsinhTest
          %31 = OpLabel
          %32 = OpFunctionCall %void %AsinhTest_PreConstructor %self_0
                OpReturn
                OpFunctionEnd
-       %Main = OpFunction %void None %10
+       %Main = OpFunction %void None %11
      %self_1 = OpFunctionParameter %_ptr_Function_AsinhTest
          %37 = OpLabel
    %floatVal = OpVariable %_ptr_Function_float Function
@@ -83,7 +83,7 @@
                OpStore %vector4Val %59
                OpReturn
                OpFunctionEnd
-%AsinhTest_Main_EntryPoint = OpFunction %void None %20
+%AsinhTest_Main_EntryPoint = OpFunction %void None %21
          %64 = OpLabel
      %self_2 = OpVariable %_ptr_Function_AsinhTest Function
          %66 = OpFunctionCall %void %AsinhTest_DefaultConstructor %self_2

--- a/CSShadersTests/Tests/IntrinsicFunctions/Glsl.std.450 Intrinsics/Atan2_IntrinsicTest.expected.spvtxt
+++ b/CSShadersTests/Tests/IntrinsicFunctions/Glsl.std.450 Intrinsics/Atan2_IntrinsicTest.expected.spvtxt
@@ -30,10 +30,11 @@
                OpName %self_2 "self"
        %uint = OpTypeInt 32 0
       %float = OpTypeFloat 32
+    %float_0 = OpConstant %float 0
   %Atan2Test = OpTypeStruct
        %void = OpTypeVoid
 %_ptr_Function_Atan2Test = OpTypePointer Function %Atan2Test
-         %10 = OpTypeFunction %void %_ptr_Function_Atan2Test
+         %11 = OpTypeFunction %void %_ptr_Function_Atan2Test
 %_ptr_Function_float = OpTypePointer Function %float
     %Vector2 = OpTypeVector %float 2
 %_ptr_Function_Vector2 = OpTypePointer Function %Vector2
@@ -42,20 +43,19 @@
     %Vector4 = OpTypeVector %float 4
 %_ptr_Function_Vector4 = OpTypePointer Function %Vector4
         %int = OpTypeInt 32 1
-         %20 = OpTypeFunction %void
-    %float_0 = OpConstant %float 0
-%Atan2Test_PreConstructor = OpFunction %void None %10
+         %21 = OpTypeFunction %void
+%Atan2Test_PreConstructor = OpFunction %void None %11
        %self = OpFunctionParameter %_ptr_Function_Atan2Test
          %26 = OpLabel
                OpReturn
                OpFunctionEnd
-%Atan2Test_DefaultConstructor = OpFunction %void None %10
+%Atan2Test_DefaultConstructor = OpFunction %void None %11
      %self_0 = OpFunctionParameter %_ptr_Function_Atan2Test
          %31 = OpLabel
          %32 = OpFunctionCall %void %Atan2Test_PreConstructor %self_0
                OpReturn
                OpFunctionEnd
-       %Main = OpFunction %void None %10
+       %Main = OpFunction %void None %11
      %self_1 = OpFunctionParameter %_ptr_Function_Atan2Test
          %37 = OpLabel
    %floatVal = OpVariable %_ptr_Function_float Function
@@ -87,7 +87,7 @@
                OpStore %vector4Val %63
                OpReturn
                OpFunctionEnd
-%Atan2Test_Main_EntryPoint = OpFunction %void None %20
+%Atan2Test_Main_EntryPoint = OpFunction %void None %21
          %68 = OpLabel
      %self_2 = OpVariable %_ptr_Function_Atan2Test Function
          %70 = OpFunctionCall %void %Atan2Test_DefaultConstructor %self_2

--- a/CSShadersTests/Tests/IntrinsicFunctions/Glsl.std.450 Intrinsics/Atan_IntrinsicTest.expected.spvtxt
+++ b/CSShadersTests/Tests/IntrinsicFunctions/Glsl.std.450 Intrinsics/Atan_IntrinsicTest.expected.spvtxt
@@ -30,10 +30,11 @@
                OpName %self_2 "self"
        %uint = OpTypeInt 32 0
       %float = OpTypeFloat 32
+    %float_0 = OpConstant %float 0
    %AtanTest = OpTypeStruct
        %void = OpTypeVoid
 %_ptr_Function_AtanTest = OpTypePointer Function %AtanTest
-         %10 = OpTypeFunction %void %_ptr_Function_AtanTest
+         %11 = OpTypeFunction %void %_ptr_Function_AtanTest
 %_ptr_Function_float = OpTypePointer Function %float
     %Vector2 = OpTypeVector %float 2
 %_ptr_Function_Vector2 = OpTypePointer Function %Vector2
@@ -42,20 +43,19 @@
     %Vector4 = OpTypeVector %float 4
 %_ptr_Function_Vector4 = OpTypePointer Function %Vector4
         %int = OpTypeInt 32 1
-         %20 = OpTypeFunction %void
-    %float_0 = OpConstant %float 0
-%AtanTest_PreConstructor = OpFunction %void None %10
+         %21 = OpTypeFunction %void
+%AtanTest_PreConstructor = OpFunction %void None %11
        %self = OpFunctionParameter %_ptr_Function_AtanTest
          %26 = OpLabel
                OpReturn
                OpFunctionEnd
-%AtanTest_DefaultConstructor = OpFunction %void None %10
+%AtanTest_DefaultConstructor = OpFunction %void None %11
      %self_0 = OpFunctionParameter %_ptr_Function_AtanTest
          %31 = OpLabel
          %32 = OpFunctionCall %void %AtanTest_PreConstructor %self_0
                OpReturn
                OpFunctionEnd
-       %Main = OpFunction %void None %10
+       %Main = OpFunction %void None %11
      %self_1 = OpFunctionParameter %_ptr_Function_AtanTest
          %37 = OpLabel
    %floatVal = OpVariable %_ptr_Function_float Function
@@ -83,7 +83,7 @@
                OpStore %vector4Val %59
                OpReturn
                OpFunctionEnd
-%AtanTest_Main_EntryPoint = OpFunction %void None %20
+%AtanTest_Main_EntryPoint = OpFunction %void None %21
          %64 = OpLabel
      %self_2 = OpVariable %_ptr_Function_AtanTest Function
          %66 = OpFunctionCall %void %AtanTest_DefaultConstructor %self_2

--- a/CSShadersTests/Tests/IntrinsicFunctions/Glsl.std.450 Intrinsics/Atanh_IntrinsicTest.expected.spvtxt
+++ b/CSShadersTests/Tests/IntrinsicFunctions/Glsl.std.450 Intrinsics/Atanh_IntrinsicTest.expected.spvtxt
@@ -30,10 +30,11 @@
                OpName %self_2 "self"
        %uint = OpTypeInt 32 0
       %float = OpTypeFloat 32
+    %float_0 = OpConstant %float 0
   %AtanhTest = OpTypeStruct
        %void = OpTypeVoid
 %_ptr_Function_AtanhTest = OpTypePointer Function %AtanhTest
-         %10 = OpTypeFunction %void %_ptr_Function_AtanhTest
+         %11 = OpTypeFunction %void %_ptr_Function_AtanhTest
 %_ptr_Function_float = OpTypePointer Function %float
     %Vector2 = OpTypeVector %float 2
 %_ptr_Function_Vector2 = OpTypePointer Function %Vector2
@@ -42,20 +43,19 @@
     %Vector4 = OpTypeVector %float 4
 %_ptr_Function_Vector4 = OpTypePointer Function %Vector4
         %int = OpTypeInt 32 1
-         %20 = OpTypeFunction %void
-    %float_0 = OpConstant %float 0
-%AtanhTest_PreConstructor = OpFunction %void None %10
+         %21 = OpTypeFunction %void
+%AtanhTest_PreConstructor = OpFunction %void None %11
        %self = OpFunctionParameter %_ptr_Function_AtanhTest
          %26 = OpLabel
                OpReturn
                OpFunctionEnd
-%AtanhTest_DefaultConstructor = OpFunction %void None %10
+%AtanhTest_DefaultConstructor = OpFunction %void None %11
      %self_0 = OpFunctionParameter %_ptr_Function_AtanhTest
          %31 = OpLabel
          %32 = OpFunctionCall %void %AtanhTest_PreConstructor %self_0
                OpReturn
                OpFunctionEnd
-       %Main = OpFunction %void None %10
+       %Main = OpFunction %void None %11
      %self_1 = OpFunctionParameter %_ptr_Function_AtanhTest
          %37 = OpLabel
    %floatVal = OpVariable %_ptr_Function_float Function
@@ -83,7 +83,7 @@
                OpStore %vector4Val %59
                OpReturn
                OpFunctionEnd
-%AtanhTest_Main_EntryPoint = OpFunction %void None %20
+%AtanhTest_Main_EntryPoint = OpFunction %void None %21
          %64 = OpLabel
      %self_2 = OpVariable %_ptr_Function_AtanhTest Function
          %66 = OpFunctionCall %void %AtanhTest_DefaultConstructor %self_2

--- a/CSShadersTests/Tests/IntrinsicFunctions/Glsl.std.450 Intrinsics/Ceil_IntrinsicTest.expected.spvtxt
+++ b/CSShadersTests/Tests/IntrinsicFunctions/Glsl.std.450 Intrinsics/Ceil_IntrinsicTest.expected.spvtxt
@@ -30,10 +30,11 @@
                OpName %self_2 "self"
        %uint = OpTypeInt 32 0
       %float = OpTypeFloat 32
+    %float_0 = OpConstant %float 0
    %CeilTest = OpTypeStruct
        %void = OpTypeVoid
 %_ptr_Function_CeilTest = OpTypePointer Function %CeilTest
-         %10 = OpTypeFunction %void %_ptr_Function_CeilTest
+         %11 = OpTypeFunction %void %_ptr_Function_CeilTest
 %_ptr_Function_float = OpTypePointer Function %float
     %Vector2 = OpTypeVector %float 2
 %_ptr_Function_Vector2 = OpTypePointer Function %Vector2
@@ -42,20 +43,19 @@
     %Vector4 = OpTypeVector %float 4
 %_ptr_Function_Vector4 = OpTypePointer Function %Vector4
         %int = OpTypeInt 32 1
-         %20 = OpTypeFunction %void
-    %float_0 = OpConstant %float 0
-%CeilTest_PreConstructor = OpFunction %void None %10
+         %21 = OpTypeFunction %void
+%CeilTest_PreConstructor = OpFunction %void None %11
        %self = OpFunctionParameter %_ptr_Function_CeilTest
          %26 = OpLabel
                OpReturn
                OpFunctionEnd
-%CeilTest_DefaultConstructor = OpFunction %void None %10
+%CeilTest_DefaultConstructor = OpFunction %void None %11
      %self_0 = OpFunctionParameter %_ptr_Function_CeilTest
          %31 = OpLabel
          %32 = OpFunctionCall %void %CeilTest_PreConstructor %self_0
                OpReturn
                OpFunctionEnd
-       %Main = OpFunction %void None %10
+       %Main = OpFunction %void None %11
      %self_1 = OpFunctionParameter %_ptr_Function_CeilTest
          %37 = OpLabel
    %floatVal = OpVariable %_ptr_Function_float Function
@@ -83,7 +83,7 @@
                OpStore %vector4Val %59
                OpReturn
                OpFunctionEnd
-%CeilTest_Main_EntryPoint = OpFunction %void None %20
+%CeilTest_Main_EntryPoint = OpFunction %void None %21
          %64 = OpLabel
      %self_2 = OpVariable %_ptr_Function_CeilTest Function
          %66 = OpFunctionCall %void %CeilTest_DefaultConstructor %self_2

--- a/CSShadersTests/Tests/IntrinsicFunctions/Glsl.std.450 Intrinsics/Cos_IntrinsicTest.expected.spvtxt
+++ b/CSShadersTests/Tests/IntrinsicFunctions/Glsl.std.450 Intrinsics/Cos_IntrinsicTest.expected.spvtxt
@@ -30,10 +30,11 @@
                OpName %self_2 "self"
        %uint = OpTypeInt 32 0
       %float = OpTypeFloat 32
+    %float_0 = OpConstant %float 0
     %CosTest = OpTypeStruct
        %void = OpTypeVoid
 %_ptr_Function_CosTest = OpTypePointer Function %CosTest
-         %10 = OpTypeFunction %void %_ptr_Function_CosTest
+         %11 = OpTypeFunction %void %_ptr_Function_CosTest
 %_ptr_Function_float = OpTypePointer Function %float
     %Vector2 = OpTypeVector %float 2
 %_ptr_Function_Vector2 = OpTypePointer Function %Vector2
@@ -42,20 +43,19 @@
     %Vector4 = OpTypeVector %float 4
 %_ptr_Function_Vector4 = OpTypePointer Function %Vector4
         %int = OpTypeInt 32 1
-         %20 = OpTypeFunction %void
-    %float_0 = OpConstant %float 0
-%CosTest_PreConstructor = OpFunction %void None %10
+         %21 = OpTypeFunction %void
+%CosTest_PreConstructor = OpFunction %void None %11
        %self = OpFunctionParameter %_ptr_Function_CosTest
          %26 = OpLabel
                OpReturn
                OpFunctionEnd
-%CosTest_DefaultConstructor = OpFunction %void None %10
+%CosTest_DefaultConstructor = OpFunction %void None %11
      %self_0 = OpFunctionParameter %_ptr_Function_CosTest
          %31 = OpLabel
          %32 = OpFunctionCall %void %CosTest_PreConstructor %self_0
                OpReturn
                OpFunctionEnd
-       %Main = OpFunction %void None %10
+       %Main = OpFunction %void None %11
      %self_1 = OpFunctionParameter %_ptr_Function_CosTest
          %37 = OpLabel
    %floatVal = OpVariable %_ptr_Function_float Function
@@ -83,7 +83,7 @@
                OpStore %vector4Val %59
                OpReturn
                OpFunctionEnd
-%CosTest_Main_EntryPoint = OpFunction %void None %20
+%CosTest_Main_EntryPoint = OpFunction %void None %21
          %64 = OpLabel
      %self_2 = OpVariable %_ptr_Function_CosTest Function
          %66 = OpFunctionCall %void %CosTest_DefaultConstructor %self_2

--- a/CSShadersTests/Tests/IntrinsicFunctions/Glsl.std.450 Intrinsics/Cosh_IntrinsicTest.expected.spvtxt
+++ b/CSShadersTests/Tests/IntrinsicFunctions/Glsl.std.450 Intrinsics/Cosh_IntrinsicTest.expected.spvtxt
@@ -30,10 +30,11 @@
                OpName %self_2 "self"
        %uint = OpTypeInt 32 0
       %float = OpTypeFloat 32
+    %float_0 = OpConstant %float 0
    %CoshTest = OpTypeStruct
        %void = OpTypeVoid
 %_ptr_Function_CoshTest = OpTypePointer Function %CoshTest
-         %10 = OpTypeFunction %void %_ptr_Function_CoshTest
+         %11 = OpTypeFunction %void %_ptr_Function_CoshTest
 %_ptr_Function_float = OpTypePointer Function %float
     %Vector2 = OpTypeVector %float 2
 %_ptr_Function_Vector2 = OpTypePointer Function %Vector2
@@ -42,20 +43,19 @@
     %Vector4 = OpTypeVector %float 4
 %_ptr_Function_Vector4 = OpTypePointer Function %Vector4
         %int = OpTypeInt 32 1
-         %20 = OpTypeFunction %void
-    %float_0 = OpConstant %float 0
-%CoshTest_PreConstructor = OpFunction %void None %10
+         %21 = OpTypeFunction %void
+%CoshTest_PreConstructor = OpFunction %void None %11
        %self = OpFunctionParameter %_ptr_Function_CoshTest
          %26 = OpLabel
                OpReturn
                OpFunctionEnd
-%CoshTest_DefaultConstructor = OpFunction %void None %10
+%CoshTest_DefaultConstructor = OpFunction %void None %11
      %self_0 = OpFunctionParameter %_ptr_Function_CoshTest
          %31 = OpLabel
          %32 = OpFunctionCall %void %CoshTest_PreConstructor %self_0
                OpReturn
                OpFunctionEnd
-       %Main = OpFunction %void None %10
+       %Main = OpFunction %void None %11
      %self_1 = OpFunctionParameter %_ptr_Function_CoshTest
          %37 = OpLabel
    %floatVal = OpVariable %_ptr_Function_float Function
@@ -83,7 +83,7 @@
                OpStore %vector4Val %59
                OpReturn
                OpFunctionEnd
-%CoshTest_Main_EntryPoint = OpFunction %void None %20
+%CoshTest_Main_EntryPoint = OpFunction %void None %21
          %64 = OpLabel
      %self_2 = OpVariable %_ptr_Function_CoshTest Function
          %66 = OpFunctionCall %void %CoshTest_DefaultConstructor %self_2

--- a/CSShadersTests/Tests/IntrinsicFunctions/Glsl.std.450 Intrinsics/Cross_IntrinsicTest.expected.spvtxt
+++ b/CSShadersTests/Tests/IntrinsicFunctions/Glsl.std.450 Intrinsics/Cross_IntrinsicTest.expected.spvtxt
@@ -25,27 +25,27 @@
                OpName %self_2 "self"
        %uint = OpTypeInt 32 0
       %float = OpTypeFloat 32
+    %float_0 = OpConstant %float 0
   %CrossTest = OpTypeStruct
        %void = OpTypeVoid
 %_ptr_Function_CrossTest = OpTypePointer Function %CrossTest
-         %10 = OpTypeFunction %void %_ptr_Function_CrossTest
+         %11 = OpTypeFunction %void %_ptr_Function_CrossTest
     %Vector3 = OpTypeVector %float 3
 %_ptr_Function_Vector3 = OpTypePointer Function %Vector3
         %int = OpTypeInt 32 1
-         %16 = OpTypeFunction %void
-    %float_0 = OpConstant %float 0
-%CrossTest_PreConstructor = OpFunction %void None %10
+         %17 = OpTypeFunction %void
+%CrossTest_PreConstructor = OpFunction %void None %11
        %self = OpFunctionParameter %_ptr_Function_CrossTest
          %22 = OpLabel
                OpReturn
                OpFunctionEnd
-%CrossTest_DefaultConstructor = OpFunction %void None %10
+%CrossTest_DefaultConstructor = OpFunction %void None %11
      %self_0 = OpFunctionParameter %_ptr_Function_CrossTest
          %27 = OpLabel
          %28 = OpFunctionCall %void %CrossTest_PreConstructor %self_0
                OpReturn
                OpFunctionEnd
-       %Main = OpFunction %void None %10
+       %Main = OpFunction %void None %11
      %self_1 = OpFunctionParameter %_ptr_Function_CrossTest
          %33 = OpLabel
  %vector3Val = OpVariable %_ptr_Function_Vector3 Function
@@ -57,7 +57,7 @@
                OpStore %vector3Val %39
                OpReturn
                OpFunctionEnd
-%CrossTest_Main_EntryPoint = OpFunction %void None %16
+%CrossTest_Main_EntryPoint = OpFunction %void None %17
          %44 = OpLabel
      %self_2 = OpVariable %_ptr_Function_CrossTest Function
          %46 = OpFunctionCall %void %CrossTest_DefaultConstructor %self_2

--- a/CSShadersTests/Tests/IntrinsicFunctions/Glsl.std.450 Intrinsics/Degrees_IntrinsicTest.expected.spvtxt
+++ b/CSShadersTests/Tests/IntrinsicFunctions/Glsl.std.450 Intrinsics/Degrees_IntrinsicTest.expected.spvtxt
@@ -30,10 +30,11 @@
                OpName %self_2 "self"
        %uint = OpTypeInt 32 0
       %float = OpTypeFloat 32
+    %float_0 = OpConstant %float 0
 %DegreesTest = OpTypeStruct
        %void = OpTypeVoid
 %_ptr_Function_DegreesTest = OpTypePointer Function %DegreesTest
-         %10 = OpTypeFunction %void %_ptr_Function_DegreesTest
+         %11 = OpTypeFunction %void %_ptr_Function_DegreesTest
 %_ptr_Function_float = OpTypePointer Function %float
     %Vector2 = OpTypeVector %float 2
 %_ptr_Function_Vector2 = OpTypePointer Function %Vector2
@@ -42,20 +43,19 @@
     %Vector4 = OpTypeVector %float 4
 %_ptr_Function_Vector4 = OpTypePointer Function %Vector4
         %int = OpTypeInt 32 1
-         %20 = OpTypeFunction %void
-    %float_0 = OpConstant %float 0
-%DegreesTest_PreConstructor = OpFunction %void None %10
+         %21 = OpTypeFunction %void
+%DegreesTest_PreConstructor = OpFunction %void None %11
        %self = OpFunctionParameter %_ptr_Function_DegreesTest
          %26 = OpLabel
                OpReturn
                OpFunctionEnd
-%DegreesTest_DefaultConstructor = OpFunction %void None %10
+%DegreesTest_DefaultConstructor = OpFunction %void None %11
      %self_0 = OpFunctionParameter %_ptr_Function_DegreesTest
          %31 = OpLabel
          %32 = OpFunctionCall %void %DegreesTest_PreConstructor %self_0
                OpReturn
                OpFunctionEnd
-       %Main = OpFunction %void None %10
+       %Main = OpFunction %void None %11
      %self_1 = OpFunctionParameter %_ptr_Function_DegreesTest
          %37 = OpLabel
    %floatVal = OpVariable %_ptr_Function_float Function
@@ -83,7 +83,7 @@
                OpStore %vector4Val %59
                OpReturn
                OpFunctionEnd
-%DegreesTest_Main_EntryPoint = OpFunction %void None %20
+%DegreesTest_Main_EntryPoint = OpFunction %void None %21
          %64 = OpLabel
      %self_2 = OpVariable %_ptr_Function_DegreesTest Function
          %66 = OpFunctionCall %void %DegreesTest_DefaultConstructor %self_2

--- a/CSShadersTests/Tests/IntrinsicFunctions/Glsl.std.450 Intrinsics/Determinant_IntrinsicTest.expected.spvtxt
+++ b/CSShadersTests/Tests/IntrinsicFunctions/Glsl.std.450 Intrinsics/Determinant_IntrinsicTest.expected.spvtxt
@@ -37,32 +37,32 @@
                OpName %self_4 "self"
        %uint = OpTypeInt 32 0
       %float = OpTypeFloat 32
+    %float_0 = OpConstant %float 0
 %DeterminantTest = OpTypeStruct
        %void = OpTypeVoid
 %_ptr_Function_DeterminantTest = OpTypePointer Function %DeterminantTest
-         %10 = OpTypeFunction %void %_ptr_Function_DeterminantTest
+         %11 = OpTypeFunction %void %_ptr_Function_DeterminantTest
 %_ptr_Function_float = OpTypePointer Function %float
     %Vector2 = OpTypeVector %float 2
    %Float2x2 = OpTypeMatrix %Vector2 2
 %_ptr_Function_Float2x2 = OpTypePointer Function %Float2x2
-         %16 = OpTypeFunction %void %_ptr_Function_Float2x2 %float
+         %17 = OpTypeFunction %void %_ptr_Function_Float2x2 %float
 %_ptr_Function_Vector2 = OpTypePointer Function %Vector2
-         %18 = OpTypeFunction %void %_ptr_Function_Float2x2 %float %float %float %float
+         %19 = OpTypeFunction %void %_ptr_Function_Float2x2 %float %float %float %float
         %int = OpTypeInt 32 1
-         %22 = OpTypeFunction %void
-    %float_0 = OpConstant %float 0
-%DeterminantTest_PreConstructor = OpFunction %void None %10
+         %23 = OpTypeFunction %void
+%DeterminantTest_PreConstructor = OpFunction %void None %11
        %self = OpFunctionParameter %_ptr_Function_DeterminantTest
          %28 = OpLabel
                OpReturn
                OpFunctionEnd
-%DeterminantTest_DefaultConstructor = OpFunction %void None %10
+%DeterminantTest_DefaultConstructor = OpFunction %void None %11
      %self_0 = OpFunctionParameter %_ptr_Function_DeterminantTest
          %33 = OpLabel
          %34 = OpFunctionCall %void %DeterminantTest_PreConstructor %self_0
                OpReturn
                OpFunctionEnd
-       %Main = OpFunction %void None %10
+       %Main = OpFunction %void None %11
      %self_1 = OpFunctionParameter %_ptr_Function_DeterminantTest
          %39 = OpLabel
    %floatVal = OpVariable %_ptr_Function_float Function
@@ -76,7 +76,7 @@
                OpStore %floatVal %47
                OpReturn
                OpFunctionEnd
-%Float2x2_Constructor = OpFunction %void None %16
+%Float2x2_Constructor = OpFunction %void None %17
      %self_2 = OpFunctionParameter %_ptr_Function_Float2x2
       %value = OpFunctionParameter %float
          %54 = OpLabel
@@ -89,7 +89,7 @@
                OpStore %self_2 %60
                OpReturn
                OpFunctionEnd
-%Float2x2_Constructor_0 = OpFunction %void None %18
+%Float2x2_Constructor_0 = OpFunction %void None %19
      %self_3 = OpFunctionParameter %_ptr_Function_Float2x2
         %m00 = OpFunctionParameter %float
         %m01 = OpFunctionParameter %float
@@ -102,7 +102,7 @@
                OpStore %self_3 %73
                OpReturn
                OpFunctionEnd
-%DeterminantTest_Main_EntryPoint = OpFunction %void None %22
+%DeterminantTest_Main_EntryPoint = OpFunction %void None %23
          %78 = OpLabel
      %self_4 = OpVariable %_ptr_Function_DeterminantTest Function
          %80 = OpFunctionCall %void %DeterminantTest_DefaultConstructor %self_4

--- a/CSShadersTests/Tests/IntrinsicFunctions/Glsl.std.450 Intrinsics/Distance_IntrinsicTest.expected.spvtxt
+++ b/CSShadersTests/Tests/IntrinsicFunctions/Glsl.std.450 Intrinsics/Distance_IntrinsicTest.expected.spvtxt
@@ -30,10 +30,11 @@
                OpName %self_2 "self"
        %uint = OpTypeInt 32 0
       %float = OpTypeFloat 32
+    %float_0 = OpConstant %float 0
 %DistanceTest = OpTypeStruct
        %void = OpTypeVoid
 %_ptr_Function_DistanceTest = OpTypePointer Function %DistanceTest
-         %10 = OpTypeFunction %void %_ptr_Function_DistanceTest
+         %11 = OpTypeFunction %void %_ptr_Function_DistanceTest
 %_ptr_Function_float = OpTypePointer Function %float
     %Vector2 = OpTypeVector %float 2
 %_ptr_Function_Vector2 = OpTypePointer Function %Vector2
@@ -42,20 +43,19 @@
     %Vector4 = OpTypeVector %float 4
 %_ptr_Function_Vector4 = OpTypePointer Function %Vector4
         %int = OpTypeInt 32 1
-         %20 = OpTypeFunction %void
-    %float_0 = OpConstant %float 0
-%DistanceTest_PreConstructor = OpFunction %void None %10
+         %21 = OpTypeFunction %void
+%DistanceTest_PreConstructor = OpFunction %void None %11
        %self = OpFunctionParameter %_ptr_Function_DistanceTest
          %26 = OpLabel
                OpReturn
                OpFunctionEnd
-%DistanceTest_DefaultConstructor = OpFunction %void None %10
+%DistanceTest_DefaultConstructor = OpFunction %void None %11
      %self_0 = OpFunctionParameter %_ptr_Function_DistanceTest
          %31 = OpLabel
          %32 = OpFunctionCall %void %DistanceTest_PreConstructor %self_0
                OpReturn
                OpFunctionEnd
-       %Main = OpFunction %void None %10
+       %Main = OpFunction %void None %11
      %self_1 = OpFunctionParameter %_ptr_Function_DistanceTest
          %37 = OpLabel
    %floatVal = OpVariable %_ptr_Function_float Function
@@ -83,7 +83,7 @@
                OpStore %floatVal %59
                OpReturn
                OpFunctionEnd
-%DistanceTest_Main_EntryPoint = OpFunction %void None %20
+%DistanceTest_Main_EntryPoint = OpFunction %void None %21
          %64 = OpLabel
      %self_2 = OpVariable %_ptr_Function_DistanceTest Function
          %66 = OpFunctionCall %void %DistanceTest_DefaultConstructor %self_2

--- a/CSShadersTests/Tests/IntrinsicFunctions/Glsl.std.450 Intrinsics/Exp2_IntrinsicTest.expected.spvtxt
+++ b/CSShadersTests/Tests/IntrinsicFunctions/Glsl.std.450 Intrinsics/Exp2_IntrinsicTest.expected.spvtxt
@@ -30,10 +30,11 @@
                OpName %self_2 "self"
        %uint = OpTypeInt 32 0
       %float = OpTypeFloat 32
+    %float_0 = OpConstant %float 0
    %Exp2Test = OpTypeStruct
        %void = OpTypeVoid
 %_ptr_Function_Exp2Test = OpTypePointer Function %Exp2Test
-         %10 = OpTypeFunction %void %_ptr_Function_Exp2Test
+         %11 = OpTypeFunction %void %_ptr_Function_Exp2Test
 %_ptr_Function_float = OpTypePointer Function %float
     %Vector2 = OpTypeVector %float 2
 %_ptr_Function_Vector2 = OpTypePointer Function %Vector2
@@ -42,20 +43,19 @@
     %Vector4 = OpTypeVector %float 4
 %_ptr_Function_Vector4 = OpTypePointer Function %Vector4
         %int = OpTypeInt 32 1
-         %20 = OpTypeFunction %void
-    %float_0 = OpConstant %float 0
-%Exp2Test_PreConstructor = OpFunction %void None %10
+         %21 = OpTypeFunction %void
+%Exp2Test_PreConstructor = OpFunction %void None %11
        %self = OpFunctionParameter %_ptr_Function_Exp2Test
          %26 = OpLabel
                OpReturn
                OpFunctionEnd
-%Exp2Test_DefaultConstructor = OpFunction %void None %10
+%Exp2Test_DefaultConstructor = OpFunction %void None %11
      %self_0 = OpFunctionParameter %_ptr_Function_Exp2Test
          %31 = OpLabel
          %32 = OpFunctionCall %void %Exp2Test_PreConstructor %self_0
                OpReturn
                OpFunctionEnd
-       %Main = OpFunction %void None %10
+       %Main = OpFunction %void None %11
      %self_1 = OpFunctionParameter %_ptr_Function_Exp2Test
          %37 = OpLabel
    %floatVal = OpVariable %_ptr_Function_float Function
@@ -83,7 +83,7 @@
                OpStore %vector4Val %59
                OpReturn
                OpFunctionEnd
-%Exp2Test_Main_EntryPoint = OpFunction %void None %20
+%Exp2Test_Main_EntryPoint = OpFunction %void None %21
          %64 = OpLabel
      %self_2 = OpVariable %_ptr_Function_Exp2Test Function
          %66 = OpFunctionCall %void %Exp2Test_DefaultConstructor %self_2

--- a/CSShadersTests/Tests/IntrinsicFunctions/Glsl.std.450 Intrinsics/Exp_IntrinsicTest.expected.spvtxt
+++ b/CSShadersTests/Tests/IntrinsicFunctions/Glsl.std.450 Intrinsics/Exp_IntrinsicTest.expected.spvtxt
@@ -30,10 +30,11 @@
                OpName %self_2 "self"
        %uint = OpTypeInt 32 0
       %float = OpTypeFloat 32
+    %float_0 = OpConstant %float 0
     %ExpTest = OpTypeStruct
        %void = OpTypeVoid
 %_ptr_Function_ExpTest = OpTypePointer Function %ExpTest
-         %10 = OpTypeFunction %void %_ptr_Function_ExpTest
+         %11 = OpTypeFunction %void %_ptr_Function_ExpTest
 %_ptr_Function_float = OpTypePointer Function %float
     %Vector2 = OpTypeVector %float 2
 %_ptr_Function_Vector2 = OpTypePointer Function %Vector2
@@ -42,20 +43,19 @@
     %Vector4 = OpTypeVector %float 4
 %_ptr_Function_Vector4 = OpTypePointer Function %Vector4
         %int = OpTypeInt 32 1
-         %20 = OpTypeFunction %void
-    %float_0 = OpConstant %float 0
-%ExpTest_PreConstructor = OpFunction %void None %10
+         %21 = OpTypeFunction %void
+%ExpTest_PreConstructor = OpFunction %void None %11
        %self = OpFunctionParameter %_ptr_Function_ExpTest
          %26 = OpLabel
                OpReturn
                OpFunctionEnd
-%ExpTest_DefaultConstructor = OpFunction %void None %10
+%ExpTest_DefaultConstructor = OpFunction %void None %11
      %self_0 = OpFunctionParameter %_ptr_Function_ExpTest
          %31 = OpLabel
          %32 = OpFunctionCall %void %ExpTest_PreConstructor %self_0
                OpReturn
                OpFunctionEnd
-       %Main = OpFunction %void None %10
+       %Main = OpFunction %void None %11
      %self_1 = OpFunctionParameter %_ptr_Function_ExpTest
          %37 = OpLabel
    %floatVal = OpVariable %_ptr_Function_float Function
@@ -83,7 +83,7 @@
                OpStore %vector4Val %59
                OpReturn
                OpFunctionEnd
-%ExpTest_Main_EntryPoint = OpFunction %void None %20
+%ExpTest_Main_EntryPoint = OpFunction %void None %21
          %64 = OpLabel
      %self_2 = OpVariable %_ptr_Function_ExpTest Function
          %66 = OpFunctionCall %void %ExpTest_DefaultConstructor %self_2

--- a/CSShadersTests/Tests/IntrinsicFunctions/Glsl.std.450 Intrinsics/FAbs_IntrinsicTest.expected.spvtxt
+++ b/CSShadersTests/Tests/IntrinsicFunctions/Glsl.std.450 Intrinsics/FAbs_IntrinsicTest.expected.spvtxt
@@ -30,10 +30,11 @@
                OpName %self_2 "self"
        %uint = OpTypeInt 32 0
       %float = OpTypeFloat 32
+    %float_0 = OpConstant %float 0
    %FAbsTest = OpTypeStruct
        %void = OpTypeVoid
 %_ptr_Function_FAbsTest = OpTypePointer Function %FAbsTest
-         %10 = OpTypeFunction %void %_ptr_Function_FAbsTest
+         %11 = OpTypeFunction %void %_ptr_Function_FAbsTest
 %_ptr_Function_float = OpTypePointer Function %float
     %Vector2 = OpTypeVector %float 2
 %_ptr_Function_Vector2 = OpTypePointer Function %Vector2
@@ -42,20 +43,19 @@
     %Vector4 = OpTypeVector %float 4
 %_ptr_Function_Vector4 = OpTypePointer Function %Vector4
         %int = OpTypeInt 32 1
-         %20 = OpTypeFunction %void
-    %float_0 = OpConstant %float 0
-%FAbsTest_PreConstructor = OpFunction %void None %10
+         %21 = OpTypeFunction %void
+%FAbsTest_PreConstructor = OpFunction %void None %11
        %self = OpFunctionParameter %_ptr_Function_FAbsTest
          %26 = OpLabel
                OpReturn
                OpFunctionEnd
-%FAbsTest_DefaultConstructor = OpFunction %void None %10
+%FAbsTest_DefaultConstructor = OpFunction %void None %11
      %self_0 = OpFunctionParameter %_ptr_Function_FAbsTest
          %31 = OpLabel
          %32 = OpFunctionCall %void %FAbsTest_PreConstructor %self_0
                OpReturn
                OpFunctionEnd
-       %Main = OpFunction %void None %10
+       %Main = OpFunction %void None %11
      %self_1 = OpFunctionParameter %_ptr_Function_FAbsTest
          %37 = OpLabel
    %floatVal = OpVariable %_ptr_Function_float Function
@@ -83,7 +83,7 @@
                OpStore %vector4Val %59
                OpReturn
                OpFunctionEnd
-%FAbsTest_Main_EntryPoint = OpFunction %void None %20
+%FAbsTest_Main_EntryPoint = OpFunction %void None %21
          %64 = OpLabel
      %self_2 = OpVariable %_ptr_Function_FAbsTest Function
          %66 = OpFunctionCall %void %FAbsTest_DefaultConstructor %self_2

--- a/CSShadersTests/Tests/IntrinsicFunctions/Glsl.std.450 Intrinsics/FClamp_IntrinsicTest.expected.spvtxt
+++ b/CSShadersTests/Tests/IntrinsicFunctions/Glsl.std.450 Intrinsics/FClamp_IntrinsicTest.expected.spvtxt
@@ -30,10 +30,11 @@
                OpName %self_2 "self"
        %uint = OpTypeInt 32 0
       %float = OpTypeFloat 32
+    %float_0 = OpConstant %float 0
  %FClampTest = OpTypeStruct
        %void = OpTypeVoid
 %_ptr_Function_FClampTest = OpTypePointer Function %FClampTest
-         %10 = OpTypeFunction %void %_ptr_Function_FClampTest
+         %11 = OpTypeFunction %void %_ptr_Function_FClampTest
 %_ptr_Function_float = OpTypePointer Function %float
     %Vector2 = OpTypeVector %float 2
 %_ptr_Function_Vector2 = OpTypePointer Function %Vector2
@@ -42,20 +43,19 @@
     %Vector4 = OpTypeVector %float 4
 %_ptr_Function_Vector4 = OpTypePointer Function %Vector4
         %int = OpTypeInt 32 1
-         %20 = OpTypeFunction %void
-    %float_0 = OpConstant %float 0
-%FClampTest_PreConstructor = OpFunction %void None %10
+         %21 = OpTypeFunction %void
+%FClampTest_PreConstructor = OpFunction %void None %11
        %self = OpFunctionParameter %_ptr_Function_FClampTest
          %26 = OpLabel
                OpReturn
                OpFunctionEnd
-%FClampTest_DefaultConstructor = OpFunction %void None %10
+%FClampTest_DefaultConstructor = OpFunction %void None %11
      %self_0 = OpFunctionParameter %_ptr_Function_FClampTest
          %31 = OpLabel
          %32 = OpFunctionCall %void %FClampTest_PreConstructor %self_0
                OpReturn
                OpFunctionEnd
-       %Main = OpFunction %void None %10
+       %Main = OpFunction %void None %11
      %self_1 = OpFunctionParameter %_ptr_Function_FClampTest
          %37 = OpLabel
    %floatVal = OpVariable %_ptr_Function_float Function
@@ -91,7 +91,7 @@
                OpStore %vector4Val %67
                OpReturn
                OpFunctionEnd
-%FClampTest_Main_EntryPoint = OpFunction %void None %20
+%FClampTest_Main_EntryPoint = OpFunction %void None %21
          %72 = OpLabel
      %self_2 = OpVariable %_ptr_Function_FClampTest Function
          %74 = OpFunctionCall %void %FClampTest_DefaultConstructor %self_2

--- a/CSShadersTests/Tests/IntrinsicFunctions/Glsl.std.450 Intrinsics/FMax_IntrinsicTest.expected.spvtxt
+++ b/CSShadersTests/Tests/IntrinsicFunctions/Glsl.std.450 Intrinsics/FMax_IntrinsicTest.expected.spvtxt
@@ -30,10 +30,11 @@
                OpName %self_2 "self"
        %uint = OpTypeInt 32 0
       %float = OpTypeFloat 32
+    %float_0 = OpConstant %float 0
    %FMaxTest = OpTypeStruct
        %void = OpTypeVoid
 %_ptr_Function_FMaxTest = OpTypePointer Function %FMaxTest
-         %10 = OpTypeFunction %void %_ptr_Function_FMaxTest
+         %11 = OpTypeFunction %void %_ptr_Function_FMaxTest
 %_ptr_Function_float = OpTypePointer Function %float
     %Vector2 = OpTypeVector %float 2
 %_ptr_Function_Vector2 = OpTypePointer Function %Vector2
@@ -42,20 +43,19 @@
     %Vector4 = OpTypeVector %float 4
 %_ptr_Function_Vector4 = OpTypePointer Function %Vector4
         %int = OpTypeInt 32 1
-         %20 = OpTypeFunction %void
-    %float_0 = OpConstant %float 0
-%FMaxTest_PreConstructor = OpFunction %void None %10
+         %21 = OpTypeFunction %void
+%FMaxTest_PreConstructor = OpFunction %void None %11
        %self = OpFunctionParameter %_ptr_Function_FMaxTest
          %26 = OpLabel
                OpReturn
                OpFunctionEnd
-%FMaxTest_DefaultConstructor = OpFunction %void None %10
+%FMaxTest_DefaultConstructor = OpFunction %void None %11
      %self_0 = OpFunctionParameter %_ptr_Function_FMaxTest
          %31 = OpLabel
          %32 = OpFunctionCall %void %FMaxTest_PreConstructor %self_0
                OpReturn
                OpFunctionEnd
-       %Main = OpFunction %void None %10
+       %Main = OpFunction %void None %11
      %self_1 = OpFunctionParameter %_ptr_Function_FMaxTest
          %37 = OpLabel
    %floatVal = OpVariable %_ptr_Function_float Function
@@ -87,7 +87,7 @@
                OpStore %vector4Val %63
                OpReturn
                OpFunctionEnd
-%FMaxTest_Main_EntryPoint = OpFunction %void None %20
+%FMaxTest_Main_EntryPoint = OpFunction %void None %21
          %68 = OpLabel
      %self_2 = OpVariable %_ptr_Function_FMaxTest Function
          %70 = OpFunctionCall %void %FMaxTest_DefaultConstructor %self_2

--- a/CSShadersTests/Tests/IntrinsicFunctions/Glsl.std.450 Intrinsics/FMin_IntrinsicTest.expected.spvtxt
+++ b/CSShadersTests/Tests/IntrinsicFunctions/Glsl.std.450 Intrinsics/FMin_IntrinsicTest.expected.spvtxt
@@ -30,10 +30,11 @@
                OpName %self_2 "self"
        %uint = OpTypeInt 32 0
       %float = OpTypeFloat 32
+    %float_0 = OpConstant %float 0
    %FMinTest = OpTypeStruct
        %void = OpTypeVoid
 %_ptr_Function_FMinTest = OpTypePointer Function %FMinTest
-         %10 = OpTypeFunction %void %_ptr_Function_FMinTest
+         %11 = OpTypeFunction %void %_ptr_Function_FMinTest
 %_ptr_Function_float = OpTypePointer Function %float
     %Vector2 = OpTypeVector %float 2
 %_ptr_Function_Vector2 = OpTypePointer Function %Vector2
@@ -42,20 +43,19 @@
     %Vector4 = OpTypeVector %float 4
 %_ptr_Function_Vector4 = OpTypePointer Function %Vector4
         %int = OpTypeInt 32 1
-         %20 = OpTypeFunction %void
-    %float_0 = OpConstant %float 0
-%FMinTest_PreConstructor = OpFunction %void None %10
+         %21 = OpTypeFunction %void
+%FMinTest_PreConstructor = OpFunction %void None %11
        %self = OpFunctionParameter %_ptr_Function_FMinTest
          %26 = OpLabel
                OpReturn
                OpFunctionEnd
-%FMinTest_DefaultConstructor = OpFunction %void None %10
+%FMinTest_DefaultConstructor = OpFunction %void None %11
      %self_0 = OpFunctionParameter %_ptr_Function_FMinTest
          %31 = OpLabel
          %32 = OpFunctionCall %void %FMinTest_PreConstructor %self_0
                OpReturn
                OpFunctionEnd
-       %Main = OpFunction %void None %10
+       %Main = OpFunction %void None %11
      %self_1 = OpFunctionParameter %_ptr_Function_FMinTest
          %37 = OpLabel
    %floatVal = OpVariable %_ptr_Function_float Function
@@ -87,7 +87,7 @@
                OpStore %vector4Val %63
                OpReturn
                OpFunctionEnd
-%FMinTest_Main_EntryPoint = OpFunction %void None %20
+%FMinTest_Main_EntryPoint = OpFunction %void None %21
          %68 = OpLabel
      %self_2 = OpVariable %_ptr_Function_FMinTest Function
          %70 = OpFunctionCall %void %FMinTest_DefaultConstructor %self_2

--- a/CSShadersTests/Tests/IntrinsicFunctions/Glsl.std.450 Intrinsics/FMix_IntrinsicTest.expected.spvtxt
+++ b/CSShadersTests/Tests/IntrinsicFunctions/Glsl.std.450 Intrinsics/FMix_IntrinsicTest.expected.spvtxt
@@ -30,10 +30,11 @@
                OpName %self_2 "self"
        %uint = OpTypeInt 32 0
       %float = OpTypeFloat 32
+    %float_0 = OpConstant %float 0
    %FMixTest = OpTypeStruct
        %void = OpTypeVoid
 %_ptr_Function_FMixTest = OpTypePointer Function %FMixTest
-         %10 = OpTypeFunction %void %_ptr_Function_FMixTest
+         %11 = OpTypeFunction %void %_ptr_Function_FMixTest
 %_ptr_Function_float = OpTypePointer Function %float
     %Vector2 = OpTypeVector %float 2
 %_ptr_Function_Vector2 = OpTypePointer Function %Vector2
@@ -42,20 +43,19 @@
     %Vector4 = OpTypeVector %float 4
 %_ptr_Function_Vector4 = OpTypePointer Function %Vector4
         %int = OpTypeInt 32 1
-         %20 = OpTypeFunction %void
-    %float_0 = OpConstant %float 0
-%FMixTest_PreConstructor = OpFunction %void None %10
+         %21 = OpTypeFunction %void
+%FMixTest_PreConstructor = OpFunction %void None %11
        %self = OpFunctionParameter %_ptr_Function_FMixTest
          %26 = OpLabel
                OpReturn
                OpFunctionEnd
-%FMixTest_DefaultConstructor = OpFunction %void None %10
+%FMixTest_DefaultConstructor = OpFunction %void None %11
      %self_0 = OpFunctionParameter %_ptr_Function_FMixTest
          %31 = OpLabel
          %32 = OpFunctionCall %void %FMixTest_PreConstructor %self_0
                OpReturn
                OpFunctionEnd
-       %Main = OpFunction %void None %10
+       %Main = OpFunction %void None %11
      %self_1 = OpFunctionParameter %_ptr_Function_FMixTest
          %37 = OpLabel
    %floatVal = OpVariable %_ptr_Function_float Function
@@ -91,7 +91,7 @@
                OpStore %vector4Val %67
                OpReturn
                OpFunctionEnd
-%FMixTest_Main_EntryPoint = OpFunction %void None %20
+%FMixTest_Main_EntryPoint = OpFunction %void None %21
          %72 = OpLabel
      %self_2 = OpVariable %_ptr_Function_FMixTest Function
          %74 = OpFunctionCall %void %FMixTest_DefaultConstructor %self_2

--- a/CSShadersTests/Tests/IntrinsicFunctions/Glsl.std.450 Intrinsics/FSign_IntrinsicTest.expected.spvtxt
+++ b/CSShadersTests/Tests/IntrinsicFunctions/Glsl.std.450 Intrinsics/FSign_IntrinsicTest.expected.spvtxt
@@ -30,10 +30,11 @@
                OpName %self_2 "self"
        %uint = OpTypeInt 32 0
       %float = OpTypeFloat 32
+    %float_0 = OpConstant %float 0
   %FSignTest = OpTypeStruct
        %void = OpTypeVoid
 %_ptr_Function_FSignTest = OpTypePointer Function %FSignTest
-         %10 = OpTypeFunction %void %_ptr_Function_FSignTest
+         %11 = OpTypeFunction %void %_ptr_Function_FSignTest
 %_ptr_Function_float = OpTypePointer Function %float
     %Vector2 = OpTypeVector %float 2
 %_ptr_Function_Vector2 = OpTypePointer Function %Vector2
@@ -42,20 +43,19 @@
     %Vector4 = OpTypeVector %float 4
 %_ptr_Function_Vector4 = OpTypePointer Function %Vector4
         %int = OpTypeInt 32 1
-         %20 = OpTypeFunction %void
-    %float_0 = OpConstant %float 0
-%FSignTest_PreConstructor = OpFunction %void None %10
+         %21 = OpTypeFunction %void
+%FSignTest_PreConstructor = OpFunction %void None %11
        %self = OpFunctionParameter %_ptr_Function_FSignTest
          %26 = OpLabel
                OpReturn
                OpFunctionEnd
-%FSignTest_DefaultConstructor = OpFunction %void None %10
+%FSignTest_DefaultConstructor = OpFunction %void None %11
      %self_0 = OpFunctionParameter %_ptr_Function_FSignTest
          %31 = OpLabel
          %32 = OpFunctionCall %void %FSignTest_PreConstructor %self_0
                OpReturn
                OpFunctionEnd
-       %Main = OpFunction %void None %10
+       %Main = OpFunction %void None %11
      %self_1 = OpFunctionParameter %_ptr_Function_FSignTest
          %37 = OpLabel
    %floatVal = OpVariable %_ptr_Function_float Function
@@ -83,7 +83,7 @@
                OpStore %vector4Val %59
                OpReturn
                OpFunctionEnd
-%FSignTest_Main_EntryPoint = OpFunction %void None %20
+%FSignTest_Main_EntryPoint = OpFunction %void None %21
          %64 = OpLabel
      %self_2 = OpVariable %_ptr_Function_FSignTest Function
          %66 = OpFunctionCall %void %FSignTest_DefaultConstructor %self_2

--- a/CSShadersTests/Tests/IntrinsicFunctions/Glsl.std.450 Intrinsics/FaceForward_IntrinsicTest.expected.spvtxt
+++ b/CSShadersTests/Tests/IntrinsicFunctions/Glsl.std.450 Intrinsics/FaceForward_IntrinsicTest.expected.spvtxt
@@ -29,10 +29,11 @@
                OpName %self_2 "self"
        %uint = OpTypeInt 32 0
       %float = OpTypeFloat 32
+    %float_0 = OpConstant %float 0
 %FaceForwardTest = OpTypeStruct
        %void = OpTypeVoid
 %_ptr_Function_FaceForwardTest = OpTypePointer Function %FaceForwardTest
-         %10 = OpTypeFunction %void %_ptr_Function_FaceForwardTest
+         %11 = OpTypeFunction %void %_ptr_Function_FaceForwardTest
     %Vector2 = OpTypeVector %float 2
 %_ptr_Function_Vector2 = OpTypePointer Function %Vector2
     %Vector3 = OpTypeVector %float 3
@@ -40,20 +41,19 @@
     %Vector4 = OpTypeVector %float 4
 %_ptr_Function_Vector4 = OpTypePointer Function %Vector4
         %int = OpTypeInt 32 1
-         %20 = OpTypeFunction %void
-    %float_0 = OpConstant %float 0
-%FaceForwardTest_PreConstructor = OpFunction %void None %10
+         %21 = OpTypeFunction %void
+%FaceForwardTest_PreConstructor = OpFunction %void None %11
        %self = OpFunctionParameter %_ptr_Function_FaceForwardTest
          %26 = OpLabel
                OpReturn
                OpFunctionEnd
-%FaceForwardTest_DefaultConstructor = OpFunction %void None %10
+%FaceForwardTest_DefaultConstructor = OpFunction %void None %11
      %self_0 = OpFunctionParameter %_ptr_Function_FaceForwardTest
          %31 = OpLabel
          %32 = OpFunctionCall %void %FaceForwardTest_PreConstructor %self_0
                OpReturn
                OpFunctionEnd
-       %Main = OpFunction %void None %10
+       %Main = OpFunction %void None %11
      %self_1 = OpFunctionParameter %_ptr_Function_FaceForwardTest
          %37 = OpLabel
  %vector2Val = OpVariable %_ptr_Function_Vector2 Function
@@ -82,7 +82,7 @@
                OpStore %vector4Val %60
                OpReturn
                OpFunctionEnd
-%FaceForwardTest_Main_EntryPoint = OpFunction %void None %20
+%FaceForwardTest_Main_EntryPoint = OpFunction %void None %21
          %65 = OpLabel
      %self_2 = OpVariable %_ptr_Function_FaceForwardTest Function
          %67 = OpFunctionCall %void %FaceForwardTest_DefaultConstructor %self_2

--- a/CSShadersTests/Tests/IntrinsicFunctions/Glsl.std.450 Intrinsics/Floor_IntrinsicTest.expected.spvtxt
+++ b/CSShadersTests/Tests/IntrinsicFunctions/Glsl.std.450 Intrinsics/Floor_IntrinsicTest.expected.spvtxt
@@ -30,10 +30,11 @@
                OpName %self_2 "self"
        %uint = OpTypeInt 32 0
       %float = OpTypeFloat 32
+    %float_0 = OpConstant %float 0
   %FloorTest = OpTypeStruct
        %void = OpTypeVoid
 %_ptr_Function_FloorTest = OpTypePointer Function %FloorTest
-         %10 = OpTypeFunction %void %_ptr_Function_FloorTest
+         %11 = OpTypeFunction %void %_ptr_Function_FloorTest
 %_ptr_Function_float = OpTypePointer Function %float
     %Vector2 = OpTypeVector %float 2
 %_ptr_Function_Vector2 = OpTypePointer Function %Vector2
@@ -42,20 +43,19 @@
     %Vector4 = OpTypeVector %float 4
 %_ptr_Function_Vector4 = OpTypePointer Function %Vector4
         %int = OpTypeInt 32 1
-         %20 = OpTypeFunction %void
-    %float_0 = OpConstant %float 0
-%FloorTest_PreConstructor = OpFunction %void None %10
+         %21 = OpTypeFunction %void
+%FloorTest_PreConstructor = OpFunction %void None %11
        %self = OpFunctionParameter %_ptr_Function_FloorTest
          %26 = OpLabel
                OpReturn
                OpFunctionEnd
-%FloorTest_DefaultConstructor = OpFunction %void None %10
+%FloorTest_DefaultConstructor = OpFunction %void None %11
      %self_0 = OpFunctionParameter %_ptr_Function_FloorTest
          %31 = OpLabel
          %32 = OpFunctionCall %void %FloorTest_PreConstructor %self_0
                OpReturn
                OpFunctionEnd
-       %Main = OpFunction %void None %10
+       %Main = OpFunction %void None %11
      %self_1 = OpFunctionParameter %_ptr_Function_FloorTest
          %37 = OpLabel
    %floatVal = OpVariable %_ptr_Function_float Function
@@ -83,7 +83,7 @@
                OpStore %vector4Val %59
                OpReturn
                OpFunctionEnd
-%FloorTest_Main_EntryPoint = OpFunction %void None %20
+%FloorTest_Main_EntryPoint = OpFunction %void None %21
          %64 = OpLabel
      %self_2 = OpVariable %_ptr_Function_FloorTest Function
          %66 = OpFunctionCall %void %FloorTest_DefaultConstructor %self_2

--- a/CSShadersTests/Tests/IntrinsicFunctions/Glsl.std.450 Intrinsics/Fma_IntrinsicTest.expected.spvtxt
+++ b/CSShadersTests/Tests/IntrinsicFunctions/Glsl.std.450 Intrinsics/Fma_IntrinsicTest.expected.spvtxt
@@ -30,10 +30,11 @@
                OpName %self_2 "self"
        %uint = OpTypeInt 32 0
       %float = OpTypeFloat 32
+    %float_0 = OpConstant %float 0
     %FmaTest = OpTypeStruct
        %void = OpTypeVoid
 %_ptr_Function_FmaTest = OpTypePointer Function %FmaTest
-         %10 = OpTypeFunction %void %_ptr_Function_FmaTest
+         %11 = OpTypeFunction %void %_ptr_Function_FmaTest
 %_ptr_Function_float = OpTypePointer Function %float
     %Vector2 = OpTypeVector %float 2
 %_ptr_Function_Vector2 = OpTypePointer Function %Vector2
@@ -42,20 +43,19 @@
     %Vector4 = OpTypeVector %float 4
 %_ptr_Function_Vector4 = OpTypePointer Function %Vector4
         %int = OpTypeInt 32 1
-         %20 = OpTypeFunction %void
-    %float_0 = OpConstant %float 0
-%FmaTest_PreConstructor = OpFunction %void None %10
+         %21 = OpTypeFunction %void
+%FmaTest_PreConstructor = OpFunction %void None %11
        %self = OpFunctionParameter %_ptr_Function_FmaTest
          %26 = OpLabel
                OpReturn
                OpFunctionEnd
-%FmaTest_DefaultConstructor = OpFunction %void None %10
+%FmaTest_DefaultConstructor = OpFunction %void None %11
      %self_0 = OpFunctionParameter %_ptr_Function_FmaTest
          %31 = OpLabel
          %32 = OpFunctionCall %void %FmaTest_PreConstructor %self_0
                OpReturn
                OpFunctionEnd
-       %Main = OpFunction %void None %10
+       %Main = OpFunction %void None %11
      %self_1 = OpFunctionParameter %_ptr_Function_FmaTest
          %37 = OpLabel
    %floatVal = OpVariable %_ptr_Function_float Function
@@ -91,7 +91,7 @@
                OpStore %vector4Val %67
                OpReturn
                OpFunctionEnd
-%FmaTest_Main_EntryPoint = OpFunction %void None %20
+%FmaTest_Main_EntryPoint = OpFunction %void None %21
          %72 = OpLabel
      %self_2 = OpVariable %_ptr_Function_FmaTest Function
          %74 = OpFunctionCall %void %FmaTest_DefaultConstructor %self_2

--- a/CSShadersTests/Tests/IntrinsicFunctions/Glsl.std.450 Intrinsics/Fract_IntrinsicTest.expected.spvtxt
+++ b/CSShadersTests/Tests/IntrinsicFunctions/Glsl.std.450 Intrinsics/Fract_IntrinsicTest.expected.spvtxt
@@ -30,10 +30,11 @@
                OpName %self_2 "self"
        %uint = OpTypeInt 32 0
       %float = OpTypeFloat 32
+    %float_0 = OpConstant %float 0
   %FractTest = OpTypeStruct
        %void = OpTypeVoid
 %_ptr_Function_FractTest = OpTypePointer Function %FractTest
-         %10 = OpTypeFunction %void %_ptr_Function_FractTest
+         %11 = OpTypeFunction %void %_ptr_Function_FractTest
 %_ptr_Function_float = OpTypePointer Function %float
     %Vector2 = OpTypeVector %float 2
 %_ptr_Function_Vector2 = OpTypePointer Function %Vector2
@@ -42,20 +43,19 @@
     %Vector4 = OpTypeVector %float 4
 %_ptr_Function_Vector4 = OpTypePointer Function %Vector4
         %int = OpTypeInt 32 1
-         %20 = OpTypeFunction %void
-    %float_0 = OpConstant %float 0
-%FractTest_PreConstructor = OpFunction %void None %10
+         %21 = OpTypeFunction %void
+%FractTest_PreConstructor = OpFunction %void None %11
        %self = OpFunctionParameter %_ptr_Function_FractTest
          %26 = OpLabel
                OpReturn
                OpFunctionEnd
-%FractTest_DefaultConstructor = OpFunction %void None %10
+%FractTest_DefaultConstructor = OpFunction %void None %11
      %self_0 = OpFunctionParameter %_ptr_Function_FractTest
          %31 = OpLabel
          %32 = OpFunctionCall %void %FractTest_PreConstructor %self_0
                OpReturn
                OpFunctionEnd
-       %Main = OpFunction %void None %10
+       %Main = OpFunction %void None %11
      %self_1 = OpFunctionParameter %_ptr_Function_FractTest
          %37 = OpLabel
    %floatVal = OpVariable %_ptr_Function_float Function
@@ -83,7 +83,7 @@
                OpStore %vector4Val %59
                OpReturn
                OpFunctionEnd
-%FractTest_Main_EntryPoint = OpFunction %void None %20
+%FractTest_Main_EntryPoint = OpFunction %void None %21
          %64 = OpLabel
      %self_2 = OpVariable %_ptr_Function_FractTest Function
          %66 = OpFunctionCall %void %FractTest_DefaultConstructor %self_2

--- a/CSShadersTests/Tests/IntrinsicFunctions/Glsl.std.450 Intrinsics/InverseSqrt_IntrinsicTest.expected.spvtxt
+++ b/CSShadersTests/Tests/IntrinsicFunctions/Glsl.std.450 Intrinsics/InverseSqrt_IntrinsicTest.expected.spvtxt
@@ -30,10 +30,11 @@
                OpName %self_2 "self"
        %uint = OpTypeInt 32 0
       %float = OpTypeFloat 32
+    %float_0 = OpConstant %float 0
 %InverseSqrtTest = OpTypeStruct
        %void = OpTypeVoid
 %_ptr_Function_InverseSqrtTest = OpTypePointer Function %InverseSqrtTest
-         %10 = OpTypeFunction %void %_ptr_Function_InverseSqrtTest
+         %11 = OpTypeFunction %void %_ptr_Function_InverseSqrtTest
 %_ptr_Function_float = OpTypePointer Function %float
     %Vector2 = OpTypeVector %float 2
 %_ptr_Function_Vector2 = OpTypePointer Function %Vector2
@@ -42,20 +43,19 @@
     %Vector4 = OpTypeVector %float 4
 %_ptr_Function_Vector4 = OpTypePointer Function %Vector4
         %int = OpTypeInt 32 1
-         %20 = OpTypeFunction %void
-    %float_0 = OpConstant %float 0
-%InverseSqrtTest_PreConstructor = OpFunction %void None %10
+         %21 = OpTypeFunction %void
+%InverseSqrtTest_PreConstructor = OpFunction %void None %11
        %self = OpFunctionParameter %_ptr_Function_InverseSqrtTest
          %26 = OpLabel
                OpReturn
                OpFunctionEnd
-%InverseSqrtTest_DefaultConstructor = OpFunction %void None %10
+%InverseSqrtTest_DefaultConstructor = OpFunction %void None %11
      %self_0 = OpFunctionParameter %_ptr_Function_InverseSqrtTest
          %31 = OpLabel
          %32 = OpFunctionCall %void %InverseSqrtTest_PreConstructor %self_0
                OpReturn
                OpFunctionEnd
-       %Main = OpFunction %void None %10
+       %Main = OpFunction %void None %11
      %self_1 = OpFunctionParameter %_ptr_Function_InverseSqrtTest
          %37 = OpLabel
    %floatVal = OpVariable %_ptr_Function_float Function
@@ -83,7 +83,7 @@
                OpStore %vector4Val %59
                OpReturn
                OpFunctionEnd
-%InverseSqrtTest_Main_EntryPoint = OpFunction %void None %20
+%InverseSqrtTest_Main_EntryPoint = OpFunction %void None %21
          %64 = OpLabel
      %self_2 = OpVariable %_ptr_Function_InverseSqrtTest Function
          %66 = OpFunctionCall %void %InverseSqrtTest_DefaultConstructor %self_2

--- a/CSShadersTests/Tests/IntrinsicFunctions/Glsl.std.450 Intrinsics/Length_IntrinsicTest.expected.spvtxt
+++ b/CSShadersTests/Tests/IntrinsicFunctions/Glsl.std.450 Intrinsics/Length_IntrinsicTest.expected.spvtxt
@@ -30,10 +30,11 @@
                OpName %self_2 "self"
        %uint = OpTypeInt 32 0
       %float = OpTypeFloat 32
+    %float_0 = OpConstant %float 0
  %LengthTest = OpTypeStruct
        %void = OpTypeVoid
 %_ptr_Function_LengthTest = OpTypePointer Function %LengthTest
-         %10 = OpTypeFunction %void %_ptr_Function_LengthTest
+         %11 = OpTypeFunction %void %_ptr_Function_LengthTest
 %_ptr_Function_float = OpTypePointer Function %float
     %Vector2 = OpTypeVector %float 2
 %_ptr_Function_Vector2 = OpTypePointer Function %Vector2
@@ -42,20 +43,19 @@
     %Vector4 = OpTypeVector %float 4
 %_ptr_Function_Vector4 = OpTypePointer Function %Vector4
         %int = OpTypeInt 32 1
-         %20 = OpTypeFunction %void
-    %float_0 = OpConstant %float 0
-%LengthTest_PreConstructor = OpFunction %void None %10
+         %21 = OpTypeFunction %void
+%LengthTest_PreConstructor = OpFunction %void None %11
        %self = OpFunctionParameter %_ptr_Function_LengthTest
          %26 = OpLabel
                OpReturn
                OpFunctionEnd
-%LengthTest_DefaultConstructor = OpFunction %void None %10
+%LengthTest_DefaultConstructor = OpFunction %void None %11
      %self_0 = OpFunctionParameter %_ptr_Function_LengthTest
          %31 = OpLabel
          %32 = OpFunctionCall %void %LengthTest_PreConstructor %self_0
                OpReturn
                OpFunctionEnd
-       %Main = OpFunction %void None %10
+       %Main = OpFunction %void None %11
      %self_1 = OpFunctionParameter %_ptr_Function_LengthTest
          %37 = OpLabel
    %floatVal = OpVariable %_ptr_Function_float Function
@@ -80,7 +80,7 @@
                OpStore %floatVal %56
                OpReturn
                OpFunctionEnd
-%LengthTest_Main_EntryPoint = OpFunction %void None %20
+%LengthTest_Main_EntryPoint = OpFunction %void None %21
          %61 = OpLabel
      %self_2 = OpVariable %_ptr_Function_LengthTest Function
          %63 = OpFunctionCall %void %LengthTest_DefaultConstructor %self_2

--- a/CSShadersTests/Tests/IntrinsicFunctions/Glsl.std.450 Intrinsics/Log2_IntrinsicTest.expected.spvtxt
+++ b/CSShadersTests/Tests/IntrinsicFunctions/Glsl.std.450 Intrinsics/Log2_IntrinsicTest.expected.spvtxt
@@ -30,10 +30,11 @@
                OpName %self_2 "self"
        %uint = OpTypeInt 32 0
       %float = OpTypeFloat 32
+    %float_0 = OpConstant %float 0
    %Log2Test = OpTypeStruct
        %void = OpTypeVoid
 %_ptr_Function_Log2Test = OpTypePointer Function %Log2Test
-         %10 = OpTypeFunction %void %_ptr_Function_Log2Test
+         %11 = OpTypeFunction %void %_ptr_Function_Log2Test
 %_ptr_Function_float = OpTypePointer Function %float
     %Vector2 = OpTypeVector %float 2
 %_ptr_Function_Vector2 = OpTypePointer Function %Vector2
@@ -42,20 +43,19 @@
     %Vector4 = OpTypeVector %float 4
 %_ptr_Function_Vector4 = OpTypePointer Function %Vector4
         %int = OpTypeInt 32 1
-         %20 = OpTypeFunction %void
-    %float_0 = OpConstant %float 0
-%Log2Test_PreConstructor = OpFunction %void None %10
+         %21 = OpTypeFunction %void
+%Log2Test_PreConstructor = OpFunction %void None %11
        %self = OpFunctionParameter %_ptr_Function_Log2Test
          %26 = OpLabel
                OpReturn
                OpFunctionEnd
-%Log2Test_DefaultConstructor = OpFunction %void None %10
+%Log2Test_DefaultConstructor = OpFunction %void None %11
      %self_0 = OpFunctionParameter %_ptr_Function_Log2Test
          %31 = OpLabel
          %32 = OpFunctionCall %void %Log2Test_PreConstructor %self_0
                OpReturn
                OpFunctionEnd
-       %Main = OpFunction %void None %10
+       %Main = OpFunction %void None %11
      %self_1 = OpFunctionParameter %_ptr_Function_Log2Test
          %37 = OpLabel
    %floatVal = OpVariable %_ptr_Function_float Function
@@ -83,7 +83,7 @@
                OpStore %vector4Val %59
                OpReturn
                OpFunctionEnd
-%Log2Test_Main_EntryPoint = OpFunction %void None %20
+%Log2Test_Main_EntryPoint = OpFunction %void None %21
          %64 = OpLabel
      %self_2 = OpVariable %_ptr_Function_Log2Test Function
          %66 = OpFunctionCall %void %Log2Test_DefaultConstructor %self_2

--- a/CSShadersTests/Tests/IntrinsicFunctions/Glsl.std.450 Intrinsics/Log_IntrinsicTest.expected.spvtxt
+++ b/CSShadersTests/Tests/IntrinsicFunctions/Glsl.std.450 Intrinsics/Log_IntrinsicTest.expected.spvtxt
@@ -30,10 +30,11 @@
                OpName %self_2 "self"
        %uint = OpTypeInt 32 0
       %float = OpTypeFloat 32
+    %float_0 = OpConstant %float 0
     %LogTest = OpTypeStruct
        %void = OpTypeVoid
 %_ptr_Function_LogTest = OpTypePointer Function %LogTest
-         %10 = OpTypeFunction %void %_ptr_Function_LogTest
+         %11 = OpTypeFunction %void %_ptr_Function_LogTest
 %_ptr_Function_float = OpTypePointer Function %float
     %Vector2 = OpTypeVector %float 2
 %_ptr_Function_Vector2 = OpTypePointer Function %Vector2
@@ -42,20 +43,19 @@
     %Vector4 = OpTypeVector %float 4
 %_ptr_Function_Vector4 = OpTypePointer Function %Vector4
         %int = OpTypeInt 32 1
-         %20 = OpTypeFunction %void
-    %float_0 = OpConstant %float 0
-%LogTest_PreConstructor = OpFunction %void None %10
+         %21 = OpTypeFunction %void
+%LogTest_PreConstructor = OpFunction %void None %11
        %self = OpFunctionParameter %_ptr_Function_LogTest
          %26 = OpLabel
                OpReturn
                OpFunctionEnd
-%LogTest_DefaultConstructor = OpFunction %void None %10
+%LogTest_DefaultConstructor = OpFunction %void None %11
      %self_0 = OpFunctionParameter %_ptr_Function_LogTest
          %31 = OpLabel
          %32 = OpFunctionCall %void %LogTest_PreConstructor %self_0
                OpReturn
                OpFunctionEnd
-       %Main = OpFunction %void None %10
+       %Main = OpFunction %void None %11
      %self_1 = OpFunctionParameter %_ptr_Function_LogTest
          %37 = OpLabel
    %floatVal = OpVariable %_ptr_Function_float Function
@@ -83,7 +83,7 @@
                OpStore %vector4Val %59
                OpReturn
                OpFunctionEnd
-%LogTest_Main_EntryPoint = OpFunction %void None %20
+%LogTest_Main_EntryPoint = OpFunction %void None %21
          %64 = OpLabel
      %self_2 = OpVariable %_ptr_Function_LogTest Function
          %66 = OpFunctionCall %void %LogTest_DefaultConstructor %self_2

--- a/CSShadersTests/Tests/IntrinsicFunctions/Glsl.std.450 Intrinsics/MatrixInverse_IntrinsicTest.expected.spvtxt
+++ b/CSShadersTests/Tests/IntrinsicFunctions/Glsl.std.450 Intrinsics/MatrixInverse_IntrinsicTest.expected.spvtxt
@@ -36,31 +36,31 @@
                OpName %self_4 "self"
        %uint = OpTypeInt 32 0
       %float = OpTypeFloat 32
+    %float_0 = OpConstant %float 0
 %MatrixInverseTest = OpTypeStruct
        %void = OpTypeVoid
 %_ptr_Function_MatrixInverseTest = OpTypePointer Function %MatrixInverseTest
-         %10 = OpTypeFunction %void %_ptr_Function_MatrixInverseTest
+         %11 = OpTypeFunction %void %_ptr_Function_MatrixInverseTest
     %Vector2 = OpTypeVector %float 2
    %Float2x2 = OpTypeMatrix %Vector2 2
 %_ptr_Function_Float2x2 = OpTypePointer Function %Float2x2
-         %16 = OpTypeFunction %void %_ptr_Function_Float2x2 %float
+         %17 = OpTypeFunction %void %_ptr_Function_Float2x2 %float
 %_ptr_Function_Vector2 = OpTypePointer Function %Vector2
-         %18 = OpTypeFunction %void %_ptr_Function_Float2x2 %float %float %float %float
+         %19 = OpTypeFunction %void %_ptr_Function_Float2x2 %float %float %float %float
         %int = OpTypeInt 32 1
-         %22 = OpTypeFunction %void
-    %float_0 = OpConstant %float 0
-%MatrixInverseTest_PreConstructor = OpFunction %void None %10
+         %23 = OpTypeFunction %void
+%MatrixInverseTest_PreConstructor = OpFunction %void None %11
        %self = OpFunctionParameter %_ptr_Function_MatrixInverseTest
          %28 = OpLabel
                OpReturn
                OpFunctionEnd
-%MatrixInverseTest_DefaultConstructor = OpFunction %void None %10
+%MatrixInverseTest_DefaultConstructor = OpFunction %void None %11
      %self_0 = OpFunctionParameter %_ptr_Function_MatrixInverseTest
          %33 = OpLabel
          %34 = OpFunctionCall %void %MatrixInverseTest_PreConstructor %self_0
                OpReturn
                OpFunctionEnd
-       %Main = OpFunction %void None %10
+       %Main = OpFunction %void None %11
      %self_1 = OpFunctionParameter %_ptr_Function_MatrixInverseTest
          %39 = OpLabel
 %float2x2Val = OpVariable %_ptr_Function_Float2x2 Function
@@ -72,7 +72,7 @@
                OpStore %float2x2Val %45
                OpReturn
                OpFunctionEnd
-%Float2x2_Constructor = OpFunction %void None %16
+%Float2x2_Constructor = OpFunction %void None %17
      %self_2 = OpFunctionParameter %_ptr_Function_Float2x2
       %value = OpFunctionParameter %float
          %52 = OpLabel
@@ -85,7 +85,7 @@
                OpStore %self_2 %58
                OpReturn
                OpFunctionEnd
-%Float2x2_Constructor_0 = OpFunction %void None %18
+%Float2x2_Constructor_0 = OpFunction %void None %19
      %self_3 = OpFunctionParameter %_ptr_Function_Float2x2
         %m00 = OpFunctionParameter %float
         %m01 = OpFunctionParameter %float
@@ -98,7 +98,7 @@
                OpStore %self_3 %71
                OpReturn
                OpFunctionEnd
-%MatrixInverseTest_Main_EntryPoint = OpFunction %void None %22
+%MatrixInverseTest_Main_EntryPoint = OpFunction %void None %23
          %76 = OpLabel
      %self_4 = OpVariable %_ptr_Function_MatrixInverseTest Function
          %78 = OpFunctionCall %void %MatrixInverseTest_DefaultConstructor %self_4

--- a/CSShadersTests/Tests/IntrinsicFunctions/Glsl.std.450 Intrinsics/Normalize_IntrinsicTest.expected.spvtxt
+++ b/CSShadersTests/Tests/IntrinsicFunctions/Glsl.std.450 Intrinsics/Normalize_IntrinsicTest.expected.spvtxt
@@ -29,10 +29,11 @@
                OpName %self_2 "self"
        %uint = OpTypeInt 32 0
       %float = OpTypeFloat 32
+    %float_0 = OpConstant %float 0
 %NormalizeTest = OpTypeStruct
        %void = OpTypeVoid
 %_ptr_Function_NormalizeTest = OpTypePointer Function %NormalizeTest
-         %10 = OpTypeFunction %void %_ptr_Function_NormalizeTest
+         %11 = OpTypeFunction %void %_ptr_Function_NormalizeTest
     %Vector2 = OpTypeVector %float 2
 %_ptr_Function_Vector2 = OpTypePointer Function %Vector2
     %Vector3 = OpTypeVector %float 3
@@ -40,20 +41,19 @@
     %Vector4 = OpTypeVector %float 4
 %_ptr_Function_Vector4 = OpTypePointer Function %Vector4
         %int = OpTypeInt 32 1
-         %20 = OpTypeFunction %void
-    %float_0 = OpConstant %float 0
-%NormalizeTest_PreConstructor = OpFunction %void None %10
+         %21 = OpTypeFunction %void
+%NormalizeTest_PreConstructor = OpFunction %void None %11
        %self = OpFunctionParameter %_ptr_Function_NormalizeTest
          %26 = OpLabel
                OpReturn
                OpFunctionEnd
-%NormalizeTest_DefaultConstructor = OpFunction %void None %10
+%NormalizeTest_DefaultConstructor = OpFunction %void None %11
      %self_0 = OpFunctionParameter %_ptr_Function_NormalizeTest
          %31 = OpLabel
          %32 = OpFunctionCall %void %NormalizeTest_PreConstructor %self_0
                OpReturn
                OpFunctionEnd
-       %Main = OpFunction %void None %10
+       %Main = OpFunction %void None %11
      %self_1 = OpFunctionParameter %_ptr_Function_NormalizeTest
          %37 = OpLabel
  %vector2Val = OpVariable %_ptr_Function_Vector2 Function
@@ -76,7 +76,7 @@
                OpStore %vector4Val %54
                OpReturn
                OpFunctionEnd
-%NormalizeTest_Main_EntryPoint = OpFunction %void None %20
+%NormalizeTest_Main_EntryPoint = OpFunction %void None %21
          %59 = OpLabel
      %self_2 = OpVariable %_ptr_Function_NormalizeTest Function
          %61 = OpFunctionCall %void %NormalizeTest_DefaultConstructor %self_2

--- a/CSShadersTests/Tests/IntrinsicFunctions/Glsl.std.450 Intrinsics/Pow_IntrinsicTest.expected.spvtxt
+++ b/CSShadersTests/Tests/IntrinsicFunctions/Glsl.std.450 Intrinsics/Pow_IntrinsicTest.expected.spvtxt
@@ -30,10 +30,11 @@
                OpName %self_2 "self"
        %uint = OpTypeInt 32 0
       %float = OpTypeFloat 32
+    %float_0 = OpConstant %float 0
     %PowTest = OpTypeStruct
        %void = OpTypeVoid
 %_ptr_Function_PowTest = OpTypePointer Function %PowTest
-         %10 = OpTypeFunction %void %_ptr_Function_PowTest
+         %11 = OpTypeFunction %void %_ptr_Function_PowTest
 %_ptr_Function_float = OpTypePointer Function %float
     %Vector2 = OpTypeVector %float 2
 %_ptr_Function_Vector2 = OpTypePointer Function %Vector2
@@ -42,20 +43,19 @@
     %Vector4 = OpTypeVector %float 4
 %_ptr_Function_Vector4 = OpTypePointer Function %Vector4
         %int = OpTypeInt 32 1
-         %20 = OpTypeFunction %void
-    %float_0 = OpConstant %float 0
-%PowTest_PreConstructor = OpFunction %void None %10
+         %21 = OpTypeFunction %void
+%PowTest_PreConstructor = OpFunction %void None %11
        %self = OpFunctionParameter %_ptr_Function_PowTest
          %26 = OpLabel
                OpReturn
                OpFunctionEnd
-%PowTest_DefaultConstructor = OpFunction %void None %10
+%PowTest_DefaultConstructor = OpFunction %void None %11
      %self_0 = OpFunctionParameter %_ptr_Function_PowTest
          %31 = OpLabel
          %32 = OpFunctionCall %void %PowTest_PreConstructor %self_0
                OpReturn
                OpFunctionEnd
-       %Main = OpFunction %void None %10
+       %Main = OpFunction %void None %11
      %self_1 = OpFunctionParameter %_ptr_Function_PowTest
          %37 = OpLabel
    %floatVal = OpVariable %_ptr_Function_float Function
@@ -87,7 +87,7 @@
                OpStore %vector4Val %63
                OpReturn
                OpFunctionEnd
-%PowTest_Main_EntryPoint = OpFunction %void None %20
+%PowTest_Main_EntryPoint = OpFunction %void None %21
          %68 = OpLabel
      %self_2 = OpVariable %_ptr_Function_PowTest Function
          %70 = OpFunctionCall %void %PowTest_DefaultConstructor %self_2

--- a/CSShadersTests/Tests/IntrinsicFunctions/Glsl.std.450 Intrinsics/Radians_IntrinsicTest.expected.spvtxt
+++ b/CSShadersTests/Tests/IntrinsicFunctions/Glsl.std.450 Intrinsics/Radians_IntrinsicTest.expected.spvtxt
@@ -30,10 +30,11 @@
                OpName %self_2 "self"
        %uint = OpTypeInt 32 0
       %float = OpTypeFloat 32
+    %float_0 = OpConstant %float 0
 %RadiansTest = OpTypeStruct
        %void = OpTypeVoid
 %_ptr_Function_RadiansTest = OpTypePointer Function %RadiansTest
-         %10 = OpTypeFunction %void %_ptr_Function_RadiansTest
+         %11 = OpTypeFunction %void %_ptr_Function_RadiansTest
 %_ptr_Function_float = OpTypePointer Function %float
     %Vector2 = OpTypeVector %float 2
 %_ptr_Function_Vector2 = OpTypePointer Function %Vector2
@@ -42,20 +43,19 @@
     %Vector4 = OpTypeVector %float 4
 %_ptr_Function_Vector4 = OpTypePointer Function %Vector4
         %int = OpTypeInt 32 1
-         %20 = OpTypeFunction %void
-    %float_0 = OpConstant %float 0
-%RadiansTest_PreConstructor = OpFunction %void None %10
+         %21 = OpTypeFunction %void
+%RadiansTest_PreConstructor = OpFunction %void None %11
        %self = OpFunctionParameter %_ptr_Function_RadiansTest
          %26 = OpLabel
                OpReturn
                OpFunctionEnd
-%RadiansTest_DefaultConstructor = OpFunction %void None %10
+%RadiansTest_DefaultConstructor = OpFunction %void None %11
      %self_0 = OpFunctionParameter %_ptr_Function_RadiansTest
          %31 = OpLabel
          %32 = OpFunctionCall %void %RadiansTest_PreConstructor %self_0
                OpReturn
                OpFunctionEnd
-       %Main = OpFunction %void None %10
+       %Main = OpFunction %void None %11
      %self_1 = OpFunctionParameter %_ptr_Function_RadiansTest
          %37 = OpLabel
    %floatVal = OpVariable %_ptr_Function_float Function
@@ -83,7 +83,7 @@
                OpStore %vector4Val %59
                OpReturn
                OpFunctionEnd
-%RadiansTest_Main_EntryPoint = OpFunction %void None %20
+%RadiansTest_Main_EntryPoint = OpFunction %void None %21
          %64 = OpLabel
      %self_2 = OpVariable %_ptr_Function_RadiansTest Function
          %66 = OpFunctionCall %void %RadiansTest_DefaultConstructor %self_2

--- a/CSShadersTests/Tests/IntrinsicFunctions/Glsl.std.450 Intrinsics/Reflect_IntrinsicTest.expected.spvtxt
+++ b/CSShadersTests/Tests/IntrinsicFunctions/Glsl.std.450 Intrinsics/Reflect_IntrinsicTest.expected.spvtxt
@@ -29,10 +29,11 @@
                OpName %self_2 "self"
        %uint = OpTypeInt 32 0
       %float = OpTypeFloat 32
+    %float_0 = OpConstant %float 0
 %ReflectTest = OpTypeStruct
        %void = OpTypeVoid
 %_ptr_Function_ReflectTest = OpTypePointer Function %ReflectTest
-         %10 = OpTypeFunction %void %_ptr_Function_ReflectTest
+         %11 = OpTypeFunction %void %_ptr_Function_ReflectTest
     %Vector2 = OpTypeVector %float 2
 %_ptr_Function_Vector2 = OpTypePointer Function %Vector2
     %Vector3 = OpTypeVector %float 3
@@ -40,20 +41,19 @@
     %Vector4 = OpTypeVector %float 4
 %_ptr_Function_Vector4 = OpTypePointer Function %Vector4
         %int = OpTypeInt 32 1
-         %20 = OpTypeFunction %void
-    %float_0 = OpConstant %float 0
-%ReflectTest_PreConstructor = OpFunction %void None %10
+         %21 = OpTypeFunction %void
+%ReflectTest_PreConstructor = OpFunction %void None %11
        %self = OpFunctionParameter %_ptr_Function_ReflectTest
          %26 = OpLabel
                OpReturn
                OpFunctionEnd
-%ReflectTest_DefaultConstructor = OpFunction %void None %10
+%ReflectTest_DefaultConstructor = OpFunction %void None %11
      %self_0 = OpFunctionParameter %_ptr_Function_ReflectTest
          %31 = OpLabel
          %32 = OpFunctionCall %void %ReflectTest_PreConstructor %self_0
                OpReturn
                OpFunctionEnd
-       %Main = OpFunction %void None %10
+       %Main = OpFunction %void None %11
      %self_1 = OpFunctionParameter %_ptr_Function_ReflectTest
          %37 = OpLabel
  %vector2Val = OpVariable %_ptr_Function_Vector2 Function
@@ -79,7 +79,7 @@
                OpStore %vector4Val %57
                OpReturn
                OpFunctionEnd
-%ReflectTest_Main_EntryPoint = OpFunction %void None %20
+%ReflectTest_Main_EntryPoint = OpFunction %void None %21
          %62 = OpLabel
      %self_2 = OpVariable %_ptr_Function_ReflectTest Function
          %64 = OpFunctionCall %void %ReflectTest_DefaultConstructor %self_2

--- a/CSShadersTests/Tests/IntrinsicFunctions/Glsl.std.450 Intrinsics/Refract_IntrinsicTest.expected.spvtxt
+++ b/CSShadersTests/Tests/IntrinsicFunctions/Glsl.std.450 Intrinsics/Refract_IntrinsicTest.expected.spvtxt
@@ -30,10 +30,11 @@
                OpName %self_2 "self"
        %uint = OpTypeInt 32 0
       %float = OpTypeFloat 32
+    %float_0 = OpConstant %float 0
 %RefractTest = OpTypeStruct
        %void = OpTypeVoid
 %_ptr_Function_RefractTest = OpTypePointer Function %RefractTest
-         %10 = OpTypeFunction %void %_ptr_Function_RefractTest
+         %11 = OpTypeFunction %void %_ptr_Function_RefractTest
     %Vector2 = OpTypeVector %float 2
 %_ptr_Function_Vector2 = OpTypePointer Function %Vector2
 %_ptr_Function_float = OpTypePointer Function %float
@@ -42,20 +43,19 @@
     %Vector4 = OpTypeVector %float 4
 %_ptr_Function_Vector4 = OpTypePointer Function %Vector4
         %int = OpTypeInt 32 1
-         %20 = OpTypeFunction %void
-    %float_0 = OpConstant %float 0
-%RefractTest_PreConstructor = OpFunction %void None %10
+         %21 = OpTypeFunction %void
+%RefractTest_PreConstructor = OpFunction %void None %11
        %self = OpFunctionParameter %_ptr_Function_RefractTest
          %26 = OpLabel
                OpReturn
                OpFunctionEnd
-%RefractTest_DefaultConstructor = OpFunction %void None %10
+%RefractTest_DefaultConstructor = OpFunction %void None %11
      %self_0 = OpFunctionParameter %_ptr_Function_RefractTest
          %31 = OpLabel
          %32 = OpFunctionCall %void %RefractTest_PreConstructor %self_0
                OpReturn
                OpFunctionEnd
-       %Main = OpFunction %void None %10
+       %Main = OpFunction %void None %11
      %self_1 = OpFunctionParameter %_ptr_Function_RefractTest
          %37 = OpLabel
  %vector2Val = OpVariable %_ptr_Function_Vector2 Function
@@ -86,7 +86,7 @@
                OpStore %vector4Val %62
                OpReturn
                OpFunctionEnd
-%RefractTest_Main_EntryPoint = OpFunction %void None %20
+%RefractTest_Main_EntryPoint = OpFunction %void None %21
          %67 = OpLabel
      %self_2 = OpVariable %_ptr_Function_RefractTest Function
          %69 = OpFunctionCall %void %RefractTest_DefaultConstructor %self_2

--- a/CSShadersTests/Tests/IntrinsicFunctions/Glsl.std.450 Intrinsics/RoundEven_IntrinsicTest.expected.spvtxt
+++ b/CSShadersTests/Tests/IntrinsicFunctions/Glsl.std.450 Intrinsics/RoundEven_IntrinsicTest.expected.spvtxt
@@ -30,10 +30,11 @@
                OpName %self_2 "self"
        %uint = OpTypeInt 32 0
       %float = OpTypeFloat 32
+    %float_0 = OpConstant %float 0
 %RoundEvenTest = OpTypeStruct
        %void = OpTypeVoid
 %_ptr_Function_RoundEvenTest = OpTypePointer Function %RoundEvenTest
-         %10 = OpTypeFunction %void %_ptr_Function_RoundEvenTest
+         %11 = OpTypeFunction %void %_ptr_Function_RoundEvenTest
 %_ptr_Function_float = OpTypePointer Function %float
     %Vector2 = OpTypeVector %float 2
 %_ptr_Function_Vector2 = OpTypePointer Function %Vector2
@@ -42,20 +43,19 @@
     %Vector4 = OpTypeVector %float 4
 %_ptr_Function_Vector4 = OpTypePointer Function %Vector4
         %int = OpTypeInt 32 1
-         %20 = OpTypeFunction %void
-    %float_0 = OpConstant %float 0
-%RoundEvenTest_PreConstructor = OpFunction %void None %10
+         %21 = OpTypeFunction %void
+%RoundEvenTest_PreConstructor = OpFunction %void None %11
        %self = OpFunctionParameter %_ptr_Function_RoundEvenTest
          %26 = OpLabel
                OpReturn
                OpFunctionEnd
-%RoundEvenTest_DefaultConstructor = OpFunction %void None %10
+%RoundEvenTest_DefaultConstructor = OpFunction %void None %11
      %self_0 = OpFunctionParameter %_ptr_Function_RoundEvenTest
          %31 = OpLabel
          %32 = OpFunctionCall %void %RoundEvenTest_PreConstructor %self_0
                OpReturn
                OpFunctionEnd
-       %Main = OpFunction %void None %10
+       %Main = OpFunction %void None %11
      %self_1 = OpFunctionParameter %_ptr_Function_RoundEvenTest
          %37 = OpLabel
    %floatVal = OpVariable %_ptr_Function_float Function
@@ -83,7 +83,7 @@
                OpStore %vector4Val %59
                OpReturn
                OpFunctionEnd
-%RoundEvenTest_Main_EntryPoint = OpFunction %void None %20
+%RoundEvenTest_Main_EntryPoint = OpFunction %void None %21
          %64 = OpLabel
      %self_2 = OpVariable %_ptr_Function_RoundEvenTest Function
          %66 = OpFunctionCall %void %RoundEvenTest_DefaultConstructor %self_2

--- a/CSShadersTests/Tests/IntrinsicFunctions/Glsl.std.450 Intrinsics/Round_IntrinsicTest.expected.spvtxt
+++ b/CSShadersTests/Tests/IntrinsicFunctions/Glsl.std.450 Intrinsics/Round_IntrinsicTest.expected.spvtxt
@@ -30,10 +30,11 @@
                OpName %self_2 "self"
        %uint = OpTypeInt 32 0
       %float = OpTypeFloat 32
+    %float_0 = OpConstant %float 0
   %RoundTest = OpTypeStruct
        %void = OpTypeVoid
 %_ptr_Function_RoundTest = OpTypePointer Function %RoundTest
-         %10 = OpTypeFunction %void %_ptr_Function_RoundTest
+         %11 = OpTypeFunction %void %_ptr_Function_RoundTest
 %_ptr_Function_float = OpTypePointer Function %float
     %Vector2 = OpTypeVector %float 2
 %_ptr_Function_Vector2 = OpTypePointer Function %Vector2
@@ -42,20 +43,19 @@
     %Vector4 = OpTypeVector %float 4
 %_ptr_Function_Vector4 = OpTypePointer Function %Vector4
         %int = OpTypeInt 32 1
-         %20 = OpTypeFunction %void
-    %float_0 = OpConstant %float 0
-%RoundTest_PreConstructor = OpFunction %void None %10
+         %21 = OpTypeFunction %void
+%RoundTest_PreConstructor = OpFunction %void None %11
        %self = OpFunctionParameter %_ptr_Function_RoundTest
          %26 = OpLabel
                OpReturn
                OpFunctionEnd
-%RoundTest_DefaultConstructor = OpFunction %void None %10
+%RoundTest_DefaultConstructor = OpFunction %void None %11
      %self_0 = OpFunctionParameter %_ptr_Function_RoundTest
          %31 = OpLabel
          %32 = OpFunctionCall %void %RoundTest_PreConstructor %self_0
                OpReturn
                OpFunctionEnd
-       %Main = OpFunction %void None %10
+       %Main = OpFunction %void None %11
      %self_1 = OpFunctionParameter %_ptr_Function_RoundTest
          %37 = OpLabel
    %floatVal = OpVariable %_ptr_Function_float Function
@@ -83,7 +83,7 @@
                OpStore %vector4Val %59
                OpReturn
                OpFunctionEnd
-%RoundTest_Main_EntryPoint = OpFunction %void None %20
+%RoundTest_Main_EntryPoint = OpFunction %void None %21
          %64 = OpLabel
      %self_2 = OpVariable %_ptr_Function_RoundTest Function
          %66 = OpFunctionCall %void %RoundTest_DefaultConstructor %self_2

--- a/CSShadersTests/Tests/IntrinsicFunctions/Glsl.std.450 Intrinsics/SAbs_IntrinsicTest.expected.spvtxt
+++ b/CSShadersTests/Tests/IntrinsicFunctions/Glsl.std.450 Intrinsics/SAbs_IntrinsicTest.expected.spvtxt
@@ -30,10 +30,11 @@
                OpName %self_2 "self"
        %uint = OpTypeInt 32 0
         %int = OpTypeInt 32 1
+      %int_0 = OpConstant %int 0
    %SAbsTest = OpTypeStruct
        %void = OpTypeVoid
 %_ptr_Function_SAbsTest = OpTypePointer Function %SAbsTest
-         %10 = OpTypeFunction %void %_ptr_Function_SAbsTest
+         %11 = OpTypeFunction %void %_ptr_Function_SAbsTest
 %_ptr_Function_int = OpTypePointer Function %int
    %Integer2 = OpTypeVector %int 2
 %_ptr_Function_Integer2 = OpTypePointer Function %Integer2
@@ -41,20 +42,19 @@
 %_ptr_Function_Integer3 = OpTypePointer Function %Integer3
    %Integer4 = OpTypeVector %int 4
 %_ptr_Function_Integer4 = OpTypePointer Function %Integer4
-         %18 = OpTypeFunction %void
-      %int_0 = OpConstant %int 0
-%SAbsTest_PreConstructor = OpFunction %void None %10
+         %19 = OpTypeFunction %void
+%SAbsTest_PreConstructor = OpFunction %void None %11
        %self = OpFunctionParameter %_ptr_Function_SAbsTest
          %24 = OpLabel
                OpReturn
                OpFunctionEnd
-%SAbsTest_DefaultConstructor = OpFunction %void None %10
+%SAbsTest_DefaultConstructor = OpFunction %void None %11
      %self_0 = OpFunctionParameter %_ptr_Function_SAbsTest
          %29 = OpLabel
          %30 = OpFunctionCall %void %SAbsTest_PreConstructor %self_0
                OpReturn
                OpFunctionEnd
-       %Main = OpFunction %void None %10
+       %Main = OpFunction %void None %11
      %self_1 = OpFunctionParameter %_ptr_Function_SAbsTest
          %35 = OpLabel
      %intVal = OpVariable %_ptr_Function_int Function
@@ -82,7 +82,7 @@
                OpStore %integer4Val %57
                OpReturn
                OpFunctionEnd
-%SAbsTest_Main_EntryPoint = OpFunction %void None %18
+%SAbsTest_Main_EntryPoint = OpFunction %void None %19
          %62 = OpLabel
      %self_2 = OpVariable %_ptr_Function_SAbsTest Function
          %64 = OpFunctionCall %void %SAbsTest_DefaultConstructor %self_2

--- a/CSShadersTests/Tests/IntrinsicFunctions/Glsl.std.450 Intrinsics/SClamp_IntrinsicTest.expected.spvtxt
+++ b/CSShadersTests/Tests/IntrinsicFunctions/Glsl.std.450 Intrinsics/SClamp_IntrinsicTest.expected.spvtxt
@@ -30,10 +30,11 @@
                OpName %self_2 "self"
        %uint = OpTypeInt 32 0
         %int = OpTypeInt 32 1
+      %int_0 = OpConstant %int 0
  %SClampTest = OpTypeStruct
        %void = OpTypeVoid
 %_ptr_Function_SClampTest = OpTypePointer Function %SClampTest
-         %10 = OpTypeFunction %void %_ptr_Function_SClampTest
+         %11 = OpTypeFunction %void %_ptr_Function_SClampTest
 %_ptr_Function_int = OpTypePointer Function %int
    %Integer2 = OpTypeVector %int 2
 %_ptr_Function_Integer2 = OpTypePointer Function %Integer2
@@ -41,20 +42,19 @@
 %_ptr_Function_Integer3 = OpTypePointer Function %Integer3
    %Integer4 = OpTypeVector %int 4
 %_ptr_Function_Integer4 = OpTypePointer Function %Integer4
-         %18 = OpTypeFunction %void
-      %int_0 = OpConstant %int 0
-%SClampTest_PreConstructor = OpFunction %void None %10
+         %19 = OpTypeFunction %void
+%SClampTest_PreConstructor = OpFunction %void None %11
        %self = OpFunctionParameter %_ptr_Function_SClampTest
          %24 = OpLabel
                OpReturn
                OpFunctionEnd
-%SClampTest_DefaultConstructor = OpFunction %void None %10
+%SClampTest_DefaultConstructor = OpFunction %void None %11
      %self_0 = OpFunctionParameter %_ptr_Function_SClampTest
          %29 = OpLabel
          %30 = OpFunctionCall %void %SClampTest_PreConstructor %self_0
                OpReturn
                OpFunctionEnd
-       %Main = OpFunction %void None %10
+       %Main = OpFunction %void None %11
      %self_1 = OpFunctionParameter %_ptr_Function_SClampTest
          %35 = OpLabel
      %intVal = OpVariable %_ptr_Function_int Function
@@ -90,7 +90,7 @@
                OpStore %integer4Val %65
                OpReturn
                OpFunctionEnd
-%SClampTest_Main_EntryPoint = OpFunction %void None %18
+%SClampTest_Main_EntryPoint = OpFunction %void None %19
          %70 = OpLabel
      %self_2 = OpVariable %_ptr_Function_SClampTest Function
          %72 = OpFunctionCall %void %SClampTest_DefaultConstructor %self_2

--- a/CSShadersTests/Tests/IntrinsicFunctions/Glsl.std.450 Intrinsics/SMax_IntrinsicTest.expected.spvtxt
+++ b/CSShadersTests/Tests/IntrinsicFunctions/Glsl.std.450 Intrinsics/SMax_IntrinsicTest.expected.spvtxt
@@ -30,10 +30,11 @@
                OpName %self_2 "self"
        %uint = OpTypeInt 32 0
         %int = OpTypeInt 32 1
+      %int_0 = OpConstant %int 0
    %SMaxTest = OpTypeStruct
        %void = OpTypeVoid
 %_ptr_Function_SMaxTest = OpTypePointer Function %SMaxTest
-         %10 = OpTypeFunction %void %_ptr_Function_SMaxTest
+         %11 = OpTypeFunction %void %_ptr_Function_SMaxTest
 %_ptr_Function_int = OpTypePointer Function %int
    %Integer2 = OpTypeVector %int 2
 %_ptr_Function_Integer2 = OpTypePointer Function %Integer2
@@ -41,20 +42,19 @@
 %_ptr_Function_Integer3 = OpTypePointer Function %Integer3
    %Integer4 = OpTypeVector %int 4
 %_ptr_Function_Integer4 = OpTypePointer Function %Integer4
-         %18 = OpTypeFunction %void
-      %int_0 = OpConstant %int 0
-%SMaxTest_PreConstructor = OpFunction %void None %10
+         %19 = OpTypeFunction %void
+%SMaxTest_PreConstructor = OpFunction %void None %11
        %self = OpFunctionParameter %_ptr_Function_SMaxTest
          %24 = OpLabel
                OpReturn
                OpFunctionEnd
-%SMaxTest_DefaultConstructor = OpFunction %void None %10
+%SMaxTest_DefaultConstructor = OpFunction %void None %11
      %self_0 = OpFunctionParameter %_ptr_Function_SMaxTest
          %29 = OpLabel
          %30 = OpFunctionCall %void %SMaxTest_PreConstructor %self_0
                OpReturn
                OpFunctionEnd
-       %Main = OpFunction %void None %10
+       %Main = OpFunction %void None %11
      %self_1 = OpFunctionParameter %_ptr_Function_SMaxTest
          %35 = OpLabel
      %intVal = OpVariable %_ptr_Function_int Function
@@ -86,7 +86,7 @@
                OpStore %integer4Val %61
                OpReturn
                OpFunctionEnd
-%SMaxTest_Main_EntryPoint = OpFunction %void None %18
+%SMaxTest_Main_EntryPoint = OpFunction %void None %19
          %66 = OpLabel
      %self_2 = OpVariable %_ptr_Function_SMaxTest Function
          %68 = OpFunctionCall %void %SMaxTest_DefaultConstructor %self_2

--- a/CSShadersTests/Tests/IntrinsicFunctions/Glsl.std.450 Intrinsics/SMin_IntrinsicTest.expected.spvtxt
+++ b/CSShadersTests/Tests/IntrinsicFunctions/Glsl.std.450 Intrinsics/SMin_IntrinsicTest.expected.spvtxt
@@ -30,10 +30,11 @@
                OpName %self_2 "self"
        %uint = OpTypeInt 32 0
         %int = OpTypeInt 32 1
+      %int_0 = OpConstant %int 0
    %SMinTest = OpTypeStruct
        %void = OpTypeVoid
 %_ptr_Function_SMinTest = OpTypePointer Function %SMinTest
-         %10 = OpTypeFunction %void %_ptr_Function_SMinTest
+         %11 = OpTypeFunction %void %_ptr_Function_SMinTest
 %_ptr_Function_int = OpTypePointer Function %int
    %Integer2 = OpTypeVector %int 2
 %_ptr_Function_Integer2 = OpTypePointer Function %Integer2
@@ -41,20 +42,19 @@
 %_ptr_Function_Integer3 = OpTypePointer Function %Integer3
    %Integer4 = OpTypeVector %int 4
 %_ptr_Function_Integer4 = OpTypePointer Function %Integer4
-         %18 = OpTypeFunction %void
-      %int_0 = OpConstant %int 0
-%SMinTest_PreConstructor = OpFunction %void None %10
+         %19 = OpTypeFunction %void
+%SMinTest_PreConstructor = OpFunction %void None %11
        %self = OpFunctionParameter %_ptr_Function_SMinTest
          %24 = OpLabel
                OpReturn
                OpFunctionEnd
-%SMinTest_DefaultConstructor = OpFunction %void None %10
+%SMinTest_DefaultConstructor = OpFunction %void None %11
      %self_0 = OpFunctionParameter %_ptr_Function_SMinTest
          %29 = OpLabel
          %30 = OpFunctionCall %void %SMinTest_PreConstructor %self_0
                OpReturn
                OpFunctionEnd
-       %Main = OpFunction %void None %10
+       %Main = OpFunction %void None %11
      %self_1 = OpFunctionParameter %_ptr_Function_SMinTest
          %35 = OpLabel
      %intVal = OpVariable %_ptr_Function_int Function
@@ -86,7 +86,7 @@
                OpStore %integer4Val %61
                OpReturn
                OpFunctionEnd
-%SMinTest_Main_EntryPoint = OpFunction %void None %18
+%SMinTest_Main_EntryPoint = OpFunction %void None %19
          %66 = OpLabel
      %self_2 = OpVariable %_ptr_Function_SMinTest Function
          %68 = OpFunctionCall %void %SMinTest_DefaultConstructor %self_2

--- a/CSShadersTests/Tests/IntrinsicFunctions/Glsl.std.450 Intrinsics/SSign_IntrinsicTest.expected.spvtxt
+++ b/CSShadersTests/Tests/IntrinsicFunctions/Glsl.std.450 Intrinsics/SSign_IntrinsicTest.expected.spvtxt
@@ -30,10 +30,11 @@
                OpName %self_2 "self"
        %uint = OpTypeInt 32 0
         %int = OpTypeInt 32 1
+      %int_0 = OpConstant %int 0
   %SSignTest = OpTypeStruct
        %void = OpTypeVoid
 %_ptr_Function_SSignTest = OpTypePointer Function %SSignTest
-         %10 = OpTypeFunction %void %_ptr_Function_SSignTest
+         %11 = OpTypeFunction %void %_ptr_Function_SSignTest
 %_ptr_Function_int = OpTypePointer Function %int
    %Integer2 = OpTypeVector %int 2
 %_ptr_Function_Integer2 = OpTypePointer Function %Integer2
@@ -41,20 +42,19 @@
 %_ptr_Function_Integer3 = OpTypePointer Function %Integer3
    %Integer4 = OpTypeVector %int 4
 %_ptr_Function_Integer4 = OpTypePointer Function %Integer4
-         %18 = OpTypeFunction %void
-      %int_0 = OpConstant %int 0
-%SSignTest_PreConstructor = OpFunction %void None %10
+         %19 = OpTypeFunction %void
+%SSignTest_PreConstructor = OpFunction %void None %11
        %self = OpFunctionParameter %_ptr_Function_SSignTest
          %24 = OpLabel
                OpReturn
                OpFunctionEnd
-%SSignTest_DefaultConstructor = OpFunction %void None %10
+%SSignTest_DefaultConstructor = OpFunction %void None %11
      %self_0 = OpFunctionParameter %_ptr_Function_SSignTest
          %29 = OpLabel
          %30 = OpFunctionCall %void %SSignTest_PreConstructor %self_0
                OpReturn
                OpFunctionEnd
-       %Main = OpFunction %void None %10
+       %Main = OpFunction %void None %11
      %self_1 = OpFunctionParameter %_ptr_Function_SSignTest
          %35 = OpLabel
      %intVal = OpVariable %_ptr_Function_int Function
@@ -82,7 +82,7 @@
                OpStore %integer4Val %57
                OpReturn
                OpFunctionEnd
-%SSignTest_Main_EntryPoint = OpFunction %void None %18
+%SSignTest_Main_EntryPoint = OpFunction %void None %19
          %62 = OpLabel
      %self_2 = OpVariable %_ptr_Function_SSignTest Function
          %64 = OpFunctionCall %void %SSignTest_DefaultConstructor %self_2

--- a/CSShadersTests/Tests/IntrinsicFunctions/Glsl.std.450 Intrinsics/Sin_IntrinsicTest.expected.spvtxt
+++ b/CSShadersTests/Tests/IntrinsicFunctions/Glsl.std.450 Intrinsics/Sin_IntrinsicTest.expected.spvtxt
@@ -30,10 +30,11 @@
                OpName %self_2 "self"
        %uint = OpTypeInt 32 0
       %float = OpTypeFloat 32
+    %float_0 = OpConstant %float 0
     %SinTest = OpTypeStruct
        %void = OpTypeVoid
 %_ptr_Function_SinTest = OpTypePointer Function %SinTest
-         %10 = OpTypeFunction %void %_ptr_Function_SinTest
+         %11 = OpTypeFunction %void %_ptr_Function_SinTest
 %_ptr_Function_float = OpTypePointer Function %float
     %Vector2 = OpTypeVector %float 2
 %_ptr_Function_Vector2 = OpTypePointer Function %Vector2
@@ -42,20 +43,19 @@
     %Vector4 = OpTypeVector %float 4
 %_ptr_Function_Vector4 = OpTypePointer Function %Vector4
         %int = OpTypeInt 32 1
-         %20 = OpTypeFunction %void
-    %float_0 = OpConstant %float 0
-%SinTest_PreConstructor = OpFunction %void None %10
+         %21 = OpTypeFunction %void
+%SinTest_PreConstructor = OpFunction %void None %11
        %self = OpFunctionParameter %_ptr_Function_SinTest
          %26 = OpLabel
                OpReturn
                OpFunctionEnd
-%SinTest_DefaultConstructor = OpFunction %void None %10
+%SinTest_DefaultConstructor = OpFunction %void None %11
      %self_0 = OpFunctionParameter %_ptr_Function_SinTest
          %31 = OpLabel
          %32 = OpFunctionCall %void %SinTest_PreConstructor %self_0
                OpReturn
                OpFunctionEnd
-       %Main = OpFunction %void None %10
+       %Main = OpFunction %void None %11
      %self_1 = OpFunctionParameter %_ptr_Function_SinTest
          %37 = OpLabel
    %floatVal = OpVariable %_ptr_Function_float Function
@@ -83,7 +83,7 @@
                OpStore %vector4Val %59
                OpReturn
                OpFunctionEnd
-%SinTest_Main_EntryPoint = OpFunction %void None %20
+%SinTest_Main_EntryPoint = OpFunction %void None %21
          %64 = OpLabel
      %self_2 = OpVariable %_ptr_Function_SinTest Function
          %66 = OpFunctionCall %void %SinTest_DefaultConstructor %self_2

--- a/CSShadersTests/Tests/IntrinsicFunctions/Glsl.std.450 Intrinsics/Sinh_IntrinsicTest.expected.spvtxt
+++ b/CSShadersTests/Tests/IntrinsicFunctions/Glsl.std.450 Intrinsics/Sinh_IntrinsicTest.expected.spvtxt
@@ -30,10 +30,11 @@
                OpName %self_2 "self"
        %uint = OpTypeInt 32 0
       %float = OpTypeFloat 32
+    %float_0 = OpConstant %float 0
    %SinhTest = OpTypeStruct
        %void = OpTypeVoid
 %_ptr_Function_SinhTest = OpTypePointer Function %SinhTest
-         %10 = OpTypeFunction %void %_ptr_Function_SinhTest
+         %11 = OpTypeFunction %void %_ptr_Function_SinhTest
 %_ptr_Function_float = OpTypePointer Function %float
     %Vector2 = OpTypeVector %float 2
 %_ptr_Function_Vector2 = OpTypePointer Function %Vector2
@@ -42,20 +43,19 @@
     %Vector4 = OpTypeVector %float 4
 %_ptr_Function_Vector4 = OpTypePointer Function %Vector4
         %int = OpTypeInt 32 1
-         %20 = OpTypeFunction %void
-    %float_0 = OpConstant %float 0
-%SinhTest_PreConstructor = OpFunction %void None %10
+         %21 = OpTypeFunction %void
+%SinhTest_PreConstructor = OpFunction %void None %11
        %self = OpFunctionParameter %_ptr_Function_SinhTest
          %26 = OpLabel
                OpReturn
                OpFunctionEnd
-%SinhTest_DefaultConstructor = OpFunction %void None %10
+%SinhTest_DefaultConstructor = OpFunction %void None %11
      %self_0 = OpFunctionParameter %_ptr_Function_SinhTest
          %31 = OpLabel
          %32 = OpFunctionCall %void %SinhTest_PreConstructor %self_0
                OpReturn
                OpFunctionEnd
-       %Main = OpFunction %void None %10
+       %Main = OpFunction %void None %11
      %self_1 = OpFunctionParameter %_ptr_Function_SinhTest
          %37 = OpLabel
    %floatVal = OpVariable %_ptr_Function_float Function
@@ -83,7 +83,7 @@
                OpStore %vector4Val %59
                OpReturn
                OpFunctionEnd
-%SinhTest_Main_EntryPoint = OpFunction %void None %20
+%SinhTest_Main_EntryPoint = OpFunction %void None %21
          %64 = OpLabel
      %self_2 = OpVariable %_ptr_Function_SinhTest Function
          %66 = OpFunctionCall %void %SinhTest_DefaultConstructor %self_2

--- a/CSShadersTests/Tests/IntrinsicFunctions/Glsl.std.450 Intrinsics/SmoothStep_IntrinsicTest.expected.spvtxt
+++ b/CSShadersTests/Tests/IntrinsicFunctions/Glsl.std.450 Intrinsics/SmoothStep_IntrinsicTest.expected.spvtxt
@@ -30,10 +30,11 @@
                OpName %self_2 "self"
        %uint = OpTypeInt 32 0
       %float = OpTypeFloat 32
+    %float_0 = OpConstant %float 0
 %SmoothStepTest = OpTypeStruct
        %void = OpTypeVoid
 %_ptr_Function_SmoothStepTest = OpTypePointer Function %SmoothStepTest
-         %10 = OpTypeFunction %void %_ptr_Function_SmoothStepTest
+         %11 = OpTypeFunction %void %_ptr_Function_SmoothStepTest
 %_ptr_Function_float = OpTypePointer Function %float
     %Vector2 = OpTypeVector %float 2
 %_ptr_Function_Vector2 = OpTypePointer Function %Vector2
@@ -42,20 +43,19 @@
     %Vector4 = OpTypeVector %float 4
 %_ptr_Function_Vector4 = OpTypePointer Function %Vector4
         %int = OpTypeInt 32 1
-         %20 = OpTypeFunction %void
-    %float_0 = OpConstant %float 0
-%SmoothStepTest_PreConstructor = OpFunction %void None %10
+         %21 = OpTypeFunction %void
+%SmoothStepTest_PreConstructor = OpFunction %void None %11
        %self = OpFunctionParameter %_ptr_Function_SmoothStepTest
          %26 = OpLabel
                OpReturn
                OpFunctionEnd
-%SmoothStepTest_DefaultConstructor = OpFunction %void None %10
+%SmoothStepTest_DefaultConstructor = OpFunction %void None %11
      %self_0 = OpFunctionParameter %_ptr_Function_SmoothStepTest
          %31 = OpLabel
          %32 = OpFunctionCall %void %SmoothStepTest_PreConstructor %self_0
                OpReturn
                OpFunctionEnd
-       %Main = OpFunction %void None %10
+       %Main = OpFunction %void None %11
      %self_1 = OpFunctionParameter %_ptr_Function_SmoothStepTest
          %37 = OpLabel
    %floatVal = OpVariable %_ptr_Function_float Function
@@ -91,7 +91,7 @@
                OpStore %vector4Val %67
                OpReturn
                OpFunctionEnd
-%SmoothStepTest_Main_EntryPoint = OpFunction %void None %20
+%SmoothStepTest_Main_EntryPoint = OpFunction %void None %21
          %72 = OpLabel
      %self_2 = OpVariable %_ptr_Function_SmoothStepTest Function
          %74 = OpFunctionCall %void %SmoothStepTest_DefaultConstructor %self_2

--- a/CSShadersTests/Tests/IntrinsicFunctions/Glsl.std.450 Intrinsics/Sqrt_IntrinsicTest.expected.spvtxt
+++ b/CSShadersTests/Tests/IntrinsicFunctions/Glsl.std.450 Intrinsics/Sqrt_IntrinsicTest.expected.spvtxt
@@ -30,10 +30,11 @@
                OpName %self_2 "self"
        %uint = OpTypeInt 32 0
       %float = OpTypeFloat 32
+    %float_0 = OpConstant %float 0
    %SqrtTest = OpTypeStruct
        %void = OpTypeVoid
 %_ptr_Function_SqrtTest = OpTypePointer Function %SqrtTest
-         %10 = OpTypeFunction %void %_ptr_Function_SqrtTest
+         %11 = OpTypeFunction %void %_ptr_Function_SqrtTest
 %_ptr_Function_float = OpTypePointer Function %float
     %Vector2 = OpTypeVector %float 2
 %_ptr_Function_Vector2 = OpTypePointer Function %Vector2
@@ -42,20 +43,19 @@
     %Vector4 = OpTypeVector %float 4
 %_ptr_Function_Vector4 = OpTypePointer Function %Vector4
         %int = OpTypeInt 32 1
-         %20 = OpTypeFunction %void
-    %float_0 = OpConstant %float 0
-%SqrtTest_PreConstructor = OpFunction %void None %10
+         %21 = OpTypeFunction %void
+%SqrtTest_PreConstructor = OpFunction %void None %11
        %self = OpFunctionParameter %_ptr_Function_SqrtTest
          %26 = OpLabel
                OpReturn
                OpFunctionEnd
-%SqrtTest_DefaultConstructor = OpFunction %void None %10
+%SqrtTest_DefaultConstructor = OpFunction %void None %11
      %self_0 = OpFunctionParameter %_ptr_Function_SqrtTest
          %31 = OpLabel
          %32 = OpFunctionCall %void %SqrtTest_PreConstructor %self_0
                OpReturn
                OpFunctionEnd
-       %Main = OpFunction %void None %10
+       %Main = OpFunction %void None %11
      %self_1 = OpFunctionParameter %_ptr_Function_SqrtTest
          %37 = OpLabel
    %floatVal = OpVariable %_ptr_Function_float Function
@@ -83,7 +83,7 @@
                OpStore %vector4Val %59
                OpReturn
                OpFunctionEnd
-%SqrtTest_Main_EntryPoint = OpFunction %void None %20
+%SqrtTest_Main_EntryPoint = OpFunction %void None %21
          %64 = OpLabel
      %self_2 = OpVariable %_ptr_Function_SqrtTest Function
          %66 = OpFunctionCall %void %SqrtTest_DefaultConstructor %self_2

--- a/CSShadersTests/Tests/IntrinsicFunctions/Glsl.std.450 Intrinsics/Step_IntrinsicTest.expected.spvtxt
+++ b/CSShadersTests/Tests/IntrinsicFunctions/Glsl.std.450 Intrinsics/Step_IntrinsicTest.expected.spvtxt
@@ -30,10 +30,11 @@
                OpName %self_2 "self"
        %uint = OpTypeInt 32 0
       %float = OpTypeFloat 32
+    %float_0 = OpConstant %float 0
    %StepTest = OpTypeStruct
        %void = OpTypeVoid
 %_ptr_Function_StepTest = OpTypePointer Function %StepTest
-         %10 = OpTypeFunction %void %_ptr_Function_StepTest
+         %11 = OpTypeFunction %void %_ptr_Function_StepTest
 %_ptr_Function_float = OpTypePointer Function %float
     %Vector2 = OpTypeVector %float 2
 %_ptr_Function_Vector2 = OpTypePointer Function %Vector2
@@ -42,20 +43,19 @@
     %Vector4 = OpTypeVector %float 4
 %_ptr_Function_Vector4 = OpTypePointer Function %Vector4
         %int = OpTypeInt 32 1
-         %20 = OpTypeFunction %void
-    %float_0 = OpConstant %float 0
-%StepTest_PreConstructor = OpFunction %void None %10
+         %21 = OpTypeFunction %void
+%StepTest_PreConstructor = OpFunction %void None %11
        %self = OpFunctionParameter %_ptr_Function_StepTest
          %26 = OpLabel
                OpReturn
                OpFunctionEnd
-%StepTest_DefaultConstructor = OpFunction %void None %10
+%StepTest_DefaultConstructor = OpFunction %void None %11
      %self_0 = OpFunctionParameter %_ptr_Function_StepTest
          %31 = OpLabel
          %32 = OpFunctionCall %void %StepTest_PreConstructor %self_0
                OpReturn
                OpFunctionEnd
-       %Main = OpFunction %void None %10
+       %Main = OpFunction %void None %11
      %self_1 = OpFunctionParameter %_ptr_Function_StepTest
          %37 = OpLabel
    %floatVal = OpVariable %_ptr_Function_float Function
@@ -87,7 +87,7 @@
                OpStore %vector4Val %63
                OpReturn
                OpFunctionEnd
-%StepTest_Main_EntryPoint = OpFunction %void None %20
+%StepTest_Main_EntryPoint = OpFunction %void None %21
          %68 = OpLabel
      %self_2 = OpVariable %_ptr_Function_StepTest Function
          %70 = OpFunctionCall %void %StepTest_DefaultConstructor %self_2

--- a/CSShadersTests/Tests/IntrinsicFunctions/Glsl.std.450 Intrinsics/Tan_IntrinsicTest.expected.spvtxt
+++ b/CSShadersTests/Tests/IntrinsicFunctions/Glsl.std.450 Intrinsics/Tan_IntrinsicTest.expected.spvtxt
@@ -30,10 +30,11 @@
                OpName %self_2 "self"
        %uint = OpTypeInt 32 0
       %float = OpTypeFloat 32
+    %float_0 = OpConstant %float 0
     %TanTest = OpTypeStruct
        %void = OpTypeVoid
 %_ptr_Function_TanTest = OpTypePointer Function %TanTest
-         %10 = OpTypeFunction %void %_ptr_Function_TanTest
+         %11 = OpTypeFunction %void %_ptr_Function_TanTest
 %_ptr_Function_float = OpTypePointer Function %float
     %Vector2 = OpTypeVector %float 2
 %_ptr_Function_Vector2 = OpTypePointer Function %Vector2
@@ -42,20 +43,19 @@
     %Vector4 = OpTypeVector %float 4
 %_ptr_Function_Vector4 = OpTypePointer Function %Vector4
         %int = OpTypeInt 32 1
-         %20 = OpTypeFunction %void
-    %float_0 = OpConstant %float 0
-%TanTest_PreConstructor = OpFunction %void None %10
+         %21 = OpTypeFunction %void
+%TanTest_PreConstructor = OpFunction %void None %11
        %self = OpFunctionParameter %_ptr_Function_TanTest
          %26 = OpLabel
                OpReturn
                OpFunctionEnd
-%TanTest_DefaultConstructor = OpFunction %void None %10
+%TanTest_DefaultConstructor = OpFunction %void None %11
      %self_0 = OpFunctionParameter %_ptr_Function_TanTest
          %31 = OpLabel
          %32 = OpFunctionCall %void %TanTest_PreConstructor %self_0
                OpReturn
                OpFunctionEnd
-       %Main = OpFunction %void None %10
+       %Main = OpFunction %void None %11
      %self_1 = OpFunctionParameter %_ptr_Function_TanTest
          %37 = OpLabel
    %floatVal = OpVariable %_ptr_Function_float Function
@@ -83,7 +83,7 @@
                OpStore %vector4Val %59
                OpReturn
                OpFunctionEnd
-%TanTest_Main_EntryPoint = OpFunction %void None %20
+%TanTest_Main_EntryPoint = OpFunction %void None %21
          %64 = OpLabel
      %self_2 = OpVariable %_ptr_Function_TanTest Function
          %66 = OpFunctionCall %void %TanTest_DefaultConstructor %self_2

--- a/CSShadersTests/Tests/IntrinsicFunctions/Glsl.std.450 Intrinsics/Tanh_IntrinsicTest.expected.spvtxt
+++ b/CSShadersTests/Tests/IntrinsicFunctions/Glsl.std.450 Intrinsics/Tanh_IntrinsicTest.expected.spvtxt
@@ -30,10 +30,11 @@
                OpName %self_2 "self"
        %uint = OpTypeInt 32 0
       %float = OpTypeFloat 32
+    %float_0 = OpConstant %float 0
    %TanhTest = OpTypeStruct
        %void = OpTypeVoid
 %_ptr_Function_TanhTest = OpTypePointer Function %TanhTest
-         %10 = OpTypeFunction %void %_ptr_Function_TanhTest
+         %11 = OpTypeFunction %void %_ptr_Function_TanhTest
 %_ptr_Function_float = OpTypePointer Function %float
     %Vector2 = OpTypeVector %float 2
 %_ptr_Function_Vector2 = OpTypePointer Function %Vector2
@@ -42,20 +43,19 @@
     %Vector4 = OpTypeVector %float 4
 %_ptr_Function_Vector4 = OpTypePointer Function %Vector4
         %int = OpTypeInt 32 1
-         %20 = OpTypeFunction %void
-    %float_0 = OpConstant %float 0
-%TanhTest_PreConstructor = OpFunction %void None %10
+         %21 = OpTypeFunction %void
+%TanhTest_PreConstructor = OpFunction %void None %11
        %self = OpFunctionParameter %_ptr_Function_TanhTest
          %26 = OpLabel
                OpReturn
                OpFunctionEnd
-%TanhTest_DefaultConstructor = OpFunction %void None %10
+%TanhTest_DefaultConstructor = OpFunction %void None %11
      %self_0 = OpFunctionParameter %_ptr_Function_TanhTest
          %31 = OpLabel
          %32 = OpFunctionCall %void %TanhTest_PreConstructor %self_0
                OpReturn
                OpFunctionEnd
-       %Main = OpFunction %void None %10
+       %Main = OpFunction %void None %11
      %self_1 = OpFunctionParameter %_ptr_Function_TanhTest
          %37 = OpLabel
    %floatVal = OpVariable %_ptr_Function_float Function
@@ -83,7 +83,7 @@
                OpStore %vector4Val %59
                OpReturn
                OpFunctionEnd
-%TanhTest_Main_EntryPoint = OpFunction %void None %20
+%TanhTest_Main_EntryPoint = OpFunction %void None %21
          %64 = OpLabel
      %self_2 = OpVariable %_ptr_Function_TanhTest Function
          %66 = OpFunctionCall %void %TanhTest_DefaultConstructor %self_2

--- a/CSShadersTests/Tests/IntrinsicFunctions/Glsl.std.450 Intrinsics/Trunc_IntrinsicTest.expected.spvtxt
+++ b/CSShadersTests/Tests/IntrinsicFunctions/Glsl.std.450 Intrinsics/Trunc_IntrinsicTest.expected.spvtxt
@@ -30,10 +30,11 @@
                OpName %self_2 "self"
        %uint = OpTypeInt 32 0
       %float = OpTypeFloat 32
+    %float_0 = OpConstant %float 0
   %TruncTest = OpTypeStruct
        %void = OpTypeVoid
 %_ptr_Function_TruncTest = OpTypePointer Function %TruncTest
-         %10 = OpTypeFunction %void %_ptr_Function_TruncTest
+         %11 = OpTypeFunction %void %_ptr_Function_TruncTest
 %_ptr_Function_float = OpTypePointer Function %float
     %Vector2 = OpTypeVector %float 2
 %_ptr_Function_Vector2 = OpTypePointer Function %Vector2
@@ -42,20 +43,19 @@
     %Vector4 = OpTypeVector %float 4
 %_ptr_Function_Vector4 = OpTypePointer Function %Vector4
         %int = OpTypeInt 32 1
-         %20 = OpTypeFunction %void
-    %float_0 = OpConstant %float 0
-%TruncTest_PreConstructor = OpFunction %void None %10
+         %21 = OpTypeFunction %void
+%TruncTest_PreConstructor = OpFunction %void None %11
        %self = OpFunctionParameter %_ptr_Function_TruncTest
          %26 = OpLabel
                OpReturn
                OpFunctionEnd
-%TruncTest_DefaultConstructor = OpFunction %void None %10
+%TruncTest_DefaultConstructor = OpFunction %void None %11
      %self_0 = OpFunctionParameter %_ptr_Function_TruncTest
          %31 = OpLabel
          %32 = OpFunctionCall %void %TruncTest_PreConstructor %self_0
                OpReturn
                OpFunctionEnd
-       %Main = OpFunction %void None %10
+       %Main = OpFunction %void None %11
      %self_1 = OpFunctionParameter %_ptr_Function_TruncTest
          %37 = OpLabel
    %floatVal = OpVariable %_ptr_Function_float Function
@@ -83,7 +83,7 @@
                OpStore %vector4Val %59
                OpReturn
                OpFunctionEnd
-%TruncTest_Main_EntryPoint = OpFunction %void None %20
+%TruncTest_Main_EntryPoint = OpFunction %void None %21
          %64 = OpLabel
      %self_2 = OpVariable %_ptr_Function_TruncTest Function
          %66 = OpFunctionCall %void %TruncTest_DefaultConstructor %self_2

--- a/CSShadersTests/Tests/IntrinsicFunctions/Image Intrinsics/ImageFetchLod_IntrinsicTest.expected.spvtxt
+++ b/CSShadersTests/Tests/IntrinsicFunctions/Image Intrinsics/ImageFetchLod_IntrinsicTest.expected.spvtxt
@@ -10,7 +10,9 @@
                OpExecutionMode %OpImageFetchTest_Main_EntryPoint OriginUpperLeft
                OpSource Unknown 100
                OpName %FloatImage2d "FloatImage2d"
+               OpName %FloatImage2dVal "FloatImage2dVal"
                OpName %FloatSampledImage2d "FloatSampledImage2d"
+               OpName %FloatSampledImage2dVal "FloatSampledImage2dVal"
                OpName %OpImageFetchTest "OpImageFetchTest"
                OpName %Vector4 "Vector4"
                OpName %Integer2 "Integer2"
@@ -25,43 +27,41 @@
                OpName %intVal "intVal"
                OpName %OpImageFetchTest_Main_EntryPoint "OpImageFetchTest_Main_EntryPoint"
                OpName %self_2 "self"
-               OpName %FloatImage2dVal "FloatImage2dVal"
-               OpName %FloatSampledImage2dVal "FloatSampledImage2dVal"
                OpName %OpImageFetchTest_Main_EntryPoint "OpImageFetchTest_Main_EntryPoint"
                OpName %self_2 "self"
        %uint = OpTypeInt 32 0
       %float = OpTypeFloat 32
+    %float_0 = OpConstant %float 0
         %int = OpTypeInt 32 1
+      %int_0 = OpConstant %int 0
 %FloatImage2d = OpTypeImage %float 2D 0 0 0 1 Unknown
 %_ptr_UniformConstant_FloatImage2d = OpTypePointer UniformConstant %FloatImage2d
+%FloatImage2dVal = OpVariable %_ptr_UniformConstant_FloatImage2d UniformConstant
 %FloatSampledImage2d = OpTypeSampledImage %FloatImage2d
 %_ptr_UniformConstant_FloatSampledImage2d = OpTypePointer UniformConstant %FloatSampledImage2d
+%FloatSampledImage2dVal = OpVariable %_ptr_UniformConstant_FloatSampledImage2d UniformConstant
 %OpImageFetchTest = OpTypeStruct
        %void = OpTypeVoid
 %_ptr_Function_OpImageFetchTest = OpTypePointer Function %OpImageFetchTest
-         %17 = OpTypeFunction %void %_ptr_Function_OpImageFetchTest
+         %21 = OpTypeFunction %void %_ptr_Function_OpImageFetchTest
     %Vector4 = OpTypeVector %float 4
 %_ptr_Function_Vector4 = OpTypePointer Function %Vector4
    %Integer2 = OpTypeVector %int 2
 %_ptr_Function_Integer2 = OpTypePointer Function %Integer2
 %_ptr_Function_int = OpTypePointer Function %int
-         %23 = OpTypeFunction %void
-    %float_0 = OpConstant %float 0
-      %int_0 = OpConstant %int 0
-%FloatImage2dVal = OpVariable %_ptr_UniformConstant_FloatImage2d UniformConstant
-%FloatSampledImage2dVal = OpVariable %_ptr_UniformConstant_FloatSampledImage2d UniformConstant
-%OpImageFetchTest_PreConstructor = OpFunction %void None %17
+         %27 = OpTypeFunction %void
+%OpImageFetchTest_PreConstructor = OpFunction %void None %21
        %self = OpFunctionParameter %_ptr_Function_OpImageFetchTest
          %32 = OpLabel
                OpReturn
                OpFunctionEnd
-%OpImageFetchTest_DefaultConstructor = OpFunction %void None %17
+%OpImageFetchTest_DefaultConstructor = OpFunction %void None %21
      %self_0 = OpFunctionParameter %_ptr_Function_OpImageFetchTest
          %37 = OpLabel
          %38 = OpFunctionCall %void %OpImageFetchTest_PreConstructor %self_0
                OpReturn
                OpFunctionEnd
-       %Main = OpFunction %void None %17
+       %Main = OpFunction %void None %21
      %self_1 = OpFunctionParameter %_ptr_Function_OpImageFetchTest
          %43 = OpLabel
  %vector4Val = OpVariable %_ptr_Function_Vector4 Function
@@ -85,7 +85,7 @@
                OpStore %vector4Val %61
                OpReturn
                OpFunctionEnd
-%OpImageFetchTest_Main_EntryPoint = OpFunction %void None %23
+%OpImageFetchTest_Main_EntryPoint = OpFunction %void None %27
          %66 = OpLabel
      %self_2 = OpVariable %_ptr_Function_OpImageFetchTest Function
          %68 = OpFunctionCall %void %OpImageFetchTest_DefaultConstructor %self_2

--- a/CSShadersTests/Tests/IntrinsicFunctions/Image Intrinsics/ImageFetch_IntrinsicTest.expected.spvtxt
+++ b/CSShadersTests/Tests/IntrinsicFunctions/Image Intrinsics/ImageFetch_IntrinsicTest.expected.spvtxt
@@ -10,7 +10,9 @@
                OpExecutionMode %OpImageFetchTest_Main_EntryPoint OriginUpperLeft
                OpSource Unknown 100
                OpName %FloatImage2d "FloatImage2d"
+               OpName %FloatImage2dVal "FloatImage2dVal"
                OpName %FloatSampledImage2d "FloatSampledImage2d"
+               OpName %FloatSampledImage2dVal "FloatSampledImage2dVal"
                OpName %OpImageFetchTest "OpImageFetchTest"
                OpName %Vector4 "Vector4"
                OpName %Integer2 "Integer2"
@@ -24,42 +26,40 @@
                OpName %integer2Val "integer2Val"
                OpName %OpImageFetchTest_Main_EntryPoint "OpImageFetchTest_Main_EntryPoint"
                OpName %self_2 "self"
-               OpName %FloatImage2dVal "FloatImage2dVal"
-               OpName %FloatSampledImage2dVal "FloatSampledImage2dVal"
                OpName %OpImageFetchTest_Main_EntryPoint "OpImageFetchTest_Main_EntryPoint"
                OpName %self_2 "self"
        %uint = OpTypeInt 32 0
       %float = OpTypeFloat 32
+    %float_0 = OpConstant %float 0
         %int = OpTypeInt 32 1
+      %int_0 = OpConstant %int 0
 %FloatImage2d = OpTypeImage %float 2D 0 0 0 1 Unknown
 %_ptr_UniformConstant_FloatImage2d = OpTypePointer UniformConstant %FloatImage2d
+%FloatImage2dVal = OpVariable %_ptr_UniformConstant_FloatImage2d UniformConstant
 %FloatSampledImage2d = OpTypeSampledImage %FloatImage2d
 %_ptr_UniformConstant_FloatSampledImage2d = OpTypePointer UniformConstant %FloatSampledImage2d
+%FloatSampledImage2dVal = OpVariable %_ptr_UniformConstant_FloatSampledImage2d UniformConstant
 %OpImageFetchTest = OpTypeStruct
        %void = OpTypeVoid
 %_ptr_Function_OpImageFetchTest = OpTypePointer Function %OpImageFetchTest
-         %17 = OpTypeFunction %void %_ptr_Function_OpImageFetchTest
+         %21 = OpTypeFunction %void %_ptr_Function_OpImageFetchTest
     %Vector4 = OpTypeVector %float 4
 %_ptr_Function_Vector4 = OpTypePointer Function %Vector4
    %Integer2 = OpTypeVector %int 2
 %_ptr_Function_Integer2 = OpTypePointer Function %Integer2
-         %23 = OpTypeFunction %void
-    %float_0 = OpConstant %float 0
-      %int_0 = OpConstant %int 0
-%FloatImage2dVal = OpVariable %_ptr_UniformConstant_FloatImage2d UniformConstant
-%FloatSampledImage2dVal = OpVariable %_ptr_UniformConstant_FloatSampledImage2d UniformConstant
-%OpImageFetchTest_PreConstructor = OpFunction %void None %17
+         %27 = OpTypeFunction %void
+%OpImageFetchTest_PreConstructor = OpFunction %void None %21
        %self = OpFunctionParameter %_ptr_Function_OpImageFetchTest
          %32 = OpLabel
                OpReturn
                OpFunctionEnd
-%OpImageFetchTest_DefaultConstructor = OpFunction %void None %17
+%OpImageFetchTest_DefaultConstructor = OpFunction %void None %21
      %self_0 = OpFunctionParameter %_ptr_Function_OpImageFetchTest
          %37 = OpLabel
          %38 = OpFunctionCall %void %OpImageFetchTest_PreConstructor %self_0
                OpReturn
                OpFunctionEnd
-       %Main = OpFunction %void None %17
+       %Main = OpFunction %void None %21
      %self_1 = OpFunctionParameter %_ptr_Function_OpImageFetchTest
          %43 = OpLabel
  %vector4Val = OpVariable %_ptr_Function_Vector4 Function
@@ -79,7 +79,7 @@
                OpStore %vector4Val %57
                OpReturn
                OpFunctionEnd
-%OpImageFetchTest_Main_EntryPoint = OpFunction %void None %23
+%OpImageFetchTest_Main_EntryPoint = OpFunction %void None %27
          %62 = OpLabel
      %self_2 = OpVariable %_ptr_Function_OpImageFetchTest Function
          %64 = OpFunctionCall %void %OpImageFetchTest_DefaultConstructor %self_2

--- a/CSShadersTests/Tests/IntrinsicFunctions/Image Intrinsics/SampleDrefExplicitLod_IntrinsicTest.expected.spvtxt
+++ b/CSShadersTests/Tests/IntrinsicFunctions/Image Intrinsics/SampleDrefExplicitLod_IntrinsicTest.expected.spvtxt
@@ -10,8 +10,11 @@
                OpExecutionMode %OpImageSampleDrefExplicitLodTest_Main_EntryPoint OriginUpperLeft
                OpSource Unknown 100
                OpName %FloatImage2d "FloatImage2d"
+               OpName %FloatImage2dVal "FloatImage2dVal"
                OpName %Sampler "Sampler"
+               OpName %SamplerVal "SamplerVal"
                OpName %FloatSampledImage2d "FloatSampledImage2d"
+               OpName %FloatSampledImage2dVal "FloatSampledImage2dVal"
                OpName %OpImageSampleDrefExplicitLodTest "OpImageSampleDrefExplicitLodTest"
                OpName %Vector2 "Vector2"
                OpName %FloatSampledImage2d "GeneratedSampledImage_CSShaders.ShaderType"
@@ -25,43 +28,40 @@
                OpName %vector2Val "vector2Val"
                OpName %OpImageSampleDrefExplicitLodTest_Main_EntryPoint "OpImageSampleDrefExplicitLodTest_Main_EntryPoint"
                OpName %self_2 "self"
-               OpName %FloatImage2dVal "FloatImage2dVal"
-               OpName %SamplerVal "SamplerVal"
-               OpName %FloatSampledImage2dVal "FloatSampledImage2dVal"
                OpName %OpImageSampleDrefExplicitLodTest_Main_EntryPoint "OpImageSampleDrefExplicitLodTest_Main_EntryPoint"
                OpName %self_2 "self"
        %uint = OpTypeInt 32 0
       %float = OpTypeFloat 32
+    %float_0 = OpConstant %float 0
 %FloatImage2d = OpTypeImage %float 2D 0 0 0 1 Unknown
 %_ptr_UniformConstant_FloatImage2d = OpTypePointer UniformConstant %FloatImage2d
+%FloatImage2dVal = OpVariable %_ptr_UniformConstant_FloatImage2d UniformConstant
     %Sampler = OpTypeSampler
 %_ptr_UniformConstant_Sampler = OpTypePointer UniformConstant %Sampler
+ %SamplerVal = OpVariable %_ptr_UniformConstant_Sampler UniformConstant
 %FloatSampledImage2d = OpTypeSampledImage %FloatImage2d
 %_ptr_UniformConstant_FloatSampledImage2d = OpTypePointer UniformConstant %FloatSampledImage2d
+%FloatSampledImage2dVal = OpVariable %_ptr_UniformConstant_FloatSampledImage2d UniformConstant
 %OpImageSampleDrefExplicitLodTest = OpTypeStruct
        %void = OpTypeVoid
 %_ptr_Function_OpImageSampleDrefExplicitLodTest = OpTypePointer Function %OpImageSampleDrefExplicitLodTest
-         %18 = OpTypeFunction %void %_ptr_Function_OpImageSampleDrefExplicitLodTest
+         %22 = OpTypeFunction %void %_ptr_Function_OpImageSampleDrefExplicitLodTest
 %_ptr_Function_float = OpTypePointer Function %float
     %Vector2 = OpTypeVector %float 2
 %_ptr_Function_Vector2 = OpTypePointer Function %Vector2
-         %22 = OpTypeFunction %void
-    %float_0 = OpConstant %float 0
-%FloatImage2dVal = OpVariable %_ptr_UniformConstant_FloatImage2d UniformConstant
- %SamplerVal = OpVariable %_ptr_UniformConstant_Sampler UniformConstant
-%FloatSampledImage2dVal = OpVariable %_ptr_UniformConstant_FloatSampledImage2d UniformConstant
-%OpImageSampleDrefExplicitLodTest_PreConstructor = OpFunction %void None %18
+         %26 = OpTypeFunction %void
+%OpImageSampleDrefExplicitLodTest_PreConstructor = OpFunction %void None %22
        %self = OpFunctionParameter %_ptr_Function_OpImageSampleDrefExplicitLodTest
          %31 = OpLabel
                OpReturn
                OpFunctionEnd
-%OpImageSampleDrefExplicitLodTest_DefaultConstructor = OpFunction %void None %18
+%OpImageSampleDrefExplicitLodTest_DefaultConstructor = OpFunction %void None %22
      %self_0 = OpFunctionParameter %_ptr_Function_OpImageSampleDrefExplicitLodTest
          %36 = OpLabel
          %37 = OpFunctionCall %void %OpImageSampleDrefExplicitLodTest_PreConstructor %self_0
                OpReturn
                OpFunctionEnd
-       %Main = OpFunction %void None %18
+       %Main = OpFunction %void None %22
      %self_1 = OpFunctionParameter %_ptr_Function_OpImageSampleDrefExplicitLodTest
          %42 = OpLabel
    %floatVal = OpVariable %_ptr_Function_float Function
@@ -85,7 +85,7 @@
                OpStore %floatVal %60
                OpReturn
                OpFunctionEnd
-%OpImageSampleDrefExplicitLodTest_Main_EntryPoint = OpFunction %void None %22
+%OpImageSampleDrefExplicitLodTest_Main_EntryPoint = OpFunction %void None %26
          %65 = OpLabel
      %self_2 = OpVariable %_ptr_Function_OpImageSampleDrefExplicitLodTest Function
          %67 = OpFunctionCall %void %OpImageSampleDrefExplicitLodTest_DefaultConstructor %self_2

--- a/CSShadersTests/Tests/IntrinsicFunctions/Image Intrinsics/SampleDrefImplicitLod_IntrinsicTest.expected.spvtxt
+++ b/CSShadersTests/Tests/IntrinsicFunctions/Image Intrinsics/SampleDrefImplicitLod_IntrinsicTest.expected.spvtxt
@@ -10,8 +10,11 @@
                OpExecutionMode %OpImageSampleDrefImplicitLodTest_Main_EntryPoint OriginUpperLeft
                OpSource Unknown 100
                OpName %FloatImage2d "FloatImage2d"
+               OpName %FloatImage2dVal "FloatImage2dVal"
                OpName %Sampler "Sampler"
+               OpName %SamplerVal "SamplerVal"
                OpName %FloatSampledImage2d "FloatSampledImage2d"
+               OpName %FloatSampledImage2dVal "FloatSampledImage2dVal"
                OpName %OpImageSampleDrefImplicitLodTest "OpImageSampleDrefImplicitLodTest"
                OpName %Vector2 "Vector2"
                OpName %FloatSampledImage2d "GeneratedSampledImage_CSShaders.ShaderType"
@@ -25,43 +28,40 @@
                OpName %vector2Val "vector2Val"
                OpName %OpImageSampleDrefImplicitLodTest_Main_EntryPoint "OpImageSampleDrefImplicitLodTest_Main_EntryPoint"
                OpName %self_2 "self"
-               OpName %FloatImage2dVal "FloatImage2dVal"
-               OpName %SamplerVal "SamplerVal"
-               OpName %FloatSampledImage2dVal "FloatSampledImage2dVal"
                OpName %OpImageSampleDrefImplicitLodTest_Main_EntryPoint "OpImageSampleDrefImplicitLodTest_Main_EntryPoint"
                OpName %self_2 "self"
        %uint = OpTypeInt 32 0
       %float = OpTypeFloat 32
+    %float_0 = OpConstant %float 0
 %FloatImage2d = OpTypeImage %float 2D 0 0 0 1 Unknown
 %_ptr_UniformConstant_FloatImage2d = OpTypePointer UniformConstant %FloatImage2d
+%FloatImage2dVal = OpVariable %_ptr_UniformConstant_FloatImage2d UniformConstant
     %Sampler = OpTypeSampler
 %_ptr_UniformConstant_Sampler = OpTypePointer UniformConstant %Sampler
+ %SamplerVal = OpVariable %_ptr_UniformConstant_Sampler UniformConstant
 %FloatSampledImage2d = OpTypeSampledImage %FloatImage2d
 %_ptr_UniformConstant_FloatSampledImage2d = OpTypePointer UniformConstant %FloatSampledImage2d
+%FloatSampledImage2dVal = OpVariable %_ptr_UniformConstant_FloatSampledImage2d UniformConstant
 %OpImageSampleDrefImplicitLodTest = OpTypeStruct
        %void = OpTypeVoid
 %_ptr_Function_OpImageSampleDrefImplicitLodTest = OpTypePointer Function %OpImageSampleDrefImplicitLodTest
-         %18 = OpTypeFunction %void %_ptr_Function_OpImageSampleDrefImplicitLodTest
+         %22 = OpTypeFunction %void %_ptr_Function_OpImageSampleDrefImplicitLodTest
 %_ptr_Function_float = OpTypePointer Function %float
     %Vector2 = OpTypeVector %float 2
 %_ptr_Function_Vector2 = OpTypePointer Function %Vector2
-         %22 = OpTypeFunction %void
-    %float_0 = OpConstant %float 0
-%FloatImage2dVal = OpVariable %_ptr_UniformConstant_FloatImage2d UniformConstant
- %SamplerVal = OpVariable %_ptr_UniformConstant_Sampler UniformConstant
-%FloatSampledImage2dVal = OpVariable %_ptr_UniformConstant_FloatSampledImage2d UniformConstant
-%OpImageSampleDrefImplicitLodTest_PreConstructor = OpFunction %void None %18
+         %26 = OpTypeFunction %void
+%OpImageSampleDrefImplicitLodTest_PreConstructor = OpFunction %void None %22
        %self = OpFunctionParameter %_ptr_Function_OpImageSampleDrefImplicitLodTest
          %31 = OpLabel
                OpReturn
                OpFunctionEnd
-%OpImageSampleDrefImplicitLodTest_DefaultConstructor = OpFunction %void None %18
+%OpImageSampleDrefImplicitLodTest_DefaultConstructor = OpFunction %void None %22
      %self_0 = OpFunctionParameter %_ptr_Function_OpImageSampleDrefImplicitLodTest
          %36 = OpLabel
          %37 = OpFunctionCall %void %OpImageSampleDrefImplicitLodTest_PreConstructor %self_0
                OpReturn
                OpFunctionEnd
-       %Main = OpFunction %void None %18
+       %Main = OpFunction %void None %22
      %self_1 = OpFunctionParameter %_ptr_Function_OpImageSampleDrefImplicitLodTest
          %42 = OpLabel
    %floatVal = OpVariable %_ptr_Function_float Function
@@ -83,7 +83,7 @@
                OpStore %floatVal %58
                OpReturn
                OpFunctionEnd
-%OpImageSampleDrefImplicitLodTest_Main_EntryPoint = OpFunction %void None %22
+%OpImageSampleDrefImplicitLodTest_Main_EntryPoint = OpFunction %void None %26
          %63 = OpLabel
      %self_2 = OpVariable %_ptr_Function_OpImageSampleDrefImplicitLodTest Function
          %65 = OpFunctionCall %void %OpImageSampleDrefImplicitLodTest_DefaultConstructor %self_2

--- a/CSShadersTests/Tests/IntrinsicFunctions/Image Intrinsics/SampleExplicitLod_IntrinsicTest.expected.spvtxt
+++ b/CSShadersTests/Tests/IntrinsicFunctions/Image Intrinsics/SampleExplicitLod_IntrinsicTest.expected.spvtxt
@@ -10,8 +10,11 @@
                OpExecutionMode %OpImageSampleExplicitLodTest_Main_EntryPoint OriginUpperLeft
                OpSource Unknown 100
                OpName %FloatImage2d "FloatImage2d"
+               OpName %FloatImage2dVal "FloatImage2dVal"
                OpName %Sampler "Sampler"
+               OpName %SamplerVal "SamplerVal"
                OpName %FloatSampledImage2d "FloatSampledImage2d"
+               OpName %FloatSampledImage2dVal "FloatSampledImage2dVal"
                OpName %OpImageSampleExplicitLodTest "OpImageSampleExplicitLodTest"
                OpName %Vector4 "Vector4"
                OpName %Vector2 "Vector2"
@@ -27,45 +30,42 @@
                OpName %floatVal "floatVal"
                OpName %OpImageSampleExplicitLodTest_Main_EntryPoint "OpImageSampleExplicitLodTest_Main_EntryPoint"
                OpName %self_2 "self"
-               OpName %FloatImage2dVal "FloatImage2dVal"
-               OpName %SamplerVal "SamplerVal"
-               OpName %FloatSampledImage2dVal "FloatSampledImage2dVal"
                OpName %OpImageSampleExplicitLodTest_Main_EntryPoint "OpImageSampleExplicitLodTest_Main_EntryPoint"
                OpName %self_2 "self"
        %uint = OpTypeInt 32 0
       %float = OpTypeFloat 32
+    %float_0 = OpConstant %float 0
 %FloatImage2d = OpTypeImage %float 2D 0 0 0 1 Unknown
 %_ptr_UniformConstant_FloatImage2d = OpTypePointer UniformConstant %FloatImage2d
+%FloatImage2dVal = OpVariable %_ptr_UniformConstant_FloatImage2d UniformConstant
     %Sampler = OpTypeSampler
 %_ptr_UniformConstant_Sampler = OpTypePointer UniformConstant %Sampler
+ %SamplerVal = OpVariable %_ptr_UniformConstant_Sampler UniformConstant
 %FloatSampledImage2d = OpTypeSampledImage %FloatImage2d
 %_ptr_UniformConstant_FloatSampledImage2d = OpTypePointer UniformConstant %FloatSampledImage2d
+%FloatSampledImage2dVal = OpVariable %_ptr_UniformConstant_FloatSampledImage2d UniformConstant
 %OpImageSampleExplicitLodTest = OpTypeStruct
        %void = OpTypeVoid
 %_ptr_Function_OpImageSampleExplicitLodTest = OpTypePointer Function %OpImageSampleExplicitLodTest
-         %18 = OpTypeFunction %void %_ptr_Function_OpImageSampleExplicitLodTest
+         %22 = OpTypeFunction %void %_ptr_Function_OpImageSampleExplicitLodTest
     %Vector4 = OpTypeVector %float 4
 %_ptr_Function_Vector4 = OpTypePointer Function %Vector4
     %Vector2 = OpTypeVector %float 2
 %_ptr_Function_Vector2 = OpTypePointer Function %Vector2
 %_ptr_Function_float = OpTypePointer Function %float
-         %24 = OpTypeFunction %void
-    %float_0 = OpConstant %float 0
-%FloatImage2dVal = OpVariable %_ptr_UniformConstant_FloatImage2d UniformConstant
- %SamplerVal = OpVariable %_ptr_UniformConstant_Sampler UniformConstant
-%FloatSampledImage2dVal = OpVariable %_ptr_UniformConstant_FloatSampledImage2d UniformConstant
-%OpImageSampleExplicitLodTest_PreConstructor = OpFunction %void None %18
+         %28 = OpTypeFunction %void
+%OpImageSampleExplicitLodTest_PreConstructor = OpFunction %void None %22
        %self = OpFunctionParameter %_ptr_Function_OpImageSampleExplicitLodTest
          %33 = OpLabel
                OpReturn
                OpFunctionEnd
-%OpImageSampleExplicitLodTest_DefaultConstructor = OpFunction %void None %18
+%OpImageSampleExplicitLodTest_DefaultConstructor = OpFunction %void None %22
      %self_0 = OpFunctionParameter %_ptr_Function_OpImageSampleExplicitLodTest
          %38 = OpLabel
          %39 = OpFunctionCall %void %OpImageSampleExplicitLodTest_PreConstructor %self_0
                OpReturn
                OpFunctionEnd
-       %Main = OpFunction %void None %18
+       %Main = OpFunction %void None %22
      %self_1 = OpFunctionParameter %_ptr_Function_OpImageSampleExplicitLodTest
          %44 = OpLabel
  %vector4Val = OpVariable %_ptr_Function_Vector4 Function
@@ -90,7 +90,7 @@
                OpStore %vector4Val %63
                OpReturn
                OpFunctionEnd
-%OpImageSampleExplicitLodTest_Main_EntryPoint = OpFunction %void None %24
+%OpImageSampleExplicitLodTest_Main_EntryPoint = OpFunction %void None %28
          %68 = OpLabel
      %self_2 = OpVariable %_ptr_Function_OpImageSampleExplicitLodTest Function
          %70 = OpFunctionCall %void %OpImageSampleExplicitLodTest_DefaultConstructor %self_2

--- a/CSShadersTests/Tests/IntrinsicFunctions/Image Intrinsics/SampleGradExplicitLod_IntrinsicTest.expected.spvtxt
+++ b/CSShadersTests/Tests/IntrinsicFunctions/Image Intrinsics/SampleGradExplicitLod_IntrinsicTest.expected.spvtxt
@@ -10,8 +10,11 @@
                OpExecutionMode %OpImageSampleExplicitLodTest_Main_EntryPoint OriginUpperLeft
                OpSource Unknown 100
                OpName %FloatImage2d "FloatImage2d"
+               OpName %FloatImage2dVal "FloatImage2dVal"
                OpName %Sampler "Sampler"
+               OpName %SamplerVal "SamplerVal"
                OpName %FloatSampledImage2d "FloatSampledImage2d"
+               OpName %FloatSampledImage2dVal "FloatSampledImage2dVal"
                OpName %OpImageSampleExplicitLodTest "OpImageSampleExplicitLodTest"
                OpName %Vector4 "Vector4"
                OpName %Vector2 "Vector2"
@@ -26,44 +29,41 @@
                OpName %vector2Val "vector2Val"
                OpName %OpImageSampleExplicitLodTest_Main_EntryPoint "OpImageSampleExplicitLodTest_Main_EntryPoint"
                OpName %self_2 "self"
-               OpName %FloatImage2dVal "FloatImage2dVal"
-               OpName %SamplerVal "SamplerVal"
-               OpName %FloatSampledImage2dVal "FloatSampledImage2dVal"
                OpName %OpImageSampleExplicitLodTest_Main_EntryPoint "OpImageSampleExplicitLodTest_Main_EntryPoint"
                OpName %self_2 "self"
        %uint = OpTypeInt 32 0
       %float = OpTypeFloat 32
+    %float_0 = OpConstant %float 0
 %FloatImage2d = OpTypeImage %float 2D 0 0 0 1 Unknown
 %_ptr_UniformConstant_FloatImage2d = OpTypePointer UniformConstant %FloatImage2d
+%FloatImage2dVal = OpVariable %_ptr_UniformConstant_FloatImage2d UniformConstant
     %Sampler = OpTypeSampler
 %_ptr_UniformConstant_Sampler = OpTypePointer UniformConstant %Sampler
+ %SamplerVal = OpVariable %_ptr_UniformConstant_Sampler UniformConstant
 %FloatSampledImage2d = OpTypeSampledImage %FloatImage2d
 %_ptr_UniformConstant_FloatSampledImage2d = OpTypePointer UniformConstant %FloatSampledImage2d
+%FloatSampledImage2dVal = OpVariable %_ptr_UniformConstant_FloatSampledImage2d UniformConstant
 %OpImageSampleExplicitLodTest = OpTypeStruct
        %void = OpTypeVoid
 %_ptr_Function_OpImageSampleExplicitLodTest = OpTypePointer Function %OpImageSampleExplicitLodTest
-         %18 = OpTypeFunction %void %_ptr_Function_OpImageSampleExplicitLodTest
+         %22 = OpTypeFunction %void %_ptr_Function_OpImageSampleExplicitLodTest
     %Vector4 = OpTypeVector %float 4
 %_ptr_Function_Vector4 = OpTypePointer Function %Vector4
     %Vector2 = OpTypeVector %float 2
 %_ptr_Function_Vector2 = OpTypePointer Function %Vector2
-         %24 = OpTypeFunction %void
-    %float_0 = OpConstant %float 0
-%FloatImage2dVal = OpVariable %_ptr_UniformConstant_FloatImage2d UniformConstant
- %SamplerVal = OpVariable %_ptr_UniformConstant_Sampler UniformConstant
-%FloatSampledImage2dVal = OpVariable %_ptr_UniformConstant_FloatSampledImage2d UniformConstant
-%OpImageSampleExplicitLodTest_PreConstructor = OpFunction %void None %18
+         %28 = OpTypeFunction %void
+%OpImageSampleExplicitLodTest_PreConstructor = OpFunction %void None %22
        %self = OpFunctionParameter %_ptr_Function_OpImageSampleExplicitLodTest
          %33 = OpLabel
                OpReturn
                OpFunctionEnd
-%OpImageSampleExplicitLodTest_DefaultConstructor = OpFunction %void None %18
+%OpImageSampleExplicitLodTest_DefaultConstructor = OpFunction %void None %22
      %self_0 = OpFunctionParameter %_ptr_Function_OpImageSampleExplicitLodTest
          %38 = OpLabel
          %39 = OpFunctionCall %void %OpImageSampleExplicitLodTest_PreConstructor %self_0
                OpReturn
                OpFunctionEnd
-       %Main = OpFunction %void None %18
+       %Main = OpFunction %void None %22
      %self_1 = OpFunctionParameter %_ptr_Function_OpImageSampleExplicitLodTest
          %44 = OpLabel
  %vector4Val = OpVariable %_ptr_Function_Vector4 Function
@@ -88,7 +88,7 @@
                OpStore %vector4Val %63
                OpReturn
                OpFunctionEnd
-%OpImageSampleExplicitLodTest_Main_EntryPoint = OpFunction %void None %24
+%OpImageSampleExplicitLodTest_Main_EntryPoint = OpFunction %void None %28
          %68 = OpLabel
      %self_2 = OpVariable %_ptr_Function_OpImageSampleExplicitLodTest Function
          %70 = OpFunctionCall %void %OpImageSampleExplicitLodTest_DefaultConstructor %self_2

--- a/CSShadersTests/Tests/IntrinsicFunctions/Image Intrinsics/SampleImplicitLod_IntrinsicTest.expected.spvtxt
+++ b/CSShadersTests/Tests/IntrinsicFunctions/Image Intrinsics/SampleImplicitLod_IntrinsicTest.expected.spvtxt
@@ -10,8 +10,11 @@
                OpExecutionMode %OpImageSampleImplicitLodTest_Main_EntryPoint OriginUpperLeft
                OpSource Unknown 100
                OpName %FloatImage2d "FloatImage2d"
+               OpName %FloatImage2dVal "FloatImage2dVal"
                OpName %Sampler "Sampler"
+               OpName %SamplerVal "SamplerVal"
                OpName %FloatSampledImage2d "FloatSampledImage2d"
+               OpName %FloatSampledImage2dVal "FloatSampledImage2dVal"
                OpName %OpImageSampleImplicitLodTest "OpImageSampleImplicitLodTest"
                OpName %Vector4 "Vector4"
                OpName %Vector2 "Vector2"
@@ -26,44 +29,41 @@
                OpName %vector2Val "vector2Val"
                OpName %OpImageSampleImplicitLodTest_Main_EntryPoint "OpImageSampleImplicitLodTest_Main_EntryPoint"
                OpName %self_2 "self"
-               OpName %FloatImage2dVal "FloatImage2dVal"
-               OpName %SamplerVal "SamplerVal"
-               OpName %FloatSampledImage2dVal "FloatSampledImage2dVal"
                OpName %OpImageSampleImplicitLodTest_Main_EntryPoint "OpImageSampleImplicitLodTest_Main_EntryPoint"
                OpName %self_2 "self"
        %uint = OpTypeInt 32 0
       %float = OpTypeFloat 32
+    %float_0 = OpConstant %float 0
 %FloatImage2d = OpTypeImage %float 2D 0 0 0 1 Unknown
 %_ptr_UniformConstant_FloatImage2d = OpTypePointer UniformConstant %FloatImage2d
+%FloatImage2dVal = OpVariable %_ptr_UniformConstant_FloatImage2d UniformConstant
     %Sampler = OpTypeSampler
 %_ptr_UniformConstant_Sampler = OpTypePointer UniformConstant %Sampler
+ %SamplerVal = OpVariable %_ptr_UniformConstant_Sampler UniformConstant
 %FloatSampledImage2d = OpTypeSampledImage %FloatImage2d
 %_ptr_UniformConstant_FloatSampledImage2d = OpTypePointer UniformConstant %FloatSampledImage2d
+%FloatSampledImage2dVal = OpVariable %_ptr_UniformConstant_FloatSampledImage2d UniformConstant
 %OpImageSampleImplicitLodTest = OpTypeStruct
        %void = OpTypeVoid
 %_ptr_Function_OpImageSampleImplicitLodTest = OpTypePointer Function %OpImageSampleImplicitLodTest
-         %18 = OpTypeFunction %void %_ptr_Function_OpImageSampleImplicitLodTest
+         %22 = OpTypeFunction %void %_ptr_Function_OpImageSampleImplicitLodTest
     %Vector4 = OpTypeVector %float 4
 %_ptr_Function_Vector4 = OpTypePointer Function %Vector4
     %Vector2 = OpTypeVector %float 2
 %_ptr_Function_Vector2 = OpTypePointer Function %Vector2
-         %24 = OpTypeFunction %void
-    %float_0 = OpConstant %float 0
-%FloatImage2dVal = OpVariable %_ptr_UniformConstant_FloatImage2d UniformConstant
- %SamplerVal = OpVariable %_ptr_UniformConstant_Sampler UniformConstant
-%FloatSampledImage2dVal = OpVariable %_ptr_UniformConstant_FloatSampledImage2d UniformConstant
-%OpImageSampleImplicitLodTest_PreConstructor = OpFunction %void None %18
+         %28 = OpTypeFunction %void
+%OpImageSampleImplicitLodTest_PreConstructor = OpFunction %void None %22
        %self = OpFunctionParameter %_ptr_Function_OpImageSampleImplicitLodTest
          %33 = OpLabel
                OpReturn
                OpFunctionEnd
-%OpImageSampleImplicitLodTest_DefaultConstructor = OpFunction %void None %18
+%OpImageSampleImplicitLodTest_DefaultConstructor = OpFunction %void None %22
      %self_0 = OpFunctionParameter %_ptr_Function_OpImageSampleImplicitLodTest
          %38 = OpLabel
          %39 = OpFunctionCall %void %OpImageSampleImplicitLodTest_PreConstructor %self_0
                OpReturn
                OpFunctionEnd
-       %Main = OpFunction %void None %18
+       %Main = OpFunction %void None %22
      %self_1 = OpFunctionParameter %_ptr_Function_OpImageSampleImplicitLodTest
          %44 = OpLabel
  %vector4Val = OpVariable %_ptr_Function_Vector4 Function
@@ -84,7 +84,7 @@
                OpStore %vector4Val %59
                OpReturn
                OpFunctionEnd
-%OpImageSampleImplicitLodTest_Main_EntryPoint = OpFunction %void None %24
+%OpImageSampleImplicitLodTest_Main_EntryPoint = OpFunction %void None %28
          %64 = OpLabel
      %self_2 = OpVariable %_ptr_Function_OpImageSampleImplicitLodTest Function
          %66 = OpFunctionCall %void %OpImageSampleImplicitLodTest_DefaultConstructor %self_2

--- a/CSShadersTests/Tests/IntrinsicFunctions/Image Intrinsics/SampleProjDrefExplicitLod_IntrinsicTest.expected.spvtxt
+++ b/CSShadersTests/Tests/IntrinsicFunctions/Image Intrinsics/SampleProjDrefExplicitLod_IntrinsicTest.expected.spvtxt
@@ -10,8 +10,11 @@
                OpExecutionMode %OpImageSampleProjDrefExplicitLodTest_Main_EntryPoint OriginUpperLeft
                OpSource Unknown 100
                OpName %FloatImage2d "FloatImage2d"
+               OpName %FloatImage2dVal "FloatImage2dVal"
                OpName %Sampler "Sampler"
+               OpName %SamplerVal "SamplerVal"
                OpName %FloatSampledImage2d "FloatSampledImage2d"
+               OpName %FloatSampledImage2dVal "FloatSampledImage2dVal"
                OpName %OpImageSampleProjDrefExplicitLodTest "OpImageSampleProjDrefExplicitLodTest"
                OpName %Vector3 "Vector3"
                OpName %FloatSampledImage2d "GeneratedSampledImage_CSShaders.ShaderType"
@@ -25,43 +28,40 @@
                OpName %vector3Val "vector3Val"
                OpName %OpImageSampleProjDrefExplicitLodTest_Main_EntryPoint "OpImageSampleProjDrefExplicitLodTest_Main_EntryPoint"
                OpName %self_2 "self"
-               OpName %FloatImage2dVal "FloatImage2dVal"
-               OpName %SamplerVal "SamplerVal"
-               OpName %FloatSampledImage2dVal "FloatSampledImage2dVal"
                OpName %OpImageSampleProjDrefExplicitLodTest_Main_EntryPoint "OpImageSampleProjDrefExplicitLodTest_Main_EntryPoint"
                OpName %self_2 "self"
        %uint = OpTypeInt 32 0
       %float = OpTypeFloat 32
+    %float_0 = OpConstant %float 0
 %FloatImage2d = OpTypeImage %float 2D 0 0 0 1 Unknown
 %_ptr_UniformConstant_FloatImage2d = OpTypePointer UniformConstant %FloatImage2d
+%FloatImage2dVal = OpVariable %_ptr_UniformConstant_FloatImage2d UniformConstant
     %Sampler = OpTypeSampler
 %_ptr_UniformConstant_Sampler = OpTypePointer UniformConstant %Sampler
+ %SamplerVal = OpVariable %_ptr_UniformConstant_Sampler UniformConstant
 %FloatSampledImage2d = OpTypeSampledImage %FloatImage2d
 %_ptr_UniformConstant_FloatSampledImage2d = OpTypePointer UniformConstant %FloatSampledImage2d
+%FloatSampledImage2dVal = OpVariable %_ptr_UniformConstant_FloatSampledImage2d UniformConstant
 %OpImageSampleProjDrefExplicitLodTest = OpTypeStruct
        %void = OpTypeVoid
 %_ptr_Function_OpImageSampleProjDrefExplicitLodTest = OpTypePointer Function %OpImageSampleProjDrefExplicitLodTest
-         %18 = OpTypeFunction %void %_ptr_Function_OpImageSampleProjDrefExplicitLodTest
+         %22 = OpTypeFunction %void %_ptr_Function_OpImageSampleProjDrefExplicitLodTest
 %_ptr_Function_float = OpTypePointer Function %float
     %Vector3 = OpTypeVector %float 3
 %_ptr_Function_Vector3 = OpTypePointer Function %Vector3
-         %22 = OpTypeFunction %void
-    %float_0 = OpConstant %float 0
-%FloatImage2dVal = OpVariable %_ptr_UniformConstant_FloatImage2d UniformConstant
- %SamplerVal = OpVariable %_ptr_UniformConstant_Sampler UniformConstant
-%FloatSampledImage2dVal = OpVariable %_ptr_UniformConstant_FloatSampledImage2d UniformConstant
-%OpImageSampleProjDrefExplicitLodTest_PreConstructor = OpFunction %void None %18
+         %26 = OpTypeFunction %void
+%OpImageSampleProjDrefExplicitLodTest_PreConstructor = OpFunction %void None %22
        %self = OpFunctionParameter %_ptr_Function_OpImageSampleProjDrefExplicitLodTest
          %31 = OpLabel
                OpReturn
                OpFunctionEnd
-%OpImageSampleProjDrefExplicitLodTest_DefaultConstructor = OpFunction %void None %18
+%OpImageSampleProjDrefExplicitLodTest_DefaultConstructor = OpFunction %void None %22
      %self_0 = OpFunctionParameter %_ptr_Function_OpImageSampleProjDrefExplicitLodTest
          %36 = OpLabel
          %37 = OpFunctionCall %void %OpImageSampleProjDrefExplicitLodTest_PreConstructor %self_0
                OpReturn
                OpFunctionEnd
-       %Main = OpFunction %void None %18
+       %Main = OpFunction %void None %22
      %self_1 = OpFunctionParameter %_ptr_Function_OpImageSampleProjDrefExplicitLodTest
          %42 = OpLabel
    %floatVal = OpVariable %_ptr_Function_float Function
@@ -85,7 +85,7 @@
                OpStore %floatVal %60
                OpReturn
                OpFunctionEnd
-%OpImageSampleProjDrefExplicitLodTest_Main_EntryPoint = OpFunction %void None %22
+%OpImageSampleProjDrefExplicitLodTest_Main_EntryPoint = OpFunction %void None %26
          %65 = OpLabel
      %self_2 = OpVariable %_ptr_Function_OpImageSampleProjDrefExplicitLodTest Function
          %67 = OpFunctionCall %void %OpImageSampleProjDrefExplicitLodTest_DefaultConstructor %self_2

--- a/CSShadersTests/Tests/IntrinsicFunctions/Image Intrinsics/SampleProjDrefImplicitLod_IntrinsicTest.expected.spvtxt
+++ b/CSShadersTests/Tests/IntrinsicFunctions/Image Intrinsics/SampleProjDrefImplicitLod_IntrinsicTest.expected.spvtxt
@@ -10,8 +10,11 @@
                OpExecutionMode %OpImageSampleProjDrefImplicitLodTest_Main_EntryPoint OriginUpperLeft
                OpSource Unknown 100
                OpName %FloatImage2d "FloatImage2d"
+               OpName %FloatImage2dVal "FloatImage2dVal"
                OpName %Sampler "Sampler"
+               OpName %SamplerVal "SamplerVal"
                OpName %FloatSampledImage2d "FloatSampledImage2d"
+               OpName %FloatSampledImage2dVal "FloatSampledImage2dVal"
                OpName %OpImageSampleProjDrefImplicitLodTest "OpImageSampleProjDrefImplicitLodTest"
                OpName %Vector3 "Vector3"
                OpName %FloatSampledImage2d "GeneratedSampledImage_CSShaders.ShaderType"
@@ -25,43 +28,40 @@
                OpName %vector3Val "vector3Val"
                OpName %OpImageSampleProjDrefImplicitLodTest_Main_EntryPoint "OpImageSampleProjDrefImplicitLodTest_Main_EntryPoint"
                OpName %self_2 "self"
-               OpName %FloatImage2dVal "FloatImage2dVal"
-               OpName %SamplerVal "SamplerVal"
-               OpName %FloatSampledImage2dVal "FloatSampledImage2dVal"
                OpName %OpImageSampleProjDrefImplicitLodTest_Main_EntryPoint "OpImageSampleProjDrefImplicitLodTest_Main_EntryPoint"
                OpName %self_2 "self"
        %uint = OpTypeInt 32 0
       %float = OpTypeFloat 32
+    %float_0 = OpConstant %float 0
 %FloatImage2d = OpTypeImage %float 2D 0 0 0 1 Unknown
 %_ptr_UniformConstant_FloatImage2d = OpTypePointer UniformConstant %FloatImage2d
+%FloatImage2dVal = OpVariable %_ptr_UniformConstant_FloatImage2d UniformConstant
     %Sampler = OpTypeSampler
 %_ptr_UniformConstant_Sampler = OpTypePointer UniformConstant %Sampler
+ %SamplerVal = OpVariable %_ptr_UniformConstant_Sampler UniformConstant
 %FloatSampledImage2d = OpTypeSampledImage %FloatImage2d
 %_ptr_UniformConstant_FloatSampledImage2d = OpTypePointer UniformConstant %FloatSampledImage2d
+%FloatSampledImage2dVal = OpVariable %_ptr_UniformConstant_FloatSampledImage2d UniformConstant
 %OpImageSampleProjDrefImplicitLodTest = OpTypeStruct
        %void = OpTypeVoid
 %_ptr_Function_OpImageSampleProjDrefImplicitLodTest = OpTypePointer Function %OpImageSampleProjDrefImplicitLodTest
-         %18 = OpTypeFunction %void %_ptr_Function_OpImageSampleProjDrefImplicitLodTest
+         %22 = OpTypeFunction %void %_ptr_Function_OpImageSampleProjDrefImplicitLodTest
 %_ptr_Function_float = OpTypePointer Function %float
     %Vector3 = OpTypeVector %float 3
 %_ptr_Function_Vector3 = OpTypePointer Function %Vector3
-         %22 = OpTypeFunction %void
-    %float_0 = OpConstant %float 0
-%FloatImage2dVal = OpVariable %_ptr_UniformConstant_FloatImage2d UniformConstant
- %SamplerVal = OpVariable %_ptr_UniformConstant_Sampler UniformConstant
-%FloatSampledImage2dVal = OpVariable %_ptr_UniformConstant_FloatSampledImage2d UniformConstant
-%OpImageSampleProjDrefImplicitLodTest_PreConstructor = OpFunction %void None %18
+         %26 = OpTypeFunction %void
+%OpImageSampleProjDrefImplicitLodTest_PreConstructor = OpFunction %void None %22
        %self = OpFunctionParameter %_ptr_Function_OpImageSampleProjDrefImplicitLodTest
          %31 = OpLabel
                OpReturn
                OpFunctionEnd
-%OpImageSampleProjDrefImplicitLodTest_DefaultConstructor = OpFunction %void None %18
+%OpImageSampleProjDrefImplicitLodTest_DefaultConstructor = OpFunction %void None %22
      %self_0 = OpFunctionParameter %_ptr_Function_OpImageSampleProjDrefImplicitLodTest
          %36 = OpLabel
          %37 = OpFunctionCall %void %OpImageSampleProjDrefImplicitLodTest_PreConstructor %self_0
                OpReturn
                OpFunctionEnd
-       %Main = OpFunction %void None %18
+       %Main = OpFunction %void None %22
      %self_1 = OpFunctionParameter %_ptr_Function_OpImageSampleProjDrefImplicitLodTest
          %42 = OpLabel
    %floatVal = OpVariable %_ptr_Function_float Function
@@ -83,7 +83,7 @@
                OpStore %floatVal %58
                OpReturn
                OpFunctionEnd
-%OpImageSampleProjDrefImplicitLodTest_Main_EntryPoint = OpFunction %void None %22
+%OpImageSampleProjDrefImplicitLodTest_Main_EntryPoint = OpFunction %void None %26
          %63 = OpLabel
      %self_2 = OpVariable %_ptr_Function_OpImageSampleProjDrefImplicitLodTest Function
          %65 = OpFunctionCall %void %OpImageSampleProjDrefImplicitLodTest_DefaultConstructor %self_2

--- a/CSShadersTests/Tests/IntrinsicFunctions/Image Intrinsics/SampleProjExplicitLod_IntrinsicTest.expected.spvtxt
+++ b/CSShadersTests/Tests/IntrinsicFunctions/Image Intrinsics/SampleProjExplicitLod_IntrinsicTest.expected.spvtxt
@@ -10,8 +10,11 @@
                OpExecutionMode %OpImageSampleProjExplicitLodTest_Main_EntryPoint OriginUpperLeft
                OpSource Unknown 100
                OpName %FloatImage2d "FloatImage2d"
+               OpName %FloatImage2dVal "FloatImage2dVal"
                OpName %Sampler "Sampler"
+               OpName %SamplerVal "SamplerVal"
                OpName %FloatSampledImage2d "FloatSampledImage2d"
+               OpName %FloatSampledImage2dVal "FloatSampledImage2dVal"
                OpName %OpImageSampleProjExplicitLodTest "OpImageSampleProjExplicitLodTest"
                OpName %Vector4 "Vector4"
                OpName %Vector3 "Vector3"
@@ -27,45 +30,42 @@
                OpName %floatVal "floatVal"
                OpName %OpImageSampleProjExplicitLodTest_Main_EntryPoint "OpImageSampleProjExplicitLodTest_Main_EntryPoint"
                OpName %self_2 "self"
-               OpName %FloatImage2dVal "FloatImage2dVal"
-               OpName %SamplerVal "SamplerVal"
-               OpName %FloatSampledImage2dVal "FloatSampledImage2dVal"
                OpName %OpImageSampleProjExplicitLodTest_Main_EntryPoint "OpImageSampleProjExplicitLodTest_Main_EntryPoint"
                OpName %self_2 "self"
        %uint = OpTypeInt 32 0
       %float = OpTypeFloat 32
+    %float_0 = OpConstant %float 0
 %FloatImage2d = OpTypeImage %float 2D 0 0 0 1 Unknown
 %_ptr_UniformConstant_FloatImage2d = OpTypePointer UniformConstant %FloatImage2d
+%FloatImage2dVal = OpVariable %_ptr_UniformConstant_FloatImage2d UniformConstant
     %Sampler = OpTypeSampler
 %_ptr_UniformConstant_Sampler = OpTypePointer UniformConstant %Sampler
+ %SamplerVal = OpVariable %_ptr_UniformConstant_Sampler UniformConstant
 %FloatSampledImage2d = OpTypeSampledImage %FloatImage2d
 %_ptr_UniformConstant_FloatSampledImage2d = OpTypePointer UniformConstant %FloatSampledImage2d
+%FloatSampledImage2dVal = OpVariable %_ptr_UniformConstant_FloatSampledImage2d UniformConstant
 %OpImageSampleProjExplicitLodTest = OpTypeStruct
        %void = OpTypeVoid
 %_ptr_Function_OpImageSampleProjExplicitLodTest = OpTypePointer Function %OpImageSampleProjExplicitLodTest
-         %18 = OpTypeFunction %void %_ptr_Function_OpImageSampleProjExplicitLodTest
+         %22 = OpTypeFunction %void %_ptr_Function_OpImageSampleProjExplicitLodTest
     %Vector4 = OpTypeVector %float 4
 %_ptr_Function_Vector4 = OpTypePointer Function %Vector4
     %Vector3 = OpTypeVector %float 3
 %_ptr_Function_Vector3 = OpTypePointer Function %Vector3
 %_ptr_Function_float = OpTypePointer Function %float
-         %24 = OpTypeFunction %void
-    %float_0 = OpConstant %float 0
-%FloatImage2dVal = OpVariable %_ptr_UniformConstant_FloatImage2d UniformConstant
- %SamplerVal = OpVariable %_ptr_UniformConstant_Sampler UniformConstant
-%FloatSampledImage2dVal = OpVariable %_ptr_UniformConstant_FloatSampledImage2d UniformConstant
-%OpImageSampleProjExplicitLodTest_PreConstructor = OpFunction %void None %18
+         %28 = OpTypeFunction %void
+%OpImageSampleProjExplicitLodTest_PreConstructor = OpFunction %void None %22
        %self = OpFunctionParameter %_ptr_Function_OpImageSampleProjExplicitLodTest
          %33 = OpLabel
                OpReturn
                OpFunctionEnd
-%OpImageSampleProjExplicitLodTest_DefaultConstructor = OpFunction %void None %18
+%OpImageSampleProjExplicitLodTest_DefaultConstructor = OpFunction %void None %22
      %self_0 = OpFunctionParameter %_ptr_Function_OpImageSampleProjExplicitLodTest
          %38 = OpLabel
          %39 = OpFunctionCall %void %OpImageSampleProjExplicitLodTest_PreConstructor %self_0
                OpReturn
                OpFunctionEnd
-       %Main = OpFunction %void None %18
+       %Main = OpFunction %void None %22
      %self_1 = OpFunctionParameter %_ptr_Function_OpImageSampleProjExplicitLodTest
          %44 = OpLabel
  %vector4Val = OpVariable %_ptr_Function_Vector4 Function
@@ -90,7 +90,7 @@
                OpStore %vector4Val %63
                OpReturn
                OpFunctionEnd
-%OpImageSampleProjExplicitLodTest_Main_EntryPoint = OpFunction %void None %24
+%OpImageSampleProjExplicitLodTest_Main_EntryPoint = OpFunction %void None %28
          %68 = OpLabel
      %self_2 = OpVariable %_ptr_Function_OpImageSampleProjExplicitLodTest Function
          %70 = OpFunctionCall %void %OpImageSampleProjExplicitLodTest_DefaultConstructor %self_2

--- a/CSShadersTests/Tests/IntrinsicFunctions/Image Intrinsics/SampleProjImplicitLod_IntrinsicTest.expected.spvtxt
+++ b/CSShadersTests/Tests/IntrinsicFunctions/Image Intrinsics/SampleProjImplicitLod_IntrinsicTest.expected.spvtxt
@@ -10,8 +10,11 @@
                OpExecutionMode %OpImageSampleProjImplicitLodTest_Main_EntryPoint OriginUpperLeft
                OpSource Unknown 100
                OpName %FloatImage2d "FloatImage2d"
+               OpName %FloatImage2dVal "FloatImage2dVal"
                OpName %Sampler "Sampler"
+               OpName %SamplerVal "SamplerVal"
                OpName %FloatSampledImage2d "FloatSampledImage2d"
+               OpName %FloatSampledImage2dVal "FloatSampledImage2dVal"
                OpName %OpImageSampleProjImplicitLodTest "OpImageSampleProjImplicitLodTest"
                OpName %Vector4 "Vector4"
                OpName %Vector3 "Vector3"
@@ -26,44 +29,41 @@
                OpName %vector3Val "vector3Val"
                OpName %OpImageSampleProjImplicitLodTest_Main_EntryPoint "OpImageSampleProjImplicitLodTest_Main_EntryPoint"
                OpName %self_2 "self"
-               OpName %FloatImage2dVal "FloatImage2dVal"
-               OpName %SamplerVal "SamplerVal"
-               OpName %FloatSampledImage2dVal "FloatSampledImage2dVal"
                OpName %OpImageSampleProjImplicitLodTest_Main_EntryPoint "OpImageSampleProjImplicitLodTest_Main_EntryPoint"
                OpName %self_2 "self"
        %uint = OpTypeInt 32 0
       %float = OpTypeFloat 32
+    %float_0 = OpConstant %float 0
 %FloatImage2d = OpTypeImage %float 2D 0 0 0 1 Unknown
 %_ptr_UniformConstant_FloatImage2d = OpTypePointer UniformConstant %FloatImage2d
+%FloatImage2dVal = OpVariable %_ptr_UniformConstant_FloatImage2d UniformConstant
     %Sampler = OpTypeSampler
 %_ptr_UniformConstant_Sampler = OpTypePointer UniformConstant %Sampler
+ %SamplerVal = OpVariable %_ptr_UniformConstant_Sampler UniformConstant
 %FloatSampledImage2d = OpTypeSampledImage %FloatImage2d
 %_ptr_UniformConstant_FloatSampledImage2d = OpTypePointer UniformConstant %FloatSampledImage2d
+%FloatSampledImage2dVal = OpVariable %_ptr_UniformConstant_FloatSampledImage2d UniformConstant
 %OpImageSampleProjImplicitLodTest = OpTypeStruct
        %void = OpTypeVoid
 %_ptr_Function_OpImageSampleProjImplicitLodTest = OpTypePointer Function %OpImageSampleProjImplicitLodTest
-         %18 = OpTypeFunction %void %_ptr_Function_OpImageSampleProjImplicitLodTest
+         %22 = OpTypeFunction %void %_ptr_Function_OpImageSampleProjImplicitLodTest
     %Vector4 = OpTypeVector %float 4
 %_ptr_Function_Vector4 = OpTypePointer Function %Vector4
     %Vector3 = OpTypeVector %float 3
 %_ptr_Function_Vector3 = OpTypePointer Function %Vector3
-         %24 = OpTypeFunction %void
-    %float_0 = OpConstant %float 0
-%FloatImage2dVal = OpVariable %_ptr_UniformConstant_FloatImage2d UniformConstant
- %SamplerVal = OpVariable %_ptr_UniformConstant_Sampler UniformConstant
-%FloatSampledImage2dVal = OpVariable %_ptr_UniformConstant_FloatSampledImage2d UniformConstant
-%OpImageSampleProjImplicitLodTest_PreConstructor = OpFunction %void None %18
+         %28 = OpTypeFunction %void
+%OpImageSampleProjImplicitLodTest_PreConstructor = OpFunction %void None %22
        %self = OpFunctionParameter %_ptr_Function_OpImageSampleProjImplicitLodTest
          %33 = OpLabel
                OpReturn
                OpFunctionEnd
-%OpImageSampleProjImplicitLodTest_DefaultConstructor = OpFunction %void None %18
+%OpImageSampleProjImplicitLodTest_DefaultConstructor = OpFunction %void None %22
      %self_0 = OpFunctionParameter %_ptr_Function_OpImageSampleProjImplicitLodTest
          %38 = OpLabel
          %39 = OpFunctionCall %void %OpImageSampleProjImplicitLodTest_PreConstructor %self_0
                OpReturn
                OpFunctionEnd
-       %Main = OpFunction %void None %18
+       %Main = OpFunction %void None %22
      %self_1 = OpFunctionParameter %_ptr_Function_OpImageSampleProjImplicitLodTest
          %44 = OpLabel
  %vector4Val = OpVariable %_ptr_Function_Vector4 Function
@@ -84,7 +84,7 @@
                OpStore %vector4Val %59
                OpReturn
                OpFunctionEnd
-%OpImageSampleProjImplicitLodTest_Main_EntryPoint = OpFunction %void None %24
+%OpImageSampleProjImplicitLodTest_Main_EntryPoint = OpFunction %void None %28
          %64 = OpLabel
      %self_2 = OpVariable %_ptr_Function_OpImageSampleProjImplicitLodTest Function
          %66 = OpFunctionCall %void %OpImageSampleProjImplicitLodTest_DefaultConstructor %self_2

--- a/CSShadersTests/Tests/IntrinsicFunctions/Relational and Logical Intrinsics/OpAll_IntrinsicTest.expected.spvtxt
+++ b/CSShadersTests/Tests/IntrinsicFunctions/Relational and Logical Intrinsics/OpAll_IntrinsicTest.expected.spvtxt
@@ -28,10 +28,11 @@
                OpName %OpAllTest_Main_EntryPoint "OpAllTest_Main_EntryPoint"
                OpName %self_2 "self"
        %bool = OpTypeBool
+      %false = OpConstantFalse %bool
   %OpAllTest = OpTypeStruct
        %void = OpTypeVoid
 %_ptr_Function_OpAllTest = OpTypePointer Function %OpAllTest
-          %7 = OpTypeFunction %void %_ptr_Function_OpAllTest
+          %8 = OpTypeFunction %void %_ptr_Function_OpAllTest
 %_ptr_Function_bool = OpTypePointer Function %bool
        %uint = OpTypeInt 32 0
       %Bool2 = OpTypeVector %bool 2
@@ -40,20 +41,19 @@
 %_ptr_Function_Bool3 = OpTypePointer Function %Bool3
       %Bool4 = OpTypeVector %bool 4
 %_ptr_Function_Bool4 = OpTypePointer Function %Bool4
-         %17 = OpTypeFunction %void
-      %false = OpConstantFalse %bool
-%OpAllTest_PreConstructor = OpFunction %void None %7
+         %18 = OpTypeFunction %void
+%OpAllTest_PreConstructor = OpFunction %void None %8
        %self = OpFunctionParameter %_ptr_Function_OpAllTest
          %23 = OpLabel
                OpReturn
                OpFunctionEnd
-%OpAllTest_DefaultConstructor = OpFunction %void None %7
+%OpAllTest_DefaultConstructor = OpFunction %void None %8
      %self_0 = OpFunctionParameter %_ptr_Function_OpAllTest
          %28 = OpLabel
          %29 = OpFunctionCall %void %OpAllTest_PreConstructor %self_0
                OpReturn
                OpFunctionEnd
-       %Main = OpFunction %void None %7
+       %Main = OpFunction %void None %8
      %self_1 = OpFunctionParameter %_ptr_Function_OpAllTest
          %34 = OpLabel
     %boolVal = OpVariable %_ptr_Function_bool Function
@@ -78,7 +78,7 @@
                OpStore %boolVal %53
                OpReturn
                OpFunctionEnd
-%OpAllTest_Main_EntryPoint = OpFunction %void None %17
+%OpAllTest_Main_EntryPoint = OpFunction %void None %18
          %58 = OpLabel
      %self_2 = OpVariable %_ptr_Function_OpAllTest Function
          %60 = OpFunctionCall %void %OpAllTest_DefaultConstructor %self_2

--- a/CSShadersTests/Tests/IntrinsicFunctions/Relational and Logical Intrinsics/OpAny_IntrinsicTest.expected.spvtxt
+++ b/CSShadersTests/Tests/IntrinsicFunctions/Relational and Logical Intrinsics/OpAny_IntrinsicTest.expected.spvtxt
@@ -28,10 +28,11 @@
                OpName %OpAnyTest_Main_EntryPoint "OpAnyTest_Main_EntryPoint"
                OpName %self_2 "self"
        %bool = OpTypeBool
+      %false = OpConstantFalse %bool
   %OpAnyTest = OpTypeStruct
        %void = OpTypeVoid
 %_ptr_Function_OpAnyTest = OpTypePointer Function %OpAnyTest
-          %7 = OpTypeFunction %void %_ptr_Function_OpAnyTest
+          %8 = OpTypeFunction %void %_ptr_Function_OpAnyTest
 %_ptr_Function_bool = OpTypePointer Function %bool
        %uint = OpTypeInt 32 0
       %Bool2 = OpTypeVector %bool 2
@@ -40,20 +41,19 @@
 %_ptr_Function_Bool3 = OpTypePointer Function %Bool3
       %Bool4 = OpTypeVector %bool 4
 %_ptr_Function_Bool4 = OpTypePointer Function %Bool4
-         %17 = OpTypeFunction %void
-      %false = OpConstantFalse %bool
-%OpAnyTest_PreConstructor = OpFunction %void None %7
+         %18 = OpTypeFunction %void
+%OpAnyTest_PreConstructor = OpFunction %void None %8
        %self = OpFunctionParameter %_ptr_Function_OpAnyTest
          %23 = OpLabel
                OpReturn
                OpFunctionEnd
-%OpAnyTest_DefaultConstructor = OpFunction %void None %7
+%OpAnyTest_DefaultConstructor = OpFunction %void None %8
      %self_0 = OpFunctionParameter %_ptr_Function_OpAnyTest
          %28 = OpLabel
          %29 = OpFunctionCall %void %OpAnyTest_PreConstructor %self_0
                OpReturn
                OpFunctionEnd
-       %Main = OpFunction %void None %7
+       %Main = OpFunction %void None %8
      %self_1 = OpFunctionParameter %_ptr_Function_OpAnyTest
          %34 = OpLabel
     %boolVal = OpVariable %_ptr_Function_bool Function
@@ -78,7 +78,7 @@
                OpStore %boolVal %53
                OpReturn
                OpFunctionEnd
-%OpAnyTest_Main_EntryPoint = OpFunction %void None %17
+%OpAnyTest_Main_EntryPoint = OpFunction %void None %18
          %58 = OpLabel
      %self_2 = OpVariable %_ptr_Function_OpAnyTest Function
          %60 = OpFunctionCall %void %OpAnyTest_DefaultConstructor %self_2

--- a/CSShadersTests/Tests/IntrinsicFunctions/Relational and Logical Intrinsics/OpFOrdEqual_IntrinsicTest.expected.spvtxt
+++ b/CSShadersTests/Tests/IntrinsicFunctions/Relational and Logical Intrinsics/OpFOrdEqual_IntrinsicTest.expected.spvtxt
@@ -35,12 +35,14 @@
                OpName %OpFOrdEqualTest_Main_EntryPoint "OpFOrdEqualTest_Main_EntryPoint"
                OpName %self_2 "self"
        %bool = OpTypeBool
+      %false = OpConstantFalse %bool
        %uint = OpTypeInt 32 0
       %float = OpTypeFloat 32
+    %float_0 = OpConstant %float 0
 %OpFOrdEqualTest = OpTypeStruct
        %void = OpTypeVoid
 %_ptr_Function_OpFOrdEqualTest = OpTypePointer Function %OpFOrdEqualTest
-         %11 = OpTypeFunction %void %_ptr_Function_OpFOrdEqualTest
+         %13 = OpTypeFunction %void %_ptr_Function_OpFOrdEqualTest
 %_ptr_Function_bool = OpTypePointer Function %bool
 %_ptr_Function_float = OpTypePointer Function %float
       %Bool2 = OpTypeVector %bool 2
@@ -55,21 +57,19 @@
 %_ptr_Function_Bool4 = OpTypePointer Function %Bool4
     %Vector4 = OpTypeVector %float 4
 %_ptr_Function_Vector4 = OpTypePointer Function %Vector4
-         %25 = OpTypeFunction %void
-      %false = OpConstantFalse %bool
-    %float_0 = OpConstant %float 0
-%OpFOrdEqualTest_PreConstructor = OpFunction %void None %11
+         %27 = OpTypeFunction %void
+%OpFOrdEqualTest_PreConstructor = OpFunction %void None %13
        %self = OpFunctionParameter %_ptr_Function_OpFOrdEqualTest
          %32 = OpLabel
                OpReturn
                OpFunctionEnd
-%OpFOrdEqualTest_DefaultConstructor = OpFunction %void None %11
+%OpFOrdEqualTest_DefaultConstructor = OpFunction %void None %13
      %self_0 = OpFunctionParameter %_ptr_Function_OpFOrdEqualTest
          %37 = OpLabel
          %38 = OpFunctionCall %void %OpFOrdEqualTest_PreConstructor %self_0
                OpReturn
                OpFunctionEnd
-       %Main = OpFunction %void None %11
+       %Main = OpFunction %void None %13
      %self_1 = OpFunctionParameter %_ptr_Function_OpFOrdEqualTest
          %43 = OpLabel
     %boolVal = OpVariable %_ptr_Function_bool Function
@@ -112,7 +112,7 @@
                OpStore %bool4Val %80
                OpReturn
                OpFunctionEnd
-%OpFOrdEqualTest_Main_EntryPoint = OpFunction %void None %25
+%OpFOrdEqualTest_Main_EntryPoint = OpFunction %void None %27
          %85 = OpLabel
      %self_2 = OpVariable %_ptr_Function_OpFOrdEqualTest Function
          %87 = OpFunctionCall %void %OpFOrdEqualTest_DefaultConstructor %self_2

--- a/CSShadersTests/Tests/IntrinsicFunctions/Relational and Logical Intrinsics/OpFOrdGreaterThanEqual_IntrinsicTest.expected.spvtxt
+++ b/CSShadersTests/Tests/IntrinsicFunctions/Relational and Logical Intrinsics/OpFOrdGreaterThanEqual_IntrinsicTest.expected.spvtxt
@@ -35,12 +35,14 @@
                OpName %OpFOrdGreaterThanEqualTest_Main_EntryPoint "OpFOrdGreaterThanEqualTest_Main_EntryPoint"
                OpName %self_2 "self"
        %bool = OpTypeBool
+      %false = OpConstantFalse %bool
        %uint = OpTypeInt 32 0
       %float = OpTypeFloat 32
+    %float_0 = OpConstant %float 0
 %OpFOrdGreaterThanEqualTest = OpTypeStruct
        %void = OpTypeVoid
 %_ptr_Function_OpFOrdGreaterThanEqualTest = OpTypePointer Function %OpFOrdGreaterThanEqualTest
-         %11 = OpTypeFunction %void %_ptr_Function_OpFOrdGreaterThanEqualTest
+         %13 = OpTypeFunction %void %_ptr_Function_OpFOrdGreaterThanEqualTest
 %_ptr_Function_bool = OpTypePointer Function %bool
 %_ptr_Function_float = OpTypePointer Function %float
       %Bool2 = OpTypeVector %bool 2
@@ -55,21 +57,19 @@
 %_ptr_Function_Bool4 = OpTypePointer Function %Bool4
     %Vector4 = OpTypeVector %float 4
 %_ptr_Function_Vector4 = OpTypePointer Function %Vector4
-         %25 = OpTypeFunction %void
-      %false = OpConstantFalse %bool
-    %float_0 = OpConstant %float 0
-%OpFOrdGreaterThanEqualTest_PreConstructor = OpFunction %void None %11
+         %27 = OpTypeFunction %void
+%OpFOrdGreaterThanEqualTest_PreConstructor = OpFunction %void None %13
        %self = OpFunctionParameter %_ptr_Function_OpFOrdGreaterThanEqualTest
          %32 = OpLabel
                OpReturn
                OpFunctionEnd
-%OpFOrdGreaterThanEqualTest_DefaultConstructor = OpFunction %void None %11
+%OpFOrdGreaterThanEqualTest_DefaultConstructor = OpFunction %void None %13
      %self_0 = OpFunctionParameter %_ptr_Function_OpFOrdGreaterThanEqualTest
          %37 = OpLabel
          %38 = OpFunctionCall %void %OpFOrdGreaterThanEqualTest_PreConstructor %self_0
                OpReturn
                OpFunctionEnd
-       %Main = OpFunction %void None %11
+       %Main = OpFunction %void None %13
      %self_1 = OpFunctionParameter %_ptr_Function_OpFOrdGreaterThanEqualTest
          %43 = OpLabel
     %boolVal = OpVariable %_ptr_Function_bool Function
@@ -112,7 +112,7 @@
                OpStore %bool4Val %80
                OpReturn
                OpFunctionEnd
-%OpFOrdGreaterThanEqualTest_Main_EntryPoint = OpFunction %void None %25
+%OpFOrdGreaterThanEqualTest_Main_EntryPoint = OpFunction %void None %27
          %85 = OpLabel
      %self_2 = OpVariable %_ptr_Function_OpFOrdGreaterThanEqualTest Function
          %87 = OpFunctionCall %void %OpFOrdGreaterThanEqualTest_DefaultConstructor %self_2

--- a/CSShadersTests/Tests/IntrinsicFunctions/Relational and Logical Intrinsics/OpFOrdGreaterThan_IntrinsicTest.expected.spvtxt
+++ b/CSShadersTests/Tests/IntrinsicFunctions/Relational and Logical Intrinsics/OpFOrdGreaterThan_IntrinsicTest.expected.spvtxt
@@ -35,12 +35,14 @@
                OpName %OpFOrdGreaterThanTest_Main_EntryPoint "OpFOrdGreaterThanTest_Main_EntryPoint"
                OpName %self_2 "self"
        %bool = OpTypeBool
+      %false = OpConstantFalse %bool
        %uint = OpTypeInt 32 0
       %float = OpTypeFloat 32
+    %float_0 = OpConstant %float 0
 %OpFOrdGreaterThanTest = OpTypeStruct
        %void = OpTypeVoid
 %_ptr_Function_OpFOrdGreaterThanTest = OpTypePointer Function %OpFOrdGreaterThanTest
-         %11 = OpTypeFunction %void %_ptr_Function_OpFOrdGreaterThanTest
+         %13 = OpTypeFunction %void %_ptr_Function_OpFOrdGreaterThanTest
 %_ptr_Function_bool = OpTypePointer Function %bool
 %_ptr_Function_float = OpTypePointer Function %float
       %Bool2 = OpTypeVector %bool 2
@@ -55,21 +57,19 @@
 %_ptr_Function_Bool4 = OpTypePointer Function %Bool4
     %Vector4 = OpTypeVector %float 4
 %_ptr_Function_Vector4 = OpTypePointer Function %Vector4
-         %25 = OpTypeFunction %void
-      %false = OpConstantFalse %bool
-    %float_0 = OpConstant %float 0
-%OpFOrdGreaterThanTest_PreConstructor = OpFunction %void None %11
+         %27 = OpTypeFunction %void
+%OpFOrdGreaterThanTest_PreConstructor = OpFunction %void None %13
        %self = OpFunctionParameter %_ptr_Function_OpFOrdGreaterThanTest
          %32 = OpLabel
                OpReturn
                OpFunctionEnd
-%OpFOrdGreaterThanTest_DefaultConstructor = OpFunction %void None %11
+%OpFOrdGreaterThanTest_DefaultConstructor = OpFunction %void None %13
      %self_0 = OpFunctionParameter %_ptr_Function_OpFOrdGreaterThanTest
          %37 = OpLabel
          %38 = OpFunctionCall %void %OpFOrdGreaterThanTest_PreConstructor %self_0
                OpReturn
                OpFunctionEnd
-       %Main = OpFunction %void None %11
+       %Main = OpFunction %void None %13
      %self_1 = OpFunctionParameter %_ptr_Function_OpFOrdGreaterThanTest
          %43 = OpLabel
     %boolVal = OpVariable %_ptr_Function_bool Function
@@ -112,7 +112,7 @@
                OpStore %bool4Val %80
                OpReturn
                OpFunctionEnd
-%OpFOrdGreaterThanTest_Main_EntryPoint = OpFunction %void None %25
+%OpFOrdGreaterThanTest_Main_EntryPoint = OpFunction %void None %27
          %85 = OpLabel
      %self_2 = OpVariable %_ptr_Function_OpFOrdGreaterThanTest Function
          %87 = OpFunctionCall %void %OpFOrdGreaterThanTest_DefaultConstructor %self_2

--- a/CSShadersTests/Tests/IntrinsicFunctions/Relational and Logical Intrinsics/OpFOrdLessThanEqual_IntrinsicTest.expected.spvtxt
+++ b/CSShadersTests/Tests/IntrinsicFunctions/Relational and Logical Intrinsics/OpFOrdLessThanEqual_IntrinsicTest.expected.spvtxt
@@ -35,12 +35,14 @@
                OpName %OpFOrdLessThanEqualTest_Main_EntryPoint "OpFOrdLessThanEqualTest_Main_EntryPoint"
                OpName %self_2 "self"
        %bool = OpTypeBool
+      %false = OpConstantFalse %bool
        %uint = OpTypeInt 32 0
       %float = OpTypeFloat 32
+    %float_0 = OpConstant %float 0
 %OpFOrdLessThanEqualTest = OpTypeStruct
        %void = OpTypeVoid
 %_ptr_Function_OpFOrdLessThanEqualTest = OpTypePointer Function %OpFOrdLessThanEqualTest
-         %11 = OpTypeFunction %void %_ptr_Function_OpFOrdLessThanEqualTest
+         %13 = OpTypeFunction %void %_ptr_Function_OpFOrdLessThanEqualTest
 %_ptr_Function_bool = OpTypePointer Function %bool
 %_ptr_Function_float = OpTypePointer Function %float
       %Bool2 = OpTypeVector %bool 2
@@ -55,21 +57,19 @@
 %_ptr_Function_Bool4 = OpTypePointer Function %Bool4
     %Vector4 = OpTypeVector %float 4
 %_ptr_Function_Vector4 = OpTypePointer Function %Vector4
-         %25 = OpTypeFunction %void
-      %false = OpConstantFalse %bool
-    %float_0 = OpConstant %float 0
-%OpFOrdLessThanEqualTest_PreConstructor = OpFunction %void None %11
+         %27 = OpTypeFunction %void
+%OpFOrdLessThanEqualTest_PreConstructor = OpFunction %void None %13
        %self = OpFunctionParameter %_ptr_Function_OpFOrdLessThanEqualTest
          %32 = OpLabel
                OpReturn
                OpFunctionEnd
-%OpFOrdLessThanEqualTest_DefaultConstructor = OpFunction %void None %11
+%OpFOrdLessThanEqualTest_DefaultConstructor = OpFunction %void None %13
      %self_0 = OpFunctionParameter %_ptr_Function_OpFOrdLessThanEqualTest
          %37 = OpLabel
          %38 = OpFunctionCall %void %OpFOrdLessThanEqualTest_PreConstructor %self_0
                OpReturn
                OpFunctionEnd
-       %Main = OpFunction %void None %11
+       %Main = OpFunction %void None %13
      %self_1 = OpFunctionParameter %_ptr_Function_OpFOrdLessThanEqualTest
          %43 = OpLabel
     %boolVal = OpVariable %_ptr_Function_bool Function
@@ -112,7 +112,7 @@
                OpStore %bool4Val %80
                OpReturn
                OpFunctionEnd
-%OpFOrdLessThanEqualTest_Main_EntryPoint = OpFunction %void None %25
+%OpFOrdLessThanEqualTest_Main_EntryPoint = OpFunction %void None %27
          %85 = OpLabel
      %self_2 = OpVariable %_ptr_Function_OpFOrdLessThanEqualTest Function
          %87 = OpFunctionCall %void %OpFOrdLessThanEqualTest_DefaultConstructor %self_2

--- a/CSShadersTests/Tests/IntrinsicFunctions/Relational and Logical Intrinsics/OpFOrdLessThan_IntrinsicTest.expected.spvtxt
+++ b/CSShadersTests/Tests/IntrinsicFunctions/Relational and Logical Intrinsics/OpFOrdLessThan_IntrinsicTest.expected.spvtxt
@@ -35,12 +35,14 @@
                OpName %OpFOrdLessThanTest_Main_EntryPoint "OpFOrdLessThanTest_Main_EntryPoint"
                OpName %self_2 "self"
        %bool = OpTypeBool
+      %false = OpConstantFalse %bool
        %uint = OpTypeInt 32 0
       %float = OpTypeFloat 32
+    %float_0 = OpConstant %float 0
 %OpFOrdLessThanTest = OpTypeStruct
        %void = OpTypeVoid
 %_ptr_Function_OpFOrdLessThanTest = OpTypePointer Function %OpFOrdLessThanTest
-         %11 = OpTypeFunction %void %_ptr_Function_OpFOrdLessThanTest
+         %13 = OpTypeFunction %void %_ptr_Function_OpFOrdLessThanTest
 %_ptr_Function_bool = OpTypePointer Function %bool
 %_ptr_Function_float = OpTypePointer Function %float
       %Bool2 = OpTypeVector %bool 2
@@ -55,21 +57,19 @@
 %_ptr_Function_Bool4 = OpTypePointer Function %Bool4
     %Vector4 = OpTypeVector %float 4
 %_ptr_Function_Vector4 = OpTypePointer Function %Vector4
-         %25 = OpTypeFunction %void
-      %false = OpConstantFalse %bool
-    %float_0 = OpConstant %float 0
-%OpFOrdLessThanTest_PreConstructor = OpFunction %void None %11
+         %27 = OpTypeFunction %void
+%OpFOrdLessThanTest_PreConstructor = OpFunction %void None %13
        %self = OpFunctionParameter %_ptr_Function_OpFOrdLessThanTest
          %32 = OpLabel
                OpReturn
                OpFunctionEnd
-%OpFOrdLessThanTest_DefaultConstructor = OpFunction %void None %11
+%OpFOrdLessThanTest_DefaultConstructor = OpFunction %void None %13
      %self_0 = OpFunctionParameter %_ptr_Function_OpFOrdLessThanTest
          %37 = OpLabel
          %38 = OpFunctionCall %void %OpFOrdLessThanTest_PreConstructor %self_0
                OpReturn
                OpFunctionEnd
-       %Main = OpFunction %void None %11
+       %Main = OpFunction %void None %13
      %self_1 = OpFunctionParameter %_ptr_Function_OpFOrdLessThanTest
          %43 = OpLabel
     %boolVal = OpVariable %_ptr_Function_bool Function
@@ -112,7 +112,7 @@
                OpStore %bool4Val %80
                OpReturn
                OpFunctionEnd
-%OpFOrdLessThanTest_Main_EntryPoint = OpFunction %void None %25
+%OpFOrdLessThanTest_Main_EntryPoint = OpFunction %void None %27
          %85 = OpLabel
      %self_2 = OpVariable %_ptr_Function_OpFOrdLessThanTest Function
          %87 = OpFunctionCall %void %OpFOrdLessThanTest_DefaultConstructor %self_2

--- a/CSShadersTests/Tests/IntrinsicFunctions/Relational and Logical Intrinsics/OpFOrdNotEqual_IntrinsicTest.expected.spvtxt
+++ b/CSShadersTests/Tests/IntrinsicFunctions/Relational and Logical Intrinsics/OpFOrdNotEqual_IntrinsicTest.expected.spvtxt
@@ -35,12 +35,14 @@
                OpName %OpFOrdNotEqualTest_Main_EntryPoint "OpFOrdNotEqualTest_Main_EntryPoint"
                OpName %self_2 "self"
        %bool = OpTypeBool
+      %false = OpConstantFalse %bool
        %uint = OpTypeInt 32 0
       %float = OpTypeFloat 32
+    %float_0 = OpConstant %float 0
 %OpFOrdNotEqualTest = OpTypeStruct
        %void = OpTypeVoid
 %_ptr_Function_OpFOrdNotEqualTest = OpTypePointer Function %OpFOrdNotEqualTest
-         %11 = OpTypeFunction %void %_ptr_Function_OpFOrdNotEqualTest
+         %13 = OpTypeFunction %void %_ptr_Function_OpFOrdNotEqualTest
 %_ptr_Function_bool = OpTypePointer Function %bool
 %_ptr_Function_float = OpTypePointer Function %float
       %Bool2 = OpTypeVector %bool 2
@@ -55,21 +57,19 @@
 %_ptr_Function_Bool4 = OpTypePointer Function %Bool4
     %Vector4 = OpTypeVector %float 4
 %_ptr_Function_Vector4 = OpTypePointer Function %Vector4
-         %25 = OpTypeFunction %void
-      %false = OpConstantFalse %bool
-    %float_0 = OpConstant %float 0
-%OpFOrdNotEqualTest_PreConstructor = OpFunction %void None %11
+         %27 = OpTypeFunction %void
+%OpFOrdNotEqualTest_PreConstructor = OpFunction %void None %13
        %self = OpFunctionParameter %_ptr_Function_OpFOrdNotEqualTest
          %32 = OpLabel
                OpReturn
                OpFunctionEnd
-%OpFOrdNotEqualTest_DefaultConstructor = OpFunction %void None %11
+%OpFOrdNotEqualTest_DefaultConstructor = OpFunction %void None %13
      %self_0 = OpFunctionParameter %_ptr_Function_OpFOrdNotEqualTest
          %37 = OpLabel
          %38 = OpFunctionCall %void %OpFOrdNotEqualTest_PreConstructor %self_0
                OpReturn
                OpFunctionEnd
-       %Main = OpFunction %void None %11
+       %Main = OpFunction %void None %13
      %self_1 = OpFunctionParameter %_ptr_Function_OpFOrdNotEqualTest
          %43 = OpLabel
     %boolVal = OpVariable %_ptr_Function_bool Function
@@ -112,7 +112,7 @@
                OpStore %bool4Val %80
                OpReturn
                OpFunctionEnd
-%OpFOrdNotEqualTest_Main_EntryPoint = OpFunction %void None %25
+%OpFOrdNotEqualTest_Main_EntryPoint = OpFunction %void None %27
          %85 = OpLabel
      %self_2 = OpVariable %_ptr_Function_OpFOrdNotEqualTest Function
          %87 = OpFunctionCall %void %OpFOrdNotEqualTest_DefaultConstructor %self_2

--- a/CSShadersTests/Tests/IntrinsicFunctions/Relational and Logical Intrinsics/OpIEqual_IntrinsicTest.expected.spvtxt
+++ b/CSShadersTests/Tests/IntrinsicFunctions/Relational and Logical Intrinsics/OpIEqual_IntrinsicTest.expected.spvtxt
@@ -35,12 +35,14 @@
                OpName %OpIEqualTest_Main_EntryPoint "OpIEqualTest_Main_EntryPoint"
                OpName %self_2 "self"
        %bool = OpTypeBool
+      %false = OpConstantFalse %bool
        %uint = OpTypeInt 32 0
         %int = OpTypeInt 32 1
+      %int_0 = OpConstant %int 0
 %OpIEqualTest = OpTypeStruct
        %void = OpTypeVoid
 %_ptr_Function_OpIEqualTest = OpTypePointer Function %OpIEqualTest
-         %11 = OpTypeFunction %void %_ptr_Function_OpIEqualTest
+         %13 = OpTypeFunction %void %_ptr_Function_OpIEqualTest
 %_ptr_Function_bool = OpTypePointer Function %bool
 %_ptr_Function_int = OpTypePointer Function %int
       %Bool2 = OpTypeVector %bool 2
@@ -55,21 +57,19 @@
 %_ptr_Function_Bool4 = OpTypePointer Function %Bool4
    %Integer4 = OpTypeVector %int 4
 %_ptr_Function_Integer4 = OpTypePointer Function %Integer4
-         %25 = OpTypeFunction %void
-      %false = OpConstantFalse %bool
-      %int_0 = OpConstant %int 0
-%OpIEqualTest_PreConstructor = OpFunction %void None %11
+         %27 = OpTypeFunction %void
+%OpIEqualTest_PreConstructor = OpFunction %void None %13
        %self = OpFunctionParameter %_ptr_Function_OpIEqualTest
          %32 = OpLabel
                OpReturn
                OpFunctionEnd
-%OpIEqualTest_DefaultConstructor = OpFunction %void None %11
+%OpIEqualTest_DefaultConstructor = OpFunction %void None %13
      %self_0 = OpFunctionParameter %_ptr_Function_OpIEqualTest
          %37 = OpLabel
          %38 = OpFunctionCall %void %OpIEqualTest_PreConstructor %self_0
                OpReturn
                OpFunctionEnd
-       %Main = OpFunction %void None %11
+       %Main = OpFunction %void None %13
      %self_1 = OpFunctionParameter %_ptr_Function_OpIEqualTest
          %43 = OpLabel
     %boolVal = OpVariable %_ptr_Function_bool Function
@@ -112,7 +112,7 @@
                OpStore %bool4Val %80
                OpReturn
                OpFunctionEnd
-%OpIEqualTest_Main_EntryPoint = OpFunction %void None %25
+%OpIEqualTest_Main_EntryPoint = OpFunction %void None %27
          %85 = OpLabel
      %self_2 = OpVariable %_ptr_Function_OpIEqualTest Function
          %87 = OpFunctionCall %void %OpIEqualTest_DefaultConstructor %self_2

--- a/CSShadersTests/Tests/IntrinsicFunctions/Relational and Logical Intrinsics/OpINotEqual_IntrinsicTest.expected.spvtxt
+++ b/CSShadersTests/Tests/IntrinsicFunctions/Relational and Logical Intrinsics/OpINotEqual_IntrinsicTest.expected.spvtxt
@@ -35,12 +35,14 @@
                OpName %OpINotEqualTest_Main_EntryPoint "OpINotEqualTest_Main_EntryPoint"
                OpName %self_2 "self"
        %bool = OpTypeBool
+      %false = OpConstantFalse %bool
        %uint = OpTypeInt 32 0
         %int = OpTypeInt 32 1
+      %int_0 = OpConstant %int 0
 %OpINotEqualTest = OpTypeStruct
        %void = OpTypeVoid
 %_ptr_Function_OpINotEqualTest = OpTypePointer Function %OpINotEqualTest
-         %11 = OpTypeFunction %void %_ptr_Function_OpINotEqualTest
+         %13 = OpTypeFunction %void %_ptr_Function_OpINotEqualTest
 %_ptr_Function_bool = OpTypePointer Function %bool
 %_ptr_Function_int = OpTypePointer Function %int
       %Bool2 = OpTypeVector %bool 2
@@ -55,21 +57,19 @@
 %_ptr_Function_Bool4 = OpTypePointer Function %Bool4
    %Integer4 = OpTypeVector %int 4
 %_ptr_Function_Integer4 = OpTypePointer Function %Integer4
-         %25 = OpTypeFunction %void
-      %false = OpConstantFalse %bool
-      %int_0 = OpConstant %int 0
-%OpINotEqualTest_PreConstructor = OpFunction %void None %11
+         %27 = OpTypeFunction %void
+%OpINotEqualTest_PreConstructor = OpFunction %void None %13
        %self = OpFunctionParameter %_ptr_Function_OpINotEqualTest
          %32 = OpLabel
                OpReturn
                OpFunctionEnd
-%OpINotEqualTest_DefaultConstructor = OpFunction %void None %11
+%OpINotEqualTest_DefaultConstructor = OpFunction %void None %13
      %self_0 = OpFunctionParameter %_ptr_Function_OpINotEqualTest
          %37 = OpLabel
          %38 = OpFunctionCall %void %OpINotEqualTest_PreConstructor %self_0
                OpReturn
                OpFunctionEnd
-       %Main = OpFunction %void None %11
+       %Main = OpFunction %void None %13
      %self_1 = OpFunctionParameter %_ptr_Function_OpINotEqualTest
          %43 = OpLabel
     %boolVal = OpVariable %_ptr_Function_bool Function
@@ -112,7 +112,7 @@
                OpStore %bool4Val %80
                OpReturn
                OpFunctionEnd
-%OpINotEqualTest_Main_EntryPoint = OpFunction %void None %25
+%OpINotEqualTest_Main_EntryPoint = OpFunction %void None %27
          %85 = OpLabel
      %self_2 = OpVariable %_ptr_Function_OpINotEqualTest Function
          %87 = OpFunctionCall %void %OpINotEqualTest_DefaultConstructor %self_2

--- a/CSShadersTests/Tests/IntrinsicFunctions/Relational and Logical Intrinsics/OpLogicalAnd_IntrinsicTest.expected.spvtxt
+++ b/CSShadersTests/Tests/IntrinsicFunctions/Relational and Logical Intrinsics/OpLogicalAnd_IntrinsicTest.expected.spvtxt
@@ -28,10 +28,11 @@
                OpName %OpLogicalAndTest_Main_EntryPoint "OpLogicalAndTest_Main_EntryPoint"
                OpName %self_2 "self"
        %bool = OpTypeBool
+      %false = OpConstantFalse %bool
 %OpLogicalAndTest = OpTypeStruct
        %void = OpTypeVoid
 %_ptr_Function_OpLogicalAndTest = OpTypePointer Function %OpLogicalAndTest
-          %7 = OpTypeFunction %void %_ptr_Function_OpLogicalAndTest
+          %8 = OpTypeFunction %void %_ptr_Function_OpLogicalAndTest
 %_ptr_Function_bool = OpTypePointer Function %bool
        %uint = OpTypeInt 32 0
       %Bool2 = OpTypeVector %bool 2
@@ -40,20 +41,19 @@
 %_ptr_Function_Bool3 = OpTypePointer Function %Bool3
       %Bool4 = OpTypeVector %bool 4
 %_ptr_Function_Bool4 = OpTypePointer Function %Bool4
-         %17 = OpTypeFunction %void
-      %false = OpConstantFalse %bool
-%OpLogicalAndTest_PreConstructor = OpFunction %void None %7
+         %18 = OpTypeFunction %void
+%OpLogicalAndTest_PreConstructor = OpFunction %void None %8
        %self = OpFunctionParameter %_ptr_Function_OpLogicalAndTest
          %23 = OpLabel
                OpReturn
                OpFunctionEnd
-%OpLogicalAndTest_DefaultConstructor = OpFunction %void None %7
+%OpLogicalAndTest_DefaultConstructor = OpFunction %void None %8
      %self_0 = OpFunctionParameter %_ptr_Function_OpLogicalAndTest
          %28 = OpLabel
          %29 = OpFunctionCall %void %OpLogicalAndTest_PreConstructor %self_0
                OpReturn
                OpFunctionEnd
-       %Main = OpFunction %void None %7
+       %Main = OpFunction %void None %8
      %self_1 = OpFunctionParameter %_ptr_Function_OpLogicalAndTest
          %34 = OpLabel
     %boolVal = OpVariable %_ptr_Function_bool Function
@@ -85,7 +85,7 @@
                OpStore %bool4Val %60
                OpReturn
                OpFunctionEnd
-%OpLogicalAndTest_Main_EntryPoint = OpFunction %void None %17
+%OpLogicalAndTest_Main_EntryPoint = OpFunction %void None %18
          %65 = OpLabel
      %self_2 = OpVariable %_ptr_Function_OpLogicalAndTest Function
          %67 = OpFunctionCall %void %OpLogicalAndTest_DefaultConstructor %self_2

--- a/CSShadersTests/Tests/IntrinsicFunctions/Relational and Logical Intrinsics/OpLogicalEqual_IntrinsicTest.expected.spvtxt
+++ b/CSShadersTests/Tests/IntrinsicFunctions/Relational and Logical Intrinsics/OpLogicalEqual_IntrinsicTest.expected.spvtxt
@@ -28,10 +28,11 @@
                OpName %OpLogicalEqualTest_Main_EntryPoint "OpLogicalEqualTest_Main_EntryPoint"
                OpName %self_2 "self"
        %bool = OpTypeBool
+      %false = OpConstantFalse %bool
 %OpLogicalEqualTest = OpTypeStruct
        %void = OpTypeVoid
 %_ptr_Function_OpLogicalEqualTest = OpTypePointer Function %OpLogicalEqualTest
-          %7 = OpTypeFunction %void %_ptr_Function_OpLogicalEqualTest
+          %8 = OpTypeFunction %void %_ptr_Function_OpLogicalEqualTest
 %_ptr_Function_bool = OpTypePointer Function %bool
        %uint = OpTypeInt 32 0
       %Bool2 = OpTypeVector %bool 2
@@ -40,20 +41,19 @@
 %_ptr_Function_Bool3 = OpTypePointer Function %Bool3
       %Bool4 = OpTypeVector %bool 4
 %_ptr_Function_Bool4 = OpTypePointer Function %Bool4
-         %17 = OpTypeFunction %void
-      %false = OpConstantFalse %bool
-%OpLogicalEqualTest_PreConstructor = OpFunction %void None %7
+         %18 = OpTypeFunction %void
+%OpLogicalEqualTest_PreConstructor = OpFunction %void None %8
        %self = OpFunctionParameter %_ptr_Function_OpLogicalEqualTest
          %23 = OpLabel
                OpReturn
                OpFunctionEnd
-%OpLogicalEqualTest_DefaultConstructor = OpFunction %void None %7
+%OpLogicalEqualTest_DefaultConstructor = OpFunction %void None %8
      %self_0 = OpFunctionParameter %_ptr_Function_OpLogicalEqualTest
          %28 = OpLabel
          %29 = OpFunctionCall %void %OpLogicalEqualTest_PreConstructor %self_0
                OpReturn
                OpFunctionEnd
-       %Main = OpFunction %void None %7
+       %Main = OpFunction %void None %8
      %self_1 = OpFunctionParameter %_ptr_Function_OpLogicalEqualTest
          %34 = OpLabel
     %boolVal = OpVariable %_ptr_Function_bool Function
@@ -85,7 +85,7 @@
                OpStore %bool4Val %60
                OpReturn
                OpFunctionEnd
-%OpLogicalEqualTest_Main_EntryPoint = OpFunction %void None %17
+%OpLogicalEqualTest_Main_EntryPoint = OpFunction %void None %18
          %65 = OpLabel
      %self_2 = OpVariable %_ptr_Function_OpLogicalEqualTest Function
          %67 = OpFunctionCall %void %OpLogicalEqualTest_DefaultConstructor %self_2

--- a/CSShadersTests/Tests/IntrinsicFunctions/Relational and Logical Intrinsics/OpLogicalNotEqual_IntrinsicTest.expected.spvtxt
+++ b/CSShadersTests/Tests/IntrinsicFunctions/Relational and Logical Intrinsics/OpLogicalNotEqual_IntrinsicTest.expected.spvtxt
@@ -28,10 +28,11 @@
                OpName %OpLogicalNotEqualTest_Main_EntryPoint "OpLogicalNotEqualTest_Main_EntryPoint"
                OpName %self_2 "self"
        %bool = OpTypeBool
+      %false = OpConstantFalse %bool
 %OpLogicalNotEqualTest = OpTypeStruct
        %void = OpTypeVoid
 %_ptr_Function_OpLogicalNotEqualTest = OpTypePointer Function %OpLogicalNotEqualTest
-          %7 = OpTypeFunction %void %_ptr_Function_OpLogicalNotEqualTest
+          %8 = OpTypeFunction %void %_ptr_Function_OpLogicalNotEqualTest
 %_ptr_Function_bool = OpTypePointer Function %bool
        %uint = OpTypeInt 32 0
       %Bool2 = OpTypeVector %bool 2
@@ -40,20 +41,19 @@
 %_ptr_Function_Bool3 = OpTypePointer Function %Bool3
       %Bool4 = OpTypeVector %bool 4
 %_ptr_Function_Bool4 = OpTypePointer Function %Bool4
-         %17 = OpTypeFunction %void
-      %false = OpConstantFalse %bool
-%OpLogicalNotEqualTest_PreConstructor = OpFunction %void None %7
+         %18 = OpTypeFunction %void
+%OpLogicalNotEqualTest_PreConstructor = OpFunction %void None %8
        %self = OpFunctionParameter %_ptr_Function_OpLogicalNotEqualTest
          %23 = OpLabel
                OpReturn
                OpFunctionEnd
-%OpLogicalNotEqualTest_DefaultConstructor = OpFunction %void None %7
+%OpLogicalNotEqualTest_DefaultConstructor = OpFunction %void None %8
      %self_0 = OpFunctionParameter %_ptr_Function_OpLogicalNotEqualTest
          %28 = OpLabel
          %29 = OpFunctionCall %void %OpLogicalNotEqualTest_PreConstructor %self_0
                OpReturn
                OpFunctionEnd
-       %Main = OpFunction %void None %7
+       %Main = OpFunction %void None %8
      %self_1 = OpFunctionParameter %_ptr_Function_OpLogicalNotEqualTest
          %34 = OpLabel
     %boolVal = OpVariable %_ptr_Function_bool Function
@@ -85,7 +85,7 @@
                OpStore %bool4Val %60
                OpReturn
                OpFunctionEnd
-%OpLogicalNotEqualTest_Main_EntryPoint = OpFunction %void None %17
+%OpLogicalNotEqualTest_Main_EntryPoint = OpFunction %void None %18
          %65 = OpLabel
      %self_2 = OpVariable %_ptr_Function_OpLogicalNotEqualTest Function
          %67 = OpFunctionCall %void %OpLogicalNotEqualTest_DefaultConstructor %self_2

--- a/CSShadersTests/Tests/IntrinsicFunctions/Relational and Logical Intrinsics/OpLogicalNot_IntrinsicTest.expected.spvtxt
+++ b/CSShadersTests/Tests/IntrinsicFunctions/Relational and Logical Intrinsics/OpLogicalNot_IntrinsicTest.expected.spvtxt
@@ -28,10 +28,11 @@
                OpName %OpLogicalNotTest_Main_EntryPoint "OpLogicalNotTest_Main_EntryPoint"
                OpName %self_2 "self"
        %bool = OpTypeBool
+      %false = OpConstantFalse %bool
 %OpLogicalNotTest = OpTypeStruct
        %void = OpTypeVoid
 %_ptr_Function_OpLogicalNotTest = OpTypePointer Function %OpLogicalNotTest
-          %7 = OpTypeFunction %void %_ptr_Function_OpLogicalNotTest
+          %8 = OpTypeFunction %void %_ptr_Function_OpLogicalNotTest
 %_ptr_Function_bool = OpTypePointer Function %bool
        %uint = OpTypeInt 32 0
       %Bool2 = OpTypeVector %bool 2
@@ -40,20 +41,19 @@
 %_ptr_Function_Bool3 = OpTypePointer Function %Bool3
       %Bool4 = OpTypeVector %bool 4
 %_ptr_Function_Bool4 = OpTypePointer Function %Bool4
-         %17 = OpTypeFunction %void
-      %false = OpConstantFalse %bool
-%OpLogicalNotTest_PreConstructor = OpFunction %void None %7
+         %18 = OpTypeFunction %void
+%OpLogicalNotTest_PreConstructor = OpFunction %void None %8
        %self = OpFunctionParameter %_ptr_Function_OpLogicalNotTest
          %23 = OpLabel
                OpReturn
                OpFunctionEnd
-%OpLogicalNotTest_DefaultConstructor = OpFunction %void None %7
+%OpLogicalNotTest_DefaultConstructor = OpFunction %void None %8
      %self_0 = OpFunctionParameter %_ptr_Function_OpLogicalNotTest
          %28 = OpLabel
          %29 = OpFunctionCall %void %OpLogicalNotTest_PreConstructor %self_0
                OpReturn
                OpFunctionEnd
-       %Main = OpFunction %void None %7
+       %Main = OpFunction %void None %8
      %self_1 = OpFunctionParameter %_ptr_Function_OpLogicalNotTest
          %34 = OpLabel
     %boolVal = OpVariable %_ptr_Function_bool Function
@@ -81,7 +81,7 @@
                OpStore %bool4Val %56
                OpReturn
                OpFunctionEnd
-%OpLogicalNotTest_Main_EntryPoint = OpFunction %void None %17
+%OpLogicalNotTest_Main_EntryPoint = OpFunction %void None %18
          %61 = OpLabel
      %self_2 = OpVariable %_ptr_Function_OpLogicalNotTest Function
          %63 = OpFunctionCall %void %OpLogicalNotTest_DefaultConstructor %self_2

--- a/CSShadersTests/Tests/IntrinsicFunctions/Relational and Logical Intrinsics/OpLogicalOr_IntrinsicTest.expected.spvtxt
+++ b/CSShadersTests/Tests/IntrinsicFunctions/Relational and Logical Intrinsics/OpLogicalOr_IntrinsicTest.expected.spvtxt
@@ -28,10 +28,11 @@
                OpName %OpLogicalOrTest_Main_EntryPoint "OpLogicalOrTest_Main_EntryPoint"
                OpName %self_2 "self"
        %bool = OpTypeBool
+      %false = OpConstantFalse %bool
 %OpLogicalOrTest = OpTypeStruct
        %void = OpTypeVoid
 %_ptr_Function_OpLogicalOrTest = OpTypePointer Function %OpLogicalOrTest
-          %7 = OpTypeFunction %void %_ptr_Function_OpLogicalOrTest
+          %8 = OpTypeFunction %void %_ptr_Function_OpLogicalOrTest
 %_ptr_Function_bool = OpTypePointer Function %bool
        %uint = OpTypeInt 32 0
       %Bool2 = OpTypeVector %bool 2
@@ -40,20 +41,19 @@
 %_ptr_Function_Bool3 = OpTypePointer Function %Bool3
       %Bool4 = OpTypeVector %bool 4
 %_ptr_Function_Bool4 = OpTypePointer Function %Bool4
-         %17 = OpTypeFunction %void
-      %false = OpConstantFalse %bool
-%OpLogicalOrTest_PreConstructor = OpFunction %void None %7
+         %18 = OpTypeFunction %void
+%OpLogicalOrTest_PreConstructor = OpFunction %void None %8
        %self = OpFunctionParameter %_ptr_Function_OpLogicalOrTest
          %23 = OpLabel
                OpReturn
                OpFunctionEnd
-%OpLogicalOrTest_DefaultConstructor = OpFunction %void None %7
+%OpLogicalOrTest_DefaultConstructor = OpFunction %void None %8
      %self_0 = OpFunctionParameter %_ptr_Function_OpLogicalOrTest
          %28 = OpLabel
          %29 = OpFunctionCall %void %OpLogicalOrTest_PreConstructor %self_0
                OpReturn
                OpFunctionEnd
-       %Main = OpFunction %void None %7
+       %Main = OpFunction %void None %8
      %self_1 = OpFunctionParameter %_ptr_Function_OpLogicalOrTest
          %34 = OpLabel
     %boolVal = OpVariable %_ptr_Function_bool Function
@@ -85,7 +85,7 @@
                OpStore %bool4Val %60
                OpReturn
                OpFunctionEnd
-%OpLogicalOrTest_Main_EntryPoint = OpFunction %void None %17
+%OpLogicalOrTest_Main_EntryPoint = OpFunction %void None %18
          %65 = OpLabel
      %self_2 = OpVariable %_ptr_Function_OpLogicalOrTest Function
          %67 = OpFunctionCall %void %OpLogicalOrTest_DefaultConstructor %self_2

--- a/CSShadersTests/Tests/IntrinsicFunctions/Relational and Logical Intrinsics/OpSGreaterThanEqual_IntrinsicTest.expected.spvtxt
+++ b/CSShadersTests/Tests/IntrinsicFunctions/Relational and Logical Intrinsics/OpSGreaterThanEqual_IntrinsicTest.expected.spvtxt
@@ -35,12 +35,14 @@
                OpName %OpSGreaterThanEqualTest_Main_EntryPoint "OpSGreaterThanEqualTest_Main_EntryPoint"
                OpName %self_2 "self"
        %bool = OpTypeBool
+      %false = OpConstantFalse %bool
        %uint = OpTypeInt 32 0
         %int = OpTypeInt 32 1
+      %int_0 = OpConstant %int 0
 %OpSGreaterThanEqualTest = OpTypeStruct
        %void = OpTypeVoid
 %_ptr_Function_OpSGreaterThanEqualTest = OpTypePointer Function %OpSGreaterThanEqualTest
-         %11 = OpTypeFunction %void %_ptr_Function_OpSGreaterThanEqualTest
+         %13 = OpTypeFunction %void %_ptr_Function_OpSGreaterThanEqualTest
 %_ptr_Function_bool = OpTypePointer Function %bool
 %_ptr_Function_int = OpTypePointer Function %int
       %Bool2 = OpTypeVector %bool 2
@@ -55,21 +57,19 @@
 %_ptr_Function_Bool4 = OpTypePointer Function %Bool4
    %Integer4 = OpTypeVector %int 4
 %_ptr_Function_Integer4 = OpTypePointer Function %Integer4
-         %25 = OpTypeFunction %void
-      %false = OpConstantFalse %bool
-      %int_0 = OpConstant %int 0
-%OpSGreaterThanEqualTest_PreConstructor = OpFunction %void None %11
+         %27 = OpTypeFunction %void
+%OpSGreaterThanEqualTest_PreConstructor = OpFunction %void None %13
        %self = OpFunctionParameter %_ptr_Function_OpSGreaterThanEqualTest
          %32 = OpLabel
                OpReturn
                OpFunctionEnd
-%OpSGreaterThanEqualTest_DefaultConstructor = OpFunction %void None %11
+%OpSGreaterThanEqualTest_DefaultConstructor = OpFunction %void None %13
      %self_0 = OpFunctionParameter %_ptr_Function_OpSGreaterThanEqualTest
          %37 = OpLabel
          %38 = OpFunctionCall %void %OpSGreaterThanEqualTest_PreConstructor %self_0
                OpReturn
                OpFunctionEnd
-       %Main = OpFunction %void None %11
+       %Main = OpFunction %void None %13
      %self_1 = OpFunctionParameter %_ptr_Function_OpSGreaterThanEqualTest
          %43 = OpLabel
     %boolVal = OpVariable %_ptr_Function_bool Function
@@ -112,7 +112,7 @@
                OpStore %bool4Val %80
                OpReturn
                OpFunctionEnd
-%OpSGreaterThanEqualTest_Main_EntryPoint = OpFunction %void None %25
+%OpSGreaterThanEqualTest_Main_EntryPoint = OpFunction %void None %27
          %85 = OpLabel
      %self_2 = OpVariable %_ptr_Function_OpSGreaterThanEqualTest Function
          %87 = OpFunctionCall %void %OpSGreaterThanEqualTest_DefaultConstructor %self_2

--- a/CSShadersTests/Tests/IntrinsicFunctions/Relational and Logical Intrinsics/OpSGreaterThan_IntrinsicTest.expected.spvtxt
+++ b/CSShadersTests/Tests/IntrinsicFunctions/Relational and Logical Intrinsics/OpSGreaterThan_IntrinsicTest.expected.spvtxt
@@ -35,12 +35,14 @@
                OpName %OpSGreaterThanTest_Main_EntryPoint "OpSGreaterThanTest_Main_EntryPoint"
                OpName %self_2 "self"
        %bool = OpTypeBool
+      %false = OpConstantFalse %bool
        %uint = OpTypeInt 32 0
         %int = OpTypeInt 32 1
+      %int_0 = OpConstant %int 0
 %OpSGreaterThanTest = OpTypeStruct
        %void = OpTypeVoid
 %_ptr_Function_OpSGreaterThanTest = OpTypePointer Function %OpSGreaterThanTest
-         %11 = OpTypeFunction %void %_ptr_Function_OpSGreaterThanTest
+         %13 = OpTypeFunction %void %_ptr_Function_OpSGreaterThanTest
 %_ptr_Function_bool = OpTypePointer Function %bool
 %_ptr_Function_int = OpTypePointer Function %int
       %Bool2 = OpTypeVector %bool 2
@@ -55,21 +57,19 @@
 %_ptr_Function_Bool4 = OpTypePointer Function %Bool4
    %Integer4 = OpTypeVector %int 4
 %_ptr_Function_Integer4 = OpTypePointer Function %Integer4
-         %25 = OpTypeFunction %void
-      %false = OpConstantFalse %bool
-      %int_0 = OpConstant %int 0
-%OpSGreaterThanTest_PreConstructor = OpFunction %void None %11
+         %27 = OpTypeFunction %void
+%OpSGreaterThanTest_PreConstructor = OpFunction %void None %13
        %self = OpFunctionParameter %_ptr_Function_OpSGreaterThanTest
          %32 = OpLabel
                OpReturn
                OpFunctionEnd
-%OpSGreaterThanTest_DefaultConstructor = OpFunction %void None %11
+%OpSGreaterThanTest_DefaultConstructor = OpFunction %void None %13
      %self_0 = OpFunctionParameter %_ptr_Function_OpSGreaterThanTest
          %37 = OpLabel
          %38 = OpFunctionCall %void %OpSGreaterThanTest_PreConstructor %self_0
                OpReturn
                OpFunctionEnd
-       %Main = OpFunction %void None %11
+       %Main = OpFunction %void None %13
      %self_1 = OpFunctionParameter %_ptr_Function_OpSGreaterThanTest
          %43 = OpLabel
     %boolVal = OpVariable %_ptr_Function_bool Function
@@ -112,7 +112,7 @@
                OpStore %bool4Val %80
                OpReturn
                OpFunctionEnd
-%OpSGreaterThanTest_Main_EntryPoint = OpFunction %void None %25
+%OpSGreaterThanTest_Main_EntryPoint = OpFunction %void None %27
          %85 = OpLabel
      %self_2 = OpVariable %_ptr_Function_OpSGreaterThanTest Function
          %87 = OpFunctionCall %void %OpSGreaterThanTest_DefaultConstructor %self_2

--- a/CSShadersTests/Tests/IntrinsicFunctions/Relational and Logical Intrinsics/OpSLessThanEqual_IntrinsicTest.expected.spvtxt
+++ b/CSShadersTests/Tests/IntrinsicFunctions/Relational and Logical Intrinsics/OpSLessThanEqual_IntrinsicTest.expected.spvtxt
@@ -35,12 +35,14 @@
                OpName %OpSLessThanEqualTest_Main_EntryPoint "OpSLessThanEqualTest_Main_EntryPoint"
                OpName %self_2 "self"
        %bool = OpTypeBool
+      %false = OpConstantFalse %bool
        %uint = OpTypeInt 32 0
         %int = OpTypeInt 32 1
+      %int_0 = OpConstant %int 0
 %OpSLessThanEqualTest = OpTypeStruct
        %void = OpTypeVoid
 %_ptr_Function_OpSLessThanEqualTest = OpTypePointer Function %OpSLessThanEqualTest
-         %11 = OpTypeFunction %void %_ptr_Function_OpSLessThanEqualTest
+         %13 = OpTypeFunction %void %_ptr_Function_OpSLessThanEqualTest
 %_ptr_Function_bool = OpTypePointer Function %bool
 %_ptr_Function_int = OpTypePointer Function %int
       %Bool2 = OpTypeVector %bool 2
@@ -55,21 +57,19 @@
 %_ptr_Function_Bool4 = OpTypePointer Function %Bool4
    %Integer4 = OpTypeVector %int 4
 %_ptr_Function_Integer4 = OpTypePointer Function %Integer4
-         %25 = OpTypeFunction %void
-      %false = OpConstantFalse %bool
-      %int_0 = OpConstant %int 0
-%OpSLessThanEqualTest_PreConstructor = OpFunction %void None %11
+         %27 = OpTypeFunction %void
+%OpSLessThanEqualTest_PreConstructor = OpFunction %void None %13
        %self = OpFunctionParameter %_ptr_Function_OpSLessThanEqualTest
          %32 = OpLabel
                OpReturn
                OpFunctionEnd
-%OpSLessThanEqualTest_DefaultConstructor = OpFunction %void None %11
+%OpSLessThanEqualTest_DefaultConstructor = OpFunction %void None %13
      %self_0 = OpFunctionParameter %_ptr_Function_OpSLessThanEqualTest
          %37 = OpLabel
          %38 = OpFunctionCall %void %OpSLessThanEqualTest_PreConstructor %self_0
                OpReturn
                OpFunctionEnd
-       %Main = OpFunction %void None %11
+       %Main = OpFunction %void None %13
      %self_1 = OpFunctionParameter %_ptr_Function_OpSLessThanEqualTest
          %43 = OpLabel
     %boolVal = OpVariable %_ptr_Function_bool Function
@@ -112,7 +112,7 @@
                OpStore %bool4Val %80
                OpReturn
                OpFunctionEnd
-%OpSLessThanEqualTest_Main_EntryPoint = OpFunction %void None %25
+%OpSLessThanEqualTest_Main_EntryPoint = OpFunction %void None %27
          %85 = OpLabel
      %self_2 = OpVariable %_ptr_Function_OpSLessThanEqualTest Function
          %87 = OpFunctionCall %void %OpSLessThanEqualTest_DefaultConstructor %self_2

--- a/CSShadersTests/Tests/IntrinsicFunctions/Relational and Logical Intrinsics/OpSLessThan_IntrinsicTest.expected.spvtxt
+++ b/CSShadersTests/Tests/IntrinsicFunctions/Relational and Logical Intrinsics/OpSLessThan_IntrinsicTest.expected.spvtxt
@@ -35,12 +35,14 @@
                OpName %OpSLessThanTest_Main_EntryPoint "OpSLessThanTest_Main_EntryPoint"
                OpName %self_2 "self"
        %bool = OpTypeBool
+      %false = OpConstantFalse %bool
        %uint = OpTypeInt 32 0
         %int = OpTypeInt 32 1
+      %int_0 = OpConstant %int 0
 %OpSLessThanTest = OpTypeStruct
        %void = OpTypeVoid
 %_ptr_Function_OpSLessThanTest = OpTypePointer Function %OpSLessThanTest
-         %11 = OpTypeFunction %void %_ptr_Function_OpSLessThanTest
+         %13 = OpTypeFunction %void %_ptr_Function_OpSLessThanTest
 %_ptr_Function_bool = OpTypePointer Function %bool
 %_ptr_Function_int = OpTypePointer Function %int
       %Bool2 = OpTypeVector %bool 2
@@ -55,21 +57,19 @@
 %_ptr_Function_Bool4 = OpTypePointer Function %Bool4
    %Integer4 = OpTypeVector %int 4
 %_ptr_Function_Integer4 = OpTypePointer Function %Integer4
-         %25 = OpTypeFunction %void
-      %false = OpConstantFalse %bool
-      %int_0 = OpConstant %int 0
-%OpSLessThanTest_PreConstructor = OpFunction %void None %11
+         %27 = OpTypeFunction %void
+%OpSLessThanTest_PreConstructor = OpFunction %void None %13
        %self = OpFunctionParameter %_ptr_Function_OpSLessThanTest
          %32 = OpLabel
                OpReturn
                OpFunctionEnd
-%OpSLessThanTest_DefaultConstructor = OpFunction %void None %11
+%OpSLessThanTest_DefaultConstructor = OpFunction %void None %13
      %self_0 = OpFunctionParameter %_ptr_Function_OpSLessThanTest
          %37 = OpLabel
          %38 = OpFunctionCall %void %OpSLessThanTest_PreConstructor %self_0
                OpReturn
                OpFunctionEnd
-       %Main = OpFunction %void None %11
+       %Main = OpFunction %void None %13
      %self_1 = OpFunctionParameter %_ptr_Function_OpSLessThanTest
          %43 = OpLabel
     %boolVal = OpVariable %_ptr_Function_bool Function
@@ -112,7 +112,7 @@
                OpStore %bool4Val %80
                OpReturn
                OpFunctionEnd
-%OpSLessThanTest_Main_EntryPoint = OpFunction %void None %25
+%OpSLessThanTest_Main_EntryPoint = OpFunction %void None %27
          %85 = OpLabel
      %self_2 = OpVariable %_ptr_Function_OpSLessThanTest Function
          %87 = OpFunctionCall %void %OpSLessThanTest_DefaultConstructor %self_2

--- a/CSShadersTests/Tests/IntrinsicFunctions/Relational and Logical Intrinsics/OpSelect_IntrinsicTest.expected.spvtxt
+++ b/CSShadersTests/Tests/IntrinsicFunctions/Relational and Logical Intrinsics/OpSelect_IntrinsicTest.expected.spvtxt
@@ -42,13 +42,16 @@
                OpName %OpSelectTest_Main_EntryPoint "OpSelectTest_Main_EntryPoint"
                OpName %self_2 "self"
        %bool = OpTypeBool
+      %false = OpConstantFalse %bool
        %uint = OpTypeInt 32 0
         %int = OpTypeInt 32 1
+      %int_0 = OpConstant %int 0
       %float = OpTypeFloat 32
+    %float_0 = OpConstant %float 0
 %OpSelectTest = OpTypeStruct
        %void = OpTypeVoid
 %_ptr_Function_OpSelectTest = OpTypePointer Function %OpSelectTest
-         %13 = OpTypeFunction %void %_ptr_Function_OpSelectTest
+         %16 = OpTypeFunction %void %_ptr_Function_OpSelectTest
 %_ptr_Function_bool = OpTypePointer Function %bool
       %Bool2 = OpTypeVector %bool 2
 %_ptr_Function_Bool2 = OpTypePointer Function %Bool2
@@ -70,22 +73,19 @@
 %_ptr_Function_Vector3 = OpTypePointer Function %Vector3
     %Vector4 = OpTypeVector %float 4
 %_ptr_Function_Vector4 = OpTypePointer Function %Vector4
-         %33 = OpTypeFunction %void
-      %false = OpConstantFalse %bool
-      %int_0 = OpConstant %int 0
-    %float_0 = OpConstant %float 0
-%OpSelectTest_PreConstructor = OpFunction %void None %13
+         %36 = OpTypeFunction %void
+%OpSelectTest_PreConstructor = OpFunction %void None %16
        %self = OpFunctionParameter %_ptr_Function_OpSelectTest
          %41 = OpLabel
                OpReturn
                OpFunctionEnd
-%OpSelectTest_DefaultConstructor = OpFunction %void None %13
+%OpSelectTest_DefaultConstructor = OpFunction %void None %16
      %self_0 = OpFunctionParameter %_ptr_Function_OpSelectTest
          %46 = OpLabel
          %47 = OpFunctionCall %void %OpSelectTest_PreConstructor %self_0
                OpReturn
                OpFunctionEnd
-       %Main = OpFunction %void None %13
+       %Main = OpFunction %void None %16
      %self_1 = OpFunctionParameter %_ptr_Function_OpSelectTest
          %52 = OpLabel
     %boolVal = OpVariable %_ptr_Function_bool Function
@@ -183,7 +183,7 @@
                OpStore %vector4Val %144
                OpReturn
                OpFunctionEnd
-%OpSelectTest_Main_EntryPoint = OpFunction %void None %33
+%OpSelectTest_Main_EntryPoint = OpFunction %void None %36
         %149 = OpLabel
      %self_2 = OpVariable %_ptr_Function_OpSelectTest Function
         %151 = OpFunctionCall %void %OpSelectTest_DefaultConstructor %self_2

--- a/CSShadersTests/Tests/LanguageBasics/AssignmentOps/IntegerCompoundAssignmentOps.expected.spvtxt
+++ b/CSShadersTests/Tests/LanguageBasics/AssignmentOps/IntegerCompoundAssignmentOps.expected.spvtxt
@@ -24,25 +24,25 @@
                OpName %self_2 "self"
        %uint = OpTypeInt 32 0
         %int = OpTypeInt 32 1
+      %int_0 = OpConstant %int 0
 %IntegerCompoundAssignmentOps = OpTypeStruct
        %void = OpTypeVoid
 %_ptr_Function_IntegerCompoundAssignmentOps = OpTypePointer Function %IntegerCompoundAssignmentOps
-          %9 = OpTypeFunction %void %_ptr_Function_IntegerCompoundAssignmentOps
+         %10 = OpTypeFunction %void %_ptr_Function_IntegerCompoundAssignmentOps
 %_ptr_Function_int = OpTypePointer Function %int
-         %11 = OpTypeFunction %void
-      %int_0 = OpConstant %int 0
-%IntegerCompoundAssignmentOps_PreConstructor = OpFunction %void None %9
+         %12 = OpTypeFunction %void
+%IntegerCompoundAssignmentOps_PreConstructor = OpFunction %void None %10
        %self = OpFunctionParameter %_ptr_Function_IntegerCompoundAssignmentOps
          %17 = OpLabel
                OpReturn
                OpFunctionEnd
-%IntegerCompoundAssignmentOps_DefaultConstructor = OpFunction %void None %9
+%IntegerCompoundAssignmentOps_DefaultConstructor = OpFunction %void None %10
      %self_0 = OpFunctionParameter %_ptr_Function_IntegerCompoundAssignmentOps
          %22 = OpLabel
          %23 = OpFunctionCall %void %IntegerCompoundAssignmentOps_PreConstructor %self_0
                OpReturn
                OpFunctionEnd
-       %Main = OpFunction %void None %9
+       %Main = OpFunction %void None %10
      %self_1 = OpFunctionParameter %_ptr_Function_IntegerCompoundAssignmentOps
          %28 = OpLabel
           %i = OpVariable %_ptr_Function_int Function
@@ -91,7 +91,7 @@
                OpStore %r %71
                OpReturn
                OpFunctionEnd
-%IntegerCompoundAssignmentOps_Main_EntryPoint = OpFunction %void None %11
+%IntegerCompoundAssignmentOps_Main_EntryPoint = OpFunction %void None %12
          %76 = OpLabel
      %self_2 = OpVariable %_ptr_Function_IntegerCompoundAssignmentOps Function
          %78 = OpFunctionCall %void %IntegerCompoundAssignmentOps_DefaultConstructor %self_2

--- a/CSShadersTests/Tests/LanguageBasics/BinaryOps/BooleanBinaryOps.expected.spvtxt
+++ b/CSShadersTests/Tests/LanguageBasics/BinaryOps/BooleanBinaryOps.expected.spvtxt
@@ -23,25 +23,25 @@
                OpName %BooleanBinaryOps_Main_EntryPoint "BooleanBinaryOps_Main_EntryPoint"
                OpName %self_2 "self"
        %bool = OpTypeBool
+      %false = OpConstantFalse %bool
 %BooleanBinaryOps = OpTypeStruct
        %void = OpTypeVoid
 %_ptr_Function_BooleanBinaryOps = OpTypePointer Function %BooleanBinaryOps
-          %7 = OpTypeFunction %void %_ptr_Function_BooleanBinaryOps
+          %8 = OpTypeFunction %void %_ptr_Function_BooleanBinaryOps
 %_ptr_Function_bool = OpTypePointer Function %bool
-          %9 = OpTypeFunction %void
-      %false = OpConstantFalse %bool
-%BooleanBinaryOps_PreConstructor = OpFunction %void None %7
+         %10 = OpTypeFunction %void
+%BooleanBinaryOps_PreConstructor = OpFunction %void None %8
        %self = OpFunctionParameter %_ptr_Function_BooleanBinaryOps
          %15 = OpLabel
                OpReturn
                OpFunctionEnd
-%BooleanBinaryOps_DefaultConstructor = OpFunction %void None %7
+%BooleanBinaryOps_DefaultConstructor = OpFunction %void None %8
      %self_0 = OpFunctionParameter %_ptr_Function_BooleanBinaryOps
          %20 = OpLabel
          %21 = OpFunctionCall %void %BooleanBinaryOps_PreConstructor %self_0
                OpReturn
                OpFunctionEnd
-       %Main = OpFunction %void None %7
+       %Main = OpFunction %void None %8
      %self_1 = OpFunctionParameter %_ptr_Function_BooleanBinaryOps
          %26 = OpLabel
           %b = OpVariable %_ptr_Function_bool Function
@@ -62,7 +62,7 @@
                OpStore %r %41
                OpReturn
                OpFunctionEnd
-%BooleanBinaryOps_Main_EntryPoint = OpFunction %void None %9
+%BooleanBinaryOps_Main_EntryPoint = OpFunction %void None %10
          %46 = OpLabel
      %self_2 = OpVariable %_ptr_Function_BooleanBinaryOps Function
          %48 = OpFunctionCall %void %BooleanBinaryOps_DefaultConstructor %self_2

--- a/CSShadersTests/Tests/LanguageBasics/BinaryOps/FloatBinaryOps.expected.spvtxt
+++ b/CSShadersTests/Tests/LanguageBasics/BinaryOps/FloatBinaryOps.expected.spvtxt
@@ -25,28 +25,28 @@
                OpName %self_2 "self"
        %uint = OpTypeInt 32 0
       %float = OpTypeFloat 32
+    %float_0 = OpConstant %float 0
        %bool = OpTypeBool
+      %false = OpConstantFalse %bool
 %FloatBinaryOps = OpTypeStruct
        %void = OpTypeVoid
 %_ptr_Function_FloatBinaryOps = OpTypePointer Function %FloatBinaryOps
-         %11 = OpTypeFunction %void %_ptr_Function_FloatBinaryOps
+         %13 = OpTypeFunction %void %_ptr_Function_FloatBinaryOps
 %_ptr_Function_float = OpTypePointer Function %float
 %_ptr_Function_bool = OpTypePointer Function %bool
-         %13 = OpTypeFunction %void
-    %float_0 = OpConstant %float 0
-      %false = OpConstantFalse %bool
-%FloatBinaryOps_PreConstructor = OpFunction %void None %11
+         %15 = OpTypeFunction %void
+%FloatBinaryOps_PreConstructor = OpFunction %void None %13
        %self = OpFunctionParameter %_ptr_Function_FloatBinaryOps
          %20 = OpLabel
                OpReturn
                OpFunctionEnd
-%FloatBinaryOps_DefaultConstructor = OpFunction %void None %11
+%FloatBinaryOps_DefaultConstructor = OpFunction %void None %13
      %self_0 = OpFunctionParameter %_ptr_Function_FloatBinaryOps
          %25 = OpLabel
          %26 = OpFunctionCall %void %FloatBinaryOps_PreConstructor %self_0
                OpReturn
                OpFunctionEnd
-       %Main = OpFunction %void None %11
+       %Main = OpFunction %void None %13
      %self_1 = OpFunctionParameter %_ptr_Function_FloatBinaryOps
          %31 = OpLabel
           %f = OpVariable %_ptr_Function_float Function
@@ -97,7 +97,7 @@
                OpStore %b %76
                OpReturn
                OpFunctionEnd
-%FloatBinaryOps_Main_EntryPoint = OpFunction %void None %13
+%FloatBinaryOps_Main_EntryPoint = OpFunction %void None %15
          %81 = OpLabel
      %self_2 = OpVariable %_ptr_Function_FloatBinaryOps Function
          %83 = OpFunctionCall %void %FloatBinaryOps_DefaultConstructor %self_2

--- a/CSShadersTests/Tests/LanguageBasics/BinaryOps/IntegerBinaryOps.expected.spvtxt
+++ b/CSShadersTests/Tests/LanguageBasics/BinaryOps/IntegerBinaryOps.expected.spvtxt
@@ -25,29 +25,29 @@
                OpName %self_2 "self"
        %uint = OpTypeInt 32 0
         %int = OpTypeInt 32 1
+      %int_0 = OpConstant %int 0
        %bool = OpTypeBool
+      %false = OpConstantFalse %bool
+      %int_2 = OpConstant %int 2
 %IntegerBinaryOps = OpTypeStruct
        %void = OpTypeVoid
 %_ptr_Function_IntegerBinaryOps = OpTypePointer Function %IntegerBinaryOps
-         %11 = OpTypeFunction %void %_ptr_Function_IntegerBinaryOps
+         %14 = OpTypeFunction %void %_ptr_Function_IntegerBinaryOps
 %_ptr_Function_int = OpTypePointer Function %int
 %_ptr_Function_bool = OpTypePointer Function %bool
-         %13 = OpTypeFunction %void
-      %int_0 = OpConstant %int 0
-      %false = OpConstantFalse %bool
-      %int_2 = OpConstant %int 2
-%IntegerBinaryOps_PreConstructor = OpFunction %void None %11
+         %16 = OpTypeFunction %void
+%IntegerBinaryOps_PreConstructor = OpFunction %void None %14
        %self = OpFunctionParameter %_ptr_Function_IntegerBinaryOps
          %21 = OpLabel
                OpReturn
                OpFunctionEnd
-%IntegerBinaryOps_DefaultConstructor = OpFunction %void None %11
+%IntegerBinaryOps_DefaultConstructor = OpFunction %void None %14
      %self_0 = OpFunctionParameter %_ptr_Function_IntegerBinaryOps
          %26 = OpLabel
          %27 = OpFunctionCall %void %IntegerBinaryOps_PreConstructor %self_0
                OpReturn
                OpFunctionEnd
-       %Main = OpFunction %void None %11
+       %Main = OpFunction %void None %14
      %self_1 = OpFunctionParameter %_ptr_Function_IntegerBinaryOps
          %32 = OpLabel
           %i = OpVariable %_ptr_Function_int Function
@@ -116,7 +116,7 @@
                OpStore %i %95
                OpReturn
                OpFunctionEnd
-%IntegerBinaryOps_Main_EntryPoint = OpFunction %void None %13
+%IntegerBinaryOps_Main_EntryPoint = OpFunction %void None %16
         %100 = OpLabel
      %self_2 = OpVariable %_ptr_Function_IntegerBinaryOps Function
         %102 = OpFunctionCall %void %IntegerBinaryOps_DefaultConstructor %self_2

--- a/CSShadersTests/Tests/LanguageBasics/BinaryOps/UnsignedIntegerBinaryOps.expected.spvtxt
+++ b/CSShadersTests/Tests/LanguageBasics/BinaryOps/UnsignedIntegerBinaryOps.expected.spvtxt
@@ -24,30 +24,30 @@
                OpName %UnsignedIntegerBinaryOps_Main_EntryPoint "UnsignedIntegerBinaryOps_Main_EntryPoint"
                OpName %self_2 "self"
        %uint = OpTypeInt 32 0
+     %uint_0 = OpConstant %uint 0
        %bool = OpTypeBool
+      %false = OpConstantFalse %bool
         %int = OpTypeInt 32 1
+      %int_2 = OpConstant %int 2
 %UnsignedIntegerBinaryOps = OpTypeStruct
        %void = OpTypeVoid
 %_ptr_Function_UnsignedIntegerBinaryOps = OpTypePointer Function %UnsignedIntegerBinaryOps
-         %11 = OpTypeFunction %void %_ptr_Function_UnsignedIntegerBinaryOps
+         %14 = OpTypeFunction %void %_ptr_Function_UnsignedIntegerBinaryOps
 %_ptr_Function_uint = OpTypePointer Function %uint
 %_ptr_Function_bool = OpTypePointer Function %bool
-         %13 = OpTypeFunction %void
-     %uint_0 = OpConstant %uint 0
-      %false = OpConstantFalse %bool
-      %int_2 = OpConstant %int 2
-%UnsignedIntegerBinaryOps_PreConstructor = OpFunction %void None %11
+         %16 = OpTypeFunction %void
+%UnsignedIntegerBinaryOps_PreConstructor = OpFunction %void None %14
        %self = OpFunctionParameter %_ptr_Function_UnsignedIntegerBinaryOps
          %21 = OpLabel
                OpReturn
                OpFunctionEnd
-%UnsignedIntegerBinaryOps_DefaultConstructor = OpFunction %void None %11
+%UnsignedIntegerBinaryOps_DefaultConstructor = OpFunction %void None %14
      %self_0 = OpFunctionParameter %_ptr_Function_UnsignedIntegerBinaryOps
          %26 = OpLabel
          %27 = OpFunctionCall %void %UnsignedIntegerBinaryOps_PreConstructor %self_0
                OpReturn
                OpFunctionEnd
-       %Main = OpFunction %void None %11
+       %Main = OpFunction %void None %14
      %self_1 = OpFunctionParameter %_ptr_Function_UnsignedIntegerBinaryOps
          %32 = OpLabel
           %u = OpVariable %_ptr_Function_uint Function
@@ -116,7 +116,7 @@
                OpStore %u %95
                OpReturn
                OpFunctionEnd
-%UnsignedIntegerBinaryOps_Main_EntryPoint = OpFunction %void None %13
+%UnsignedIntegerBinaryOps_Main_EntryPoint = OpFunction %void None %16
         %100 = OpLabel
      %self_2 = OpVariable %_ptr_Function_UnsignedIntegerBinaryOps Function
         %102 = OpFunctionCall %void %UnsignedIntegerBinaryOps_DefaultConstructor %self_2

--- a/CSShadersTests/Tests/LanguageBasics/Casting/CustomCast.expected.spvtxt
+++ b/CSShadersTests/Tests/LanguageBasics/Casting/CustomCast.expected.spvtxt
@@ -44,24 +44,24 @@
                OpName %self_6 "self"
        %uint = OpTypeInt 32 0
         %int = OpTypeInt 32 1
-       %Int2 = OpTypeStruct %int %int
-       %void = OpTypeVoid
-%_ptr_Function_Int2 = OpTypePointer Function %Int2
-          %9 = OpTypeFunction %void %_ptr_Function_Int2
-%_ptr_Function_int = OpTypePointer Function %int
-      %MyInt = OpTypeStruct %int
-%_ptr_Function_MyInt = OpTypePointer Function %MyInt
-         %13 = OpTypeFunction %void %_ptr_Function_MyInt
-         %15 = OpTypeFunction %int %MyInt
-         %17 = OpTypeFunction %Int2 %MyInt
- %CustomCast = OpTypeStruct
-%_ptr_Function_CustomCast = OpTypePointer Function %CustomCast
-         %21 = OpTypeFunction %void %_ptr_Function_CustomCast
-         %23 = OpTypeFunction %void
       %int_0 = OpConstant %int 0
      %uint_0 = OpConstant %uint 0
      %uint_1 = OpConstant %uint 1
-%Int2_PreConstructor = OpFunction %void None %9
+       %Int2 = OpTypeStruct %int %int
+       %void = OpTypeVoid
+%_ptr_Function_Int2 = OpTypePointer Function %Int2
+         %12 = OpTypeFunction %void %_ptr_Function_Int2
+%_ptr_Function_int = OpTypePointer Function %int
+      %MyInt = OpTypeStruct %int
+%_ptr_Function_MyInt = OpTypePointer Function %MyInt
+         %16 = OpTypeFunction %void %_ptr_Function_MyInt
+         %18 = OpTypeFunction %int %MyInt
+         %20 = OpTypeFunction %Int2 %MyInt
+ %CustomCast = OpTypeStruct
+%_ptr_Function_CustomCast = OpTypePointer Function %CustomCast
+         %24 = OpTypeFunction %void %_ptr_Function_CustomCast
+         %26 = OpTypeFunction %void
+%Int2_PreConstructor = OpFunction %void None %12
        %self = OpFunctionParameter %_ptr_Function_Int2
          %31 = OpLabel
          %32 = OpAccessChain %_ptr_Function_int %self %uint_0
@@ -70,32 +70,32 @@
                OpStore %34 %int_0
                OpReturn
                OpFunctionEnd
-%Int2_DefaultConstructor = OpFunction %void None %9
+%Int2_DefaultConstructor = OpFunction %void None %12
      %self_0 = OpFunctionParameter %_ptr_Function_Int2
          %40 = OpLabel
          %41 = OpFunctionCall %void %Int2_PreConstructor %self_0
                OpReturn
                OpFunctionEnd
-%MyInt_PreConstructor = OpFunction %void None %13
+%MyInt_PreConstructor = OpFunction %void None %16
      %self_1 = OpFunctionParameter %_ptr_Function_MyInt
          %46 = OpLabel
          %47 = OpAccessChain %_ptr_Function_int %self_1 %uint_0
                OpStore %47 %int_0
                OpReturn
                OpFunctionEnd
-%MyInt_DefaultConstructor = OpFunction %void None %13
+%MyInt_DefaultConstructor = OpFunction %void None %16
      %self_2 = OpFunctionParameter %_ptr_Function_MyInt
          %53 = OpLabel
          %54 = OpFunctionCall %void %MyInt_PreConstructor %self_2
                OpReturn
                OpFunctionEnd
-%op_Implicit = OpFunction %int None %15
+%op_Implicit = OpFunction %int None %18
       %value = OpFunctionParameter %MyInt
          %59 = OpLabel
          %60 = OpCompositeExtract %int %value 0
                OpReturnValue %60
                OpFunctionEnd
-%op_Implicit_0 = OpFunction %Int2 None %17
+%op_Implicit_0 = OpFunction %Int2 None %20
     %value_0 = OpFunctionParameter %MyInt
          %65 = OpLabel
    %tempInt2 = OpVariable %_ptr_Function_Int2 Function
@@ -109,18 +109,18 @@
          %74 = OpLoad %Int2 %tempInt2
                OpReturnValue %74
                OpFunctionEnd
-%CustomCast_PreConstructor = OpFunction %void None %21
+%CustomCast_PreConstructor = OpFunction %void None %24
      %self_3 = OpFunctionParameter %_ptr_Function_CustomCast
          %79 = OpLabel
                OpReturn
                OpFunctionEnd
-%CustomCast_DefaultConstructor = OpFunction %void None %21
+%CustomCast_DefaultConstructor = OpFunction %void None %24
      %self_4 = OpFunctionParameter %_ptr_Function_CustomCast
          %84 = OpLabel
          %85 = OpFunctionCall %void %CustomCast_PreConstructor %self_4
                OpReturn
                OpFunctionEnd
-       %Main = OpFunction %void None %21
+       %Main = OpFunction %void None %24
      %self_5 = OpFunctionParameter %_ptr_Function_CustomCast
          %90 = OpLabel
       %myInt = OpVariable %_ptr_Function_MyInt Function
@@ -138,7 +138,7 @@
                OpStore %i2 %102
                OpReturn
                OpFunctionEnd
-%CustomCast_Main_EntryPoint = OpFunction %void None %23
+%CustomCast_Main_EntryPoint = OpFunction %void None %26
         %107 = OpLabel
      %self_6 = OpVariable %_ptr_Function_CustomCast Function
         %109 = OpFunctionCall %void %CustomCast_DefaultConstructor %self_6

--- a/CSShadersTests/Tests/LanguageBasics/Casting/PrimitiveCasts.expected.spvtxt
+++ b/CSShadersTests/Tests/LanguageBasics/Casting/PrimitiveCasts.expected.spvtxt
@@ -25,34 +25,34 @@
                OpName %PrimitiveCasts_Main_EntryPoint "PrimitiveCasts_Main_EntryPoint"
                OpName %self_2 "self"
        %bool = OpTypeBool
+      %false = OpConstantFalse %bool
        %uint = OpTypeInt 32 0
         %int = OpTypeInt 32 1
+      %int_0 = OpConstant %int 0
+     %uint_0 = OpConstant %uint 0
       %float = OpTypeFloat 32
+    %float_0 = OpConstant %float 0
 %PrimitiveCasts = OpTypeStruct
        %void = OpTypeVoid
 %_ptr_Function_PrimitiveCasts = OpTypePointer Function %PrimitiveCasts
-         %13 = OpTypeFunction %void %_ptr_Function_PrimitiveCasts
+         %17 = OpTypeFunction %void %_ptr_Function_PrimitiveCasts
 %_ptr_Function_bool = OpTypePointer Function %bool
 %_ptr_Function_int = OpTypePointer Function %int
 %_ptr_Function_uint = OpTypePointer Function %uint
 %_ptr_Function_float = OpTypePointer Function %float
-         %15 = OpTypeFunction %void
-      %false = OpConstantFalse %bool
-      %int_0 = OpConstant %int 0
-     %uint_0 = OpConstant %uint 0
-    %float_0 = OpConstant %float 0
-%PrimitiveCasts_PreConstructor = OpFunction %void None %13
+         %19 = OpTypeFunction %void
+%PrimitiveCasts_PreConstructor = OpFunction %void None %17
        %self = OpFunctionParameter %_ptr_Function_PrimitiveCasts
          %24 = OpLabel
                OpReturn
                OpFunctionEnd
-%PrimitiveCasts_DefaultConstructor = OpFunction %void None %13
+%PrimitiveCasts_DefaultConstructor = OpFunction %void None %17
      %self_0 = OpFunctionParameter %_ptr_Function_PrimitiveCasts
          %29 = OpLabel
          %30 = OpFunctionCall %void %PrimitiveCasts_PreConstructor %self_0
                OpReturn
                OpFunctionEnd
-       %Main = OpFunction %void None %13
+       %Main = OpFunction %void None %17
      %self_1 = OpFunctionParameter %_ptr_Function_PrimitiveCasts
          %35 = OpLabel
           %b = OpVariable %_ptr_Function_bool Function
@@ -107,7 +107,7 @@
                OpStore %f %84
                OpReturn
                OpFunctionEnd
-%PrimitiveCasts_Main_EntryPoint = OpFunction %void None %15
+%PrimitiveCasts_Main_EntryPoint = OpFunction %void None %19
          %89 = OpLabel
      %self_2 = OpVariable %_ptr_Function_PrimitiveCasts Function
          %91 = OpFunctionCall %void %PrimitiveCasts_DefaultConstructor %self_2

--- a/CSShadersTests/Tests/LanguageBasics/Construction/CustomConstructor.expected.spvtxt
+++ b/CSShadersTests/Tests/LanguageBasics/Construction/CustomConstructor.expected.spvtxt
@@ -35,25 +35,25 @@
                OpName %self_5 "self"
        %uint = OpTypeInt 32 0
         %int = OpTypeInt 32 1
-      %float = OpTypeFloat 32
-    %MyClass = OpTypeStruct %int %float
-       %void = OpTypeVoid
-%_ptr_Function_MyClass = OpTypePointer Function %MyClass
-         %11 = OpTypeFunction %void %_ptr_Function_MyClass
-%_ptr_Function_int = OpTypePointer Function %int
-%_ptr_Function_float = OpTypePointer Function %float
-         %13 = OpTypeFunction %void %_ptr_Function_MyClass %int %float
-%DefaultConstructorIntrinsic = OpTypeStruct
-%_ptr_Function_DefaultConstructorIntrinsic = OpTypePointer Function %DefaultConstructorIntrinsic
-         %17 = OpTypeFunction %void %_ptr_Function_DefaultConstructorIntrinsic
-         %19 = OpTypeFunction %void
       %int_0 = OpConstant %int 0
      %uint_0 = OpConstant %uint 0
+      %float = OpTypeFloat 32
     %float_0 = OpConstant %float 0
      %uint_1 = OpConstant %uint 1
       %int_1 = OpConstant %int 1
     %float_2 = OpConstant %float 2
-%MyClass_PreConstructor = OpFunction %void None %11
+    %MyClass = OpTypeStruct %int %float
+       %void = OpTypeVoid
+%_ptr_Function_MyClass = OpTypePointer Function %MyClass
+         %17 = OpTypeFunction %void %_ptr_Function_MyClass
+%_ptr_Function_int = OpTypePointer Function %int
+%_ptr_Function_float = OpTypePointer Function %float
+         %19 = OpTypeFunction %void %_ptr_Function_MyClass %int %float
+%DefaultConstructorIntrinsic = OpTypeStruct
+%_ptr_Function_DefaultConstructorIntrinsic = OpTypePointer Function %DefaultConstructorIntrinsic
+         %23 = OpTypeFunction %void %_ptr_Function_DefaultConstructorIntrinsic
+         %25 = OpTypeFunction %void
+%MyClass_PreConstructor = OpFunction %void None %17
        %self = OpFunctionParameter %_ptr_Function_MyClass
          %30 = OpLabel
          %31 = OpAccessChain %_ptr_Function_int %self %uint_0
@@ -62,13 +62,13 @@
                OpStore %33 %float_0
                OpReturn
                OpFunctionEnd
-%MyClass_DefaultConstructor = OpFunction %void None %11
+%MyClass_DefaultConstructor = OpFunction %void None %17
      %self_0 = OpFunctionParameter %_ptr_Function_MyClass
          %39 = OpLabel
          %40 = OpFunctionCall %void %MyClass_PreConstructor %self_0
                OpReturn
                OpFunctionEnd
-%MyClass_Constructor = OpFunction %void None %13
+%MyClass_Constructor = OpFunction %void None %19
      %self_1 = OpFunctionParameter %_ptr_Function_MyClass
      %intVal = OpFunctionParameter %int
    %floatVal = OpFunctionParameter %float
@@ -79,18 +79,18 @@
                OpStore %50 %floatVal
                OpReturn
                OpFunctionEnd
-%DefaultConstructorIntrinsic_PreConstructor = OpFunction %void None %17
+%DefaultConstructorIntrinsic_PreConstructor = OpFunction %void None %23
      %self_2 = OpFunctionParameter %_ptr_Function_DefaultConstructorIntrinsic
          %56 = OpLabel
                OpReturn
                OpFunctionEnd
-%DefaultConstructorIntrinsic_DefaultConstructor = OpFunction %void None %17
+%DefaultConstructorIntrinsic_DefaultConstructor = OpFunction %void None %23
      %self_3 = OpFunctionParameter %_ptr_Function_DefaultConstructorIntrinsic
          %61 = OpLabel
          %62 = OpFunctionCall %void %DefaultConstructorIntrinsic_PreConstructor %self_3
                OpReturn
                OpFunctionEnd
-       %Main = OpFunction %void None %17
+       %Main = OpFunction %void None %23
      %self_4 = OpFunctionParameter %_ptr_Function_DefaultConstructorIntrinsic
          %67 = OpLabel
     %myClass = OpVariable %_ptr_Function_MyClass Function
@@ -100,7 +100,7 @@
                OpStore %myClass %71
                OpReturn
                OpFunctionEnd
-%DefaultConstructorIntrinsic_Main_EntryPoint = OpFunction %void None %19
+%DefaultConstructorIntrinsic_Main_EntryPoint = OpFunction %void None %25
          %76 = OpLabel
      %self_5 = OpVariable %_ptr_Function_DefaultConstructorIntrinsic Function
          %78 = OpFunctionCall %void %DefaultConstructorIntrinsic_DefaultConstructor %self_5

--- a/CSShadersTests/Tests/LanguageBasics/Construction/ExplicitDefaultConstructor.expected.spvtxt
+++ b/CSShadersTests/Tests/LanguageBasics/Construction/ExplicitDefaultConstructor.expected.spvtxt
@@ -31,22 +31,22 @@
                OpName %self_4 "self"
        %uint = OpTypeInt 32 0
         %int = OpTypeInt 32 1
+      %int_0 = OpConstant %int 0
+     %uint_0 = OpConstant %uint 0
       %float = OpTypeFloat 32
+    %float_0 = OpConstant %float 0
+     %uint_1 = OpConstant %uint 1
     %MyClass = OpTypeStruct %int %float
        %void = OpTypeVoid
 %_ptr_Function_MyClass = OpTypePointer Function %MyClass
-         %11 = OpTypeFunction %void %_ptr_Function_MyClass
+         %15 = OpTypeFunction %void %_ptr_Function_MyClass
 %_ptr_Function_int = OpTypePointer Function %int
 %_ptr_Function_float = OpTypePointer Function %float
 %DefaultConstructorIntrinsic = OpTypeStruct
 %_ptr_Function_DefaultConstructorIntrinsic = OpTypePointer Function %DefaultConstructorIntrinsic
-         %15 = OpTypeFunction %void %_ptr_Function_DefaultConstructorIntrinsic
-         %17 = OpTypeFunction %void
-      %int_0 = OpConstant %int 0
-     %uint_0 = OpConstant %uint 0
-    %float_0 = OpConstant %float 0
-     %uint_1 = OpConstant %uint 1
-%MyClass_PreConstructor = OpFunction %void None %11
+         %19 = OpTypeFunction %void %_ptr_Function_DefaultConstructorIntrinsic
+         %21 = OpTypeFunction %void
+%MyClass_PreConstructor = OpFunction %void None %15
        %self = OpFunctionParameter %_ptr_Function_MyClass
          %26 = OpLabel
          %27 = OpAccessChain %_ptr_Function_int %self %uint_0
@@ -55,24 +55,24 @@
                OpStore %29 %float_0
                OpReturn
                OpFunctionEnd
-%MyClass_DefaultConstructor = OpFunction %void None %11
+%MyClass_DefaultConstructor = OpFunction %void None %15
      %self_0 = OpFunctionParameter %_ptr_Function_MyClass
          %35 = OpLabel
          %36 = OpFunctionCall %void %MyClass_PreConstructor %self_0
                OpReturn
                OpFunctionEnd
-%DefaultConstructorIntrinsic_PreConstructor = OpFunction %void None %15
+%DefaultConstructorIntrinsic_PreConstructor = OpFunction %void None %19
      %self_1 = OpFunctionParameter %_ptr_Function_DefaultConstructorIntrinsic
          %41 = OpLabel
                OpReturn
                OpFunctionEnd
-%DefaultConstructorIntrinsic_DefaultConstructor = OpFunction %void None %15
+%DefaultConstructorIntrinsic_DefaultConstructor = OpFunction %void None %19
      %self_2 = OpFunctionParameter %_ptr_Function_DefaultConstructorIntrinsic
          %46 = OpLabel
          %47 = OpFunctionCall %void %DefaultConstructorIntrinsic_PreConstructor %self_2
                OpReturn
                OpFunctionEnd
-       %Main = OpFunction %void None %15
+       %Main = OpFunction %void None %19
      %self_3 = OpFunctionParameter %_ptr_Function_DefaultConstructorIntrinsic
          %52 = OpLabel
     %myClass = OpVariable %_ptr_Function_MyClass Function
@@ -82,7 +82,7 @@
                OpStore %myClass %56
                OpReturn
                OpFunctionEnd
-%DefaultConstructorIntrinsic_Main_EntryPoint = OpFunction %void None %17
+%DefaultConstructorIntrinsic_Main_EntryPoint = OpFunction %void None %21
          %61 = OpLabel
      %self_4 = OpVariable %_ptr_Function_DefaultConstructorIntrinsic Function
          %63 = OpFunctionCall %void %DefaultConstructorIntrinsic_DefaultConstructor %self_4

--- a/CSShadersTests/Tests/LanguageBasics/Construction/ImplicitDefaultConstructor.expected.spvtxt
+++ b/CSShadersTests/Tests/LanguageBasics/Construction/ImplicitDefaultConstructor.expected.spvtxt
@@ -30,22 +30,22 @@
                OpName %self_4 "self"
        %uint = OpTypeInt 32 0
         %int = OpTypeInt 32 1
+      %int_0 = OpConstant %int 0
+     %uint_0 = OpConstant %uint 0
       %float = OpTypeFloat 32
+    %float_0 = OpConstant %float 0
+     %uint_1 = OpConstant %uint 1
     %MyClass = OpTypeStruct %int %float
        %void = OpTypeVoid
 %_ptr_Function_MyClass = OpTypePointer Function %MyClass
-         %11 = OpTypeFunction %void %_ptr_Function_MyClass
+         %15 = OpTypeFunction %void %_ptr_Function_MyClass
 %_ptr_Function_int = OpTypePointer Function %int
 %_ptr_Function_float = OpTypePointer Function %float
 %ImplicitDefaultConstructor = OpTypeStruct
 %_ptr_Function_ImplicitDefaultConstructor = OpTypePointer Function %ImplicitDefaultConstructor
-         %15 = OpTypeFunction %void %_ptr_Function_ImplicitDefaultConstructor
-         %17 = OpTypeFunction %void
-      %int_0 = OpConstant %int 0
-     %uint_0 = OpConstant %uint 0
-    %float_0 = OpConstant %float 0
-     %uint_1 = OpConstant %uint 1
-%MyClass_PreConstructor = OpFunction %void None %11
+         %19 = OpTypeFunction %void %_ptr_Function_ImplicitDefaultConstructor
+         %21 = OpTypeFunction %void
+%MyClass_PreConstructor = OpFunction %void None %15
        %self = OpFunctionParameter %_ptr_Function_MyClass
          %26 = OpLabel
          %27 = OpAccessChain %_ptr_Function_int %self %uint_0
@@ -54,31 +54,31 @@
                OpStore %29 %float_0
                OpReturn
                OpFunctionEnd
-%MyClass_DefaultConstructor = OpFunction %void None %11
+%MyClass_DefaultConstructor = OpFunction %void None %15
      %self_0 = OpFunctionParameter %_ptr_Function_MyClass
          %35 = OpLabel
          %36 = OpFunctionCall %void %MyClass_PreConstructor %self_0
                OpReturn
                OpFunctionEnd
-%ImplicitDefaultConstructor_PreConstructor = OpFunction %void None %15
+%ImplicitDefaultConstructor_PreConstructor = OpFunction %void None %19
      %self_1 = OpFunctionParameter %_ptr_Function_ImplicitDefaultConstructor
          %41 = OpLabel
                OpReturn
                OpFunctionEnd
-%ImplicitDefaultConstructor_DefaultConstructor = OpFunction %void None %15
+%ImplicitDefaultConstructor_DefaultConstructor = OpFunction %void None %19
      %self_2 = OpFunctionParameter %_ptr_Function_ImplicitDefaultConstructor
          %46 = OpLabel
          %47 = OpFunctionCall %void %ImplicitDefaultConstructor_PreConstructor %self_2
                OpReturn
                OpFunctionEnd
-       %Main = OpFunction %void None %15
+       %Main = OpFunction %void None %19
      %self_3 = OpFunctionParameter %_ptr_Function_ImplicitDefaultConstructor
          %52 = OpLabel
     %myClass = OpVariable %_ptr_Function_MyClass Function
          %54 = OpFunctionCall %void %MyClass_DefaultConstructor %myClass
                OpReturn
                OpFunctionEnd
-%ImplicitDefaultConstructor_Main_EntryPoint = OpFunction %void None %17
+%ImplicitDefaultConstructor_Main_EntryPoint = OpFunction %void None %21
          %58 = OpLabel
      %self_4 = OpVariable %_ptr_Function_ImplicitDefaultConstructor Function
          %60 = OpFunctionCall %void %ImplicitDefaultConstructor_DefaultConstructor %self_4

--- a/CSShadersTests/Tests/LanguageBasics/Construction/ImplicitDefaultConstructorFloatIntrinsic.expected.spvtxt
+++ b/CSShadersTests/Tests/LanguageBasics/Construction/ImplicitDefaultConstructorFloatIntrinsic.expected.spvtxt
@@ -23,32 +23,32 @@
                OpName %self_2 "self"
        %uint = OpTypeInt 32 0
       %float = OpTypeFloat 32
+    %float_0 = OpConstant %float 0
 %ImplicitDefaultConstructorFloatIntrinsic = OpTypeStruct
        %void = OpTypeVoid
 %_ptr_Function_ImplicitDefaultConstructorFloatIntrinsic = OpTypePointer Function %ImplicitDefaultConstructorFloatIntrinsic
-          %9 = OpTypeFunction %void %_ptr_Function_ImplicitDefaultConstructorFloatIntrinsic
+         %10 = OpTypeFunction %void %_ptr_Function_ImplicitDefaultConstructorFloatIntrinsic
 %_ptr_Function_float = OpTypePointer Function %float
-         %11 = OpTypeFunction %void
-    %float_0 = OpConstant %float 0
-%ImplicitDefaultConstructorFloatIntrinsic_PreConstructor = OpFunction %void None %9
+         %12 = OpTypeFunction %void
+%ImplicitDefaultConstructorFloatIntrinsic_PreConstructor = OpFunction %void None %10
        %self = OpFunctionParameter %_ptr_Function_ImplicitDefaultConstructorFloatIntrinsic
          %17 = OpLabel
                OpReturn
                OpFunctionEnd
-%ImplicitDefaultConstructorFloatIntrinsic_DefaultConstructor = OpFunction %void None %9
+%ImplicitDefaultConstructorFloatIntrinsic_DefaultConstructor = OpFunction %void None %10
      %self_0 = OpFunctionParameter %_ptr_Function_ImplicitDefaultConstructorFloatIntrinsic
          %22 = OpLabel
          %23 = OpFunctionCall %void %ImplicitDefaultConstructorFloatIntrinsic_PreConstructor %self_0
                OpReturn
                OpFunctionEnd
-       %Main = OpFunction %void None %9
+       %Main = OpFunction %void None %10
      %self_1 = OpFunctionParameter %_ptr_Function_ImplicitDefaultConstructorFloatIntrinsic
          %28 = OpLabel
     %myFloat = OpVariable %_ptr_Function_float Function
                OpStore %myFloat %float_0
                OpReturn
                OpFunctionEnd
-%ImplicitDefaultConstructorFloatIntrinsic_Main_EntryPoint = OpFunction %void None %11
+%ImplicitDefaultConstructorFloatIntrinsic_Main_EntryPoint = OpFunction %void None %12
          %34 = OpLabel
      %self_2 = OpVariable %_ptr_Function_ImplicitDefaultConstructorFloatIntrinsic Function
          %36 = OpFunctionCall %void %ImplicitDefaultConstructorFloatIntrinsic_DefaultConstructor %self_2

--- a/CSShadersTests/Tests/LanguageBasics/Construction/ImplicitDefaultConstructorMatrixIntrinsic.expected.spvtxt
+++ b/CSShadersTests/Tests/LanguageBasics/Construction/ImplicitDefaultConstructorMatrixIntrinsic.expected.spvtxt
@@ -25,27 +25,27 @@
                OpName %self_2 "self"
        %uint = OpTypeInt 32 0
       %float = OpTypeFloat 32
+    %float_0 = OpConstant %float 0
          %V2 = OpTypeVector %float 2
        %M2x2 = OpTypeMatrix %V2 2
 %ImplicitDefaultConstructorMatrixIntrinsic = OpTypeStruct
        %void = OpTypeVoid
 %_ptr_Function_ImplicitDefaultConstructorMatrixIntrinsic = OpTypePointer Function %ImplicitDefaultConstructorMatrixIntrinsic
-         %13 = OpTypeFunction %void %_ptr_Function_ImplicitDefaultConstructorMatrixIntrinsic
+         %14 = OpTypeFunction %void %_ptr_Function_ImplicitDefaultConstructorMatrixIntrinsic
 %_ptr_Function_M2x2 = OpTypePointer Function %M2x2
-         %15 = OpTypeFunction %void
-    %float_0 = OpConstant %float 0
-%ImplicitDefaultConstructorMatrixIntrinsic_PreConstructor = OpFunction %void None %13
+         %16 = OpTypeFunction %void
+%ImplicitDefaultConstructorMatrixIntrinsic_PreConstructor = OpFunction %void None %14
        %self = OpFunctionParameter %_ptr_Function_ImplicitDefaultConstructorMatrixIntrinsic
          %21 = OpLabel
                OpReturn
                OpFunctionEnd
-%ImplicitDefaultConstructorMatrixIntrinsic_DefaultConstructor = OpFunction %void None %13
+%ImplicitDefaultConstructorMatrixIntrinsic_DefaultConstructor = OpFunction %void None %14
      %self_0 = OpFunctionParameter %_ptr_Function_ImplicitDefaultConstructorMatrixIntrinsic
          %26 = OpLabel
          %27 = OpFunctionCall %void %ImplicitDefaultConstructorMatrixIntrinsic_PreConstructor %self_0
                OpReturn
                OpFunctionEnd
-       %Main = OpFunction %void None %13
+       %Main = OpFunction %void None %14
      %self_1 = OpFunctionParameter %_ptr_Function_ImplicitDefaultConstructorMatrixIntrinsic
          %32 = OpLabel
    %myMatrix = OpVariable %_ptr_Function_M2x2 Function
@@ -54,7 +54,7 @@
                OpStore %myMatrix %35
                OpReturn
                OpFunctionEnd
-%ImplicitDefaultConstructorMatrixIntrinsic_Main_EntryPoint = OpFunction %void None %15
+%ImplicitDefaultConstructorMatrixIntrinsic_Main_EntryPoint = OpFunction %void None %16
          %40 = OpLabel
      %self_2 = OpVariable %_ptr_Function_ImplicitDefaultConstructorMatrixIntrinsic Function
          %42 = OpFunctionCall %void %ImplicitDefaultConstructorMatrixIntrinsic_DefaultConstructor %self_2

--- a/CSShadersTests/Tests/LanguageBasics/ControlFlow/CombinedControlFlow/DoWhileIf.expected.spvtxt
+++ b/CSShadersTests/Tests/LanguageBasics/ControlFlow/CombinedControlFlow/DoWhileIf.expected.spvtxt
@@ -54,28 +54,28 @@
                OpName %self_5 "self"
        %uint = OpTypeInt 32 0
         %int = OpTypeInt 32 1
+      %int_1 = OpConstant %int 1
+      %int_0 = OpConstant %int 0
   %DoWhileIf = OpTypeStruct
        %void = OpTypeVoid
 %_ptr_Function_DoWhileIf = OpTypePointer Function %DoWhileIf
-          %9 = OpTypeFunction %void %_ptr_Function_DoWhileIf
-         %11 = OpTypeFunction %int %_ptr_Function_DoWhileIf
+         %11 = OpTypeFunction %void %_ptr_Function_DoWhileIf
+         %13 = OpTypeFunction %int %_ptr_Function_DoWhileIf
 %_ptr_Function_int = OpTypePointer Function %int
        %bool = OpTypeBool
-         %15 = OpTypeFunction %void
-      %int_1 = OpConstant %int 1
-      %int_0 = OpConstant %int 0
-%DoWhileIf_PreConstructor = OpFunction %void None %9
+         %17 = OpTypeFunction %void
+%DoWhileIf_PreConstructor = OpFunction %void None %11
        %self = OpFunctionParameter %_ptr_Function_DoWhileIf
          %22 = OpLabel
                OpReturn
                OpFunctionEnd
-%DoWhileIf_DefaultConstructor = OpFunction %void None %9
+%DoWhileIf_DefaultConstructor = OpFunction %void None %11
      %self_0 = OpFunctionParameter %_ptr_Function_DoWhileIf
          %27 = OpLabel
          %28 = OpFunctionCall %void %DoWhileIf_PreConstructor %self_0
                OpReturn
                OpFunctionEnd
- %DoWhileIf0 = OpFunction %int None %11
+ %DoWhileIf0 = OpFunction %int None %13
      %self_1 = OpFunctionParameter %_ptr_Function_DoWhileIf
          %33 = OpLabel
           %a = OpVariable %_ptr_Function_int Function
@@ -104,7 +104,7 @@
          %57 = OpLoad %int %a
                OpReturnValue %57
                OpFunctionEnd
- %DoWhileIf1 = OpFunction %int None %11
+ %DoWhileIf1 = OpFunction %int None %13
      %self_2 = OpFunctionParameter %_ptr_Function_DoWhileIf
          %62 = OpLabel
         %a_0 = OpVariable %_ptr_Function_int Function
@@ -133,7 +133,7 @@
          %86 = OpLoad %int %a_0
                OpReturnValue %86
                OpFunctionEnd
- %DoWhileIf2 = OpFunction %int None %11
+ %DoWhileIf2 = OpFunction %int None %13
      %self_3 = OpFunctionParameter %_ptr_Function_DoWhileIf
          %91 = OpLabel
         %a_1 = OpVariable %_ptr_Function_int Function
@@ -174,7 +174,7 @@
         %127 = OpLoad %int %a_1
                OpReturnValue %127
                OpFunctionEnd
-       %Main = OpFunction %void None %9
+       %Main = OpFunction %void None %11
      %self_4 = OpFunctionParameter %_ptr_Function_DoWhileIf
         %132 = OpLabel
         %ret = OpVariable %_ptr_Function_int Function
@@ -187,7 +187,7 @@
                OpStore %ret %139
                OpReturn
                OpFunctionEnd
-%DoWhileIf_Main_EntryPoint = OpFunction %void None %15
+%DoWhileIf_Main_EntryPoint = OpFunction %void None %17
         %144 = OpLabel
      %self_5 = OpVariable %_ptr_Function_DoWhileIf Function
         %146 = OpFunctionCall %void %DoWhileIf_DefaultConstructor %self_5

--- a/CSShadersTests/Tests/LanguageBasics/ControlFlow/CombinedControlFlow/ForIf.expected.spvtxt
+++ b/CSShadersTests/Tests/LanguageBasics/ControlFlow/CombinedControlFlow/ForIf.expected.spvtxt
@@ -60,28 +60,28 @@
                OpName %self_5 "self"
        %uint = OpTypeInt 32 0
         %int = OpTypeInt 32 1
+      %int_0 = OpConstant %int 0
+      %int_1 = OpConstant %int 1
       %ForIf = OpTypeStruct
        %void = OpTypeVoid
 %_ptr_Function_ForIf = OpTypePointer Function %ForIf
-          %9 = OpTypeFunction %void %_ptr_Function_ForIf
-         %11 = OpTypeFunction %int %_ptr_Function_ForIf
+         %11 = OpTypeFunction %void %_ptr_Function_ForIf
+         %13 = OpTypeFunction %int %_ptr_Function_ForIf
 %_ptr_Function_int = OpTypePointer Function %int
        %bool = OpTypeBool
-         %15 = OpTypeFunction %void
-      %int_0 = OpConstant %int 0
-      %int_1 = OpConstant %int 1
-%ForIf_PreConstructor = OpFunction %void None %9
+         %17 = OpTypeFunction %void
+%ForIf_PreConstructor = OpFunction %void None %11
        %self = OpFunctionParameter %_ptr_Function_ForIf
          %22 = OpLabel
                OpReturn
                OpFunctionEnd
-%ForIf_DefaultConstructor = OpFunction %void None %9
+%ForIf_DefaultConstructor = OpFunction %void None %11
      %self_0 = OpFunctionParameter %_ptr_Function_ForIf
          %27 = OpLabel
          %28 = OpFunctionCall %void %ForIf_PreConstructor %self_0
                OpReturn
                OpFunctionEnd
-     %ForIf0 = OpFunction %int None %11
+     %ForIf0 = OpFunction %int None %13
      %self_1 = OpFunctionParameter %_ptr_Function_ForIf
          %33 = OpLabel
      %result = OpVariable %_ptr_Function_int Function
@@ -117,7 +117,7 @@
          %64 = OpLoad %int %result
                OpReturnValue %64
                OpFunctionEnd
-     %ForIf1 = OpFunction %int None %11
+     %ForIf1 = OpFunction %int None %13
      %self_2 = OpFunctionParameter %_ptr_Function_ForIf
          %69 = OpLabel
    %result_0 = OpVariable %_ptr_Function_int Function
@@ -153,7 +153,7 @@
         %100 = OpLoad %int %result_0
                OpReturnValue %100
                OpFunctionEnd
-     %ForIf2 = OpFunction %int None %11
+     %ForIf2 = OpFunction %int None %13
      %self_3 = OpFunctionParameter %_ptr_Function_ForIf
         %105 = OpLabel
    %result_1 = OpVariable %_ptr_Function_int Function
@@ -201,7 +201,7 @@
         %148 = OpLoad %int %result_1
                OpReturnValue %148
                OpFunctionEnd
-       %Main = OpFunction %void None %9
+       %Main = OpFunction %void None %11
      %self_4 = OpFunctionParameter %_ptr_Function_ForIf
         %153 = OpLabel
         %ret = OpVariable %_ptr_Function_int Function
@@ -214,7 +214,7 @@
                OpStore %ret %160
                OpReturn
                OpFunctionEnd
-%ForIf_Main_EntryPoint = OpFunction %void None %15
+%ForIf_Main_EntryPoint = OpFunction %void None %17
         %165 = OpLabel
      %self_5 = OpVariable %_ptr_Function_ForIf Function
         %167 = OpFunctionCall %void %ForIf_DefaultConstructor %self_5

--- a/CSShadersTests/Tests/LanguageBasics/ControlFlow/CombinedControlFlow/ShortCircuitIf.expected.spvtxt
+++ b/CSShadersTests/Tests/LanguageBasics/ControlFlow/CombinedControlFlow/ShortCircuitIf.expected.spvtxt
@@ -67,34 +67,34 @@
                OpName %ShortCircuitIf_Main_EntryPoint "ShortCircuitIf_Main_EntryPoint"
                OpName %self_5 "self"
        %bool = OpTypeBool
-       %uint = OpTypeInt 32 0
-        %int = OpTypeInt 32 1
-%ShortCircuitIf = OpTypeStruct
-       %void = OpTypeVoid
-%_ptr_Function_ShortCircuitIf = OpTypePointer Function %ShortCircuitIf
-         %11 = OpTypeFunction %void %_ptr_Function_ShortCircuitIf
-         %13 = OpTypeFunction %int %_ptr_Function_ShortCircuitIf
-%_ptr_Function_bool = OpTypePointer Function %bool
-%_ptr_Function_int = OpTypePointer Function %int
-         %15 = OpTypeFunction %void
        %true = OpConstantTrue %bool
       %false = OpConstantFalse %bool
+       %uint = OpTypeInt 32 0
+        %int = OpTypeInt 32 1
       %int_0 = OpConstant %int 0
       %int_3 = OpConstant %int 3
       %int_1 = OpConstant %int 1
       %int_2 = OpConstant %int 2
-%ShortCircuitIf_PreConstructor = OpFunction %void None %11
+%ShortCircuitIf = OpTypeStruct
+       %void = OpTypeVoid
+%_ptr_Function_ShortCircuitIf = OpTypePointer Function %ShortCircuitIf
+         %17 = OpTypeFunction %void %_ptr_Function_ShortCircuitIf
+         %19 = OpTypeFunction %int %_ptr_Function_ShortCircuitIf
+%_ptr_Function_bool = OpTypePointer Function %bool
+%_ptr_Function_int = OpTypePointer Function %int
+         %21 = OpTypeFunction %void
+%ShortCircuitIf_PreConstructor = OpFunction %void None %17
        %self = OpFunctionParameter %_ptr_Function_ShortCircuitIf
          %26 = OpLabel
                OpReturn
                OpFunctionEnd
-%ShortCircuitIf_DefaultConstructor = OpFunction %void None %11
+%ShortCircuitIf_DefaultConstructor = OpFunction %void None %17
      %self_0 = OpFunctionParameter %_ptr_Function_ShortCircuitIf
          %31 = OpLabel
          %32 = OpFunctionCall %void %ShortCircuitIf_PreConstructor %self_0
                OpReturn
                OpFunctionEnd
-%ShortCircuitIf0 = OpFunction %int None %13
+%ShortCircuitIf0 = OpFunction %int None %19
      %self_1 = OpFunctionParameter %_ptr_Function_ShortCircuitIf
          %37 = OpLabel
         %lhs = OpVariable %_ptr_Function_bool Function
@@ -121,7 +121,7 @@
    %ifMerge0 = OpLabel
                OpReturnValue %int_3
                OpFunctionEnd
-%ShortCircuitIf1 = OpFunction %int None %13
+%ShortCircuitIf1 = OpFunction %int None %19
      %self_2 = OpFunctionParameter %_ptr_Function_ShortCircuitIf
          %64 = OpLabel
       %lhs_0 = OpVariable %_ptr_Function_bool Function
@@ -168,7 +168,7 @@
  %ifMerge0_0 = OpLabel
                OpReturnValue %int_3
                OpFunctionEnd
-%ShortCircuitIf2 = OpFunction %int None %13
+%ShortCircuitIf2 = OpFunction %int None %19
      %self_3 = OpFunctionParameter %_ptr_Function_ShortCircuitIf
         %111 = OpLabel
       %lhs_1 = OpVariable %_ptr_Function_bool Function
@@ -217,7 +217,7 @@
  %ifMerge0_1 = OpLabel
                OpUnreachable
                OpFunctionEnd
-       %Main = OpFunction %void None %11
+       %Main = OpFunction %void None %17
      %self_4 = OpFunctionParameter %_ptr_Function_ShortCircuitIf
         %160 = OpLabel
         %ret = OpVariable %_ptr_Function_int Function
@@ -230,7 +230,7 @@
                OpStore %ret %167
                OpReturn
                OpFunctionEnd
-%ShortCircuitIf_Main_EntryPoint = OpFunction %void None %15
+%ShortCircuitIf_Main_EntryPoint = OpFunction %void None %21
         %172 = OpLabel
      %self_5 = OpVariable %_ptr_Function_ShortCircuitIf Function
         %174 = OpFunctionCall %void %ShortCircuitIf_DefaultConstructor %self_5

--- a/CSShadersTests/Tests/LanguageBasics/ControlFlow/CombinedControlFlow/WhileIf.expected.spvtxt
+++ b/CSShadersTests/Tests/LanguageBasics/ControlFlow/CombinedControlFlow/WhileIf.expected.spvtxt
@@ -57,28 +57,28 @@
                OpName %self_5 "self"
        %uint = OpTypeInt 32 0
         %int = OpTypeInt 32 1
+      %int_1 = OpConstant %int 1
+      %int_0 = OpConstant %int 0
     %WhileIf = OpTypeStruct
        %void = OpTypeVoid
 %_ptr_Function_WhileIf = OpTypePointer Function %WhileIf
-          %9 = OpTypeFunction %void %_ptr_Function_WhileIf
-         %11 = OpTypeFunction %int %_ptr_Function_WhileIf
+         %11 = OpTypeFunction %void %_ptr_Function_WhileIf
+         %13 = OpTypeFunction %int %_ptr_Function_WhileIf
 %_ptr_Function_int = OpTypePointer Function %int
        %bool = OpTypeBool
-         %15 = OpTypeFunction %void
-      %int_1 = OpConstant %int 1
-      %int_0 = OpConstant %int 0
-%WhileIf_PreConstructor = OpFunction %void None %9
+         %17 = OpTypeFunction %void
+%WhileIf_PreConstructor = OpFunction %void None %11
        %self = OpFunctionParameter %_ptr_Function_WhileIf
          %22 = OpLabel
                OpReturn
                OpFunctionEnd
-%WhileIf_DefaultConstructor = OpFunction %void None %9
+%WhileIf_DefaultConstructor = OpFunction %void None %11
      %self_0 = OpFunctionParameter %_ptr_Function_WhileIf
          %27 = OpLabel
          %28 = OpFunctionCall %void %WhileIf_PreConstructor %self_0
                OpReturn
                OpFunctionEnd
-   %WhileIf0 = OpFunction %int None %11
+   %WhileIf0 = OpFunction %int None %13
      %self_1 = OpFunctionParameter %_ptr_Function_WhileIf
          %33 = OpLabel
           %a = OpVariable %_ptr_Function_int Function
@@ -109,7 +109,7 @@
          %59 = OpLoad %int %a
                OpReturnValue %59
                OpFunctionEnd
-   %WhileIf1 = OpFunction %int None %11
+   %WhileIf1 = OpFunction %int None %13
      %self_2 = OpFunctionParameter %_ptr_Function_WhileIf
          %64 = OpLabel
         %a_0 = OpVariable %_ptr_Function_int Function
@@ -140,7 +140,7 @@
          %90 = OpLoad %int %a_0
                OpReturnValue %90
                OpFunctionEnd
-   %WhileIf2 = OpFunction %int None %11
+   %WhileIf2 = OpFunction %int None %13
      %self_3 = OpFunctionParameter %_ptr_Function_WhileIf
          %95 = OpLabel
         %a_1 = OpVariable %_ptr_Function_int Function
@@ -183,7 +183,7 @@
         %133 = OpLoad %int %a_1
                OpReturnValue %133
                OpFunctionEnd
-       %Main = OpFunction %void None %9
+       %Main = OpFunction %void None %11
      %self_4 = OpFunctionParameter %_ptr_Function_WhileIf
         %138 = OpLabel
         %ret = OpVariable %_ptr_Function_int Function
@@ -196,7 +196,7 @@
                OpStore %ret %145
                OpReturn
                OpFunctionEnd
-%WhileIf_Main_EntryPoint = OpFunction %void None %15
+%WhileIf_Main_EntryPoint = OpFunction %void None %17
         %150 = OpLabel
      %self_5 = OpVariable %_ptr_Function_WhileIf Function
         %152 = OpFunctionCall %void %WhileIf_DefaultConstructor %self_5

--- a/CSShadersTests/Tests/LanguageBasics/ControlFlow/DoWhile/DoWhile.expected.spvtxt
+++ b/CSShadersTests/Tests/LanguageBasics/ControlFlow/DoWhile/DoWhile.expected.spvtxt
@@ -30,28 +30,28 @@
                OpName %self_3 "self"
        %uint = OpTypeInt 32 0
         %int = OpTypeInt 32 1
+      %int_1 = OpConstant %int 1
+      %int_0 = OpConstant %int 0
     %DoWhile = OpTypeStruct
        %void = OpTypeVoid
 %_ptr_Function_DoWhile = OpTypePointer Function %DoWhile
-          %9 = OpTypeFunction %void %_ptr_Function_DoWhile
-         %11 = OpTypeFunction %int %_ptr_Function_DoWhile
+         %11 = OpTypeFunction %void %_ptr_Function_DoWhile
+         %13 = OpTypeFunction %int %_ptr_Function_DoWhile
 %_ptr_Function_int = OpTypePointer Function %int
        %bool = OpTypeBool
-         %15 = OpTypeFunction %void
-      %int_1 = OpConstant %int 1
-      %int_0 = OpConstant %int 0
-%DoWhile_PreConstructor = OpFunction %void None %9
+         %17 = OpTypeFunction %void
+%DoWhile_PreConstructor = OpFunction %void None %11
        %self = OpFunctionParameter %_ptr_Function_DoWhile
          %22 = OpLabel
                OpReturn
                OpFunctionEnd
-%DoWhile_DefaultConstructor = OpFunction %void None %9
+%DoWhile_DefaultConstructor = OpFunction %void None %11
      %self_0 = OpFunctionParameter %_ptr_Function_DoWhile
          %27 = OpLabel
          %28 = OpFunctionCall %void %DoWhile_PreConstructor %self_0
                OpReturn
                OpFunctionEnd
-   %DoWhile0 = OpFunction %int None %11
+   %DoWhile0 = OpFunction %int None %13
      %self_1 = OpFunctionParameter %_ptr_Function_DoWhile
          %33 = OpLabel
           %a = OpVariable %_ptr_Function_int Function
@@ -73,7 +73,7 @@
          %50 = OpLoad %int %a
                OpReturnValue %50
                OpFunctionEnd
-       %Main = OpFunction %void None %9
+       %Main = OpFunction %void None %11
      %self_2 = OpFunctionParameter %_ptr_Function_DoWhile
          %55 = OpLabel
         %ret = OpVariable %_ptr_Function_int Function
@@ -81,7 +81,7 @@
                OpStore %ret %57
                OpReturn
                OpFunctionEnd
-%DoWhile_Main_EntryPoint = OpFunction %void None %15
+%DoWhile_Main_EntryPoint = OpFunction %void None %17
          %62 = OpLabel
      %self_3 = OpVariable %_ptr_Function_DoWhile Function
          %64 = OpFunctionCall %void %DoWhile_DefaultConstructor %self_3

--- a/CSShadersTests/Tests/LanguageBasics/ControlFlow/DoWhile/DoWhileBreak.expected.spvtxt
+++ b/CSShadersTests/Tests/LanguageBasics/ControlFlow/DoWhile/DoWhileBreak.expected.spvtxt
@@ -30,28 +30,28 @@
                OpName %self_3 "self"
        %uint = OpTypeInt 32 0
         %int = OpTypeInt 32 1
+      %int_1 = OpConstant %int 1
+      %int_0 = OpConstant %int 0
 %DoWhileBreak = OpTypeStruct
        %void = OpTypeVoid
 %_ptr_Function_DoWhileBreak = OpTypePointer Function %DoWhileBreak
-          %9 = OpTypeFunction %void %_ptr_Function_DoWhileBreak
-         %11 = OpTypeFunction %int %_ptr_Function_DoWhileBreak
+         %11 = OpTypeFunction %void %_ptr_Function_DoWhileBreak
+         %13 = OpTypeFunction %int %_ptr_Function_DoWhileBreak
 %_ptr_Function_int = OpTypePointer Function %int
        %bool = OpTypeBool
-         %15 = OpTypeFunction %void
-      %int_1 = OpConstant %int 1
-      %int_0 = OpConstant %int 0
-%DoWhileBreak_PreConstructor = OpFunction %void None %9
+         %17 = OpTypeFunction %void
+%DoWhileBreak_PreConstructor = OpFunction %void None %11
        %self = OpFunctionParameter %_ptr_Function_DoWhileBreak
          %22 = OpLabel
                OpReturn
                OpFunctionEnd
-%DoWhileBreak_DefaultConstructor = OpFunction %void None %9
+%DoWhileBreak_DefaultConstructor = OpFunction %void None %11
      %self_0 = OpFunctionParameter %_ptr_Function_DoWhileBreak
          %27 = OpLabel
          %28 = OpFunctionCall %void %DoWhileBreak_PreConstructor %self_0
                OpReturn
                OpFunctionEnd
-%DoWhileBreak0 = OpFunction %int None %11
+%DoWhileBreak0 = OpFunction %int None %13
      %self_1 = OpFunctionParameter %_ptr_Function_DoWhileBreak
          %33 = OpLabel
           %a = OpVariable %_ptr_Function_int Function
@@ -70,7 +70,7 @@
          %47 = OpLoad %int %a
                OpReturnValue %47
                OpFunctionEnd
-       %Main = OpFunction %void None %9
+       %Main = OpFunction %void None %11
      %self_2 = OpFunctionParameter %_ptr_Function_DoWhileBreak
          %52 = OpLabel
         %ret = OpVariable %_ptr_Function_int Function
@@ -78,7 +78,7 @@
                OpStore %ret %54
                OpReturn
                OpFunctionEnd
-%DoWhileBreak_Main_EntryPoint = OpFunction %void None %15
+%DoWhileBreak_Main_EntryPoint = OpFunction %void None %17
          %59 = OpLabel
      %self_3 = OpVariable %_ptr_Function_DoWhileBreak Function
          %61 = OpFunctionCall %void %DoWhileBreak_DefaultConstructor %self_3

--- a/CSShadersTests/Tests/LanguageBasics/ControlFlow/DoWhile/DoWhileContinue.expected.spvtxt
+++ b/CSShadersTests/Tests/LanguageBasics/ControlFlow/DoWhile/DoWhileContinue.expected.spvtxt
@@ -30,28 +30,28 @@
                OpName %self_3 "self"
        %uint = OpTypeInt 32 0
         %int = OpTypeInt 32 1
+      %int_1 = OpConstant %int 1
+      %int_0 = OpConstant %int 0
 %DoWhileContinue = OpTypeStruct
        %void = OpTypeVoid
 %_ptr_Function_DoWhileContinue = OpTypePointer Function %DoWhileContinue
-          %9 = OpTypeFunction %void %_ptr_Function_DoWhileContinue
-         %11 = OpTypeFunction %int %_ptr_Function_DoWhileContinue
+         %11 = OpTypeFunction %void %_ptr_Function_DoWhileContinue
+         %13 = OpTypeFunction %int %_ptr_Function_DoWhileContinue
 %_ptr_Function_int = OpTypePointer Function %int
        %bool = OpTypeBool
-         %15 = OpTypeFunction %void
-      %int_1 = OpConstant %int 1
-      %int_0 = OpConstant %int 0
-%DoWhileContinue_PreConstructor = OpFunction %void None %9
+         %17 = OpTypeFunction %void
+%DoWhileContinue_PreConstructor = OpFunction %void None %11
        %self = OpFunctionParameter %_ptr_Function_DoWhileContinue
          %22 = OpLabel
                OpReturn
                OpFunctionEnd
-%DoWhileContinue_DefaultConstructor = OpFunction %void None %9
+%DoWhileContinue_DefaultConstructor = OpFunction %void None %11
      %self_0 = OpFunctionParameter %_ptr_Function_DoWhileContinue
          %27 = OpLabel
          %28 = OpFunctionCall %void %DoWhileContinue_PreConstructor %self_0
                OpReturn
                OpFunctionEnd
-%DoWhileContinue0 = OpFunction %int None %11
+%DoWhileContinue0 = OpFunction %int None %13
      %self_1 = OpFunctionParameter %_ptr_Function_DoWhileContinue
          %33 = OpLabel
           %a = OpVariable %_ptr_Function_int Function
@@ -70,7 +70,7 @@
          %47 = OpLoad %int %a
                OpReturnValue %47
                OpFunctionEnd
-       %Main = OpFunction %void None %9
+       %Main = OpFunction %void None %11
      %self_2 = OpFunctionParameter %_ptr_Function_DoWhileContinue
          %52 = OpLabel
         %ret = OpVariable %_ptr_Function_int Function
@@ -78,7 +78,7 @@
                OpStore %ret %54
                OpReturn
                OpFunctionEnd
-%DoWhileContinue_Main_EntryPoint = OpFunction %void None %15
+%DoWhileContinue_Main_EntryPoint = OpFunction %void None %17
          %59 = OpLabel
      %self_3 = OpVariable %_ptr_Function_DoWhileContinue Function
          %61 = OpFunctionCall %void %DoWhileContinue_DefaultConstructor %self_3

--- a/CSShadersTests/Tests/LanguageBasics/ControlFlow/DoWhile/DoWhileNested.expected.spvtxt
+++ b/CSShadersTests/Tests/LanguageBasics/ControlFlow/DoWhile/DoWhileNested.expected.spvtxt
@@ -71,28 +71,28 @@
                OpName %self_6 "self"
        %uint = OpTypeInt 32 0
         %int = OpTypeInt 32 1
+      %int_1 = OpConstant %int 1
+      %int_0 = OpConstant %int 0
 %DoWhileNested = OpTypeStruct
        %void = OpTypeVoid
 %_ptr_Function_DoWhileNested = OpTypePointer Function %DoWhileNested
-          %9 = OpTypeFunction %void %_ptr_Function_DoWhileNested
-         %11 = OpTypeFunction %int %_ptr_Function_DoWhileNested
+         %11 = OpTypeFunction %void %_ptr_Function_DoWhileNested
+         %13 = OpTypeFunction %int %_ptr_Function_DoWhileNested
 %_ptr_Function_int = OpTypePointer Function %int
        %bool = OpTypeBool
-         %15 = OpTypeFunction %void
-      %int_1 = OpConstant %int 1
-      %int_0 = OpConstant %int 0
-%DoWhileNested_PreConstructor = OpFunction %void None %9
+         %17 = OpTypeFunction %void
+%DoWhileNested_PreConstructor = OpFunction %void None %11
        %self = OpFunctionParameter %_ptr_Function_DoWhileNested
          %22 = OpLabel
                OpReturn
                OpFunctionEnd
-%DoWhileNested_DefaultConstructor = OpFunction %void None %9
+%DoWhileNested_DefaultConstructor = OpFunction %void None %11
      %self_0 = OpFunctionParameter %_ptr_Function_DoWhileNested
          %27 = OpLabel
          %28 = OpFunctionCall %void %DoWhileNested_PreConstructor %self_0
                OpReturn
                OpFunctionEnd
-%DoWhileNested0 = OpFunction %int None %11
+%DoWhileNested0 = OpFunction %int None %13
      %self_1 = OpFunctionParameter %_ptr_Function_DoWhileNested
          %33 = OpLabel
           %a = OpVariable %_ptr_Function_int Function
@@ -130,7 +130,7 @@
          %66 = OpLoad %int %a
                OpReturnValue %66
                OpFunctionEnd
-%DoWhileNested1 = OpFunction %int None %11
+%DoWhileNested1 = OpFunction %int None %13
      %self_2 = OpFunctionParameter %_ptr_Function_DoWhileNested
          %71 = OpLabel
         %a_0 = OpVariable %_ptr_Function_int Function
@@ -165,7 +165,7 @@
         %101 = OpLoad %int %a_0
                OpReturnValue %101
                OpFunctionEnd
-%DoWhileNested2 = OpFunction %int None %11
+%DoWhileNested2 = OpFunction %int None %13
      %self_3 = OpFunctionParameter %_ptr_Function_DoWhileNested
         %106 = OpLabel
         %a_1 = OpVariable %_ptr_Function_int Function
@@ -200,7 +200,7 @@
         %136 = OpLoad %int %a_1
                OpReturnValue %136
                OpFunctionEnd
-%DoWhileNested3 = OpFunction %int None %11
+%DoWhileNested3 = OpFunction %int None %13
      %self_4 = OpFunctionParameter %_ptr_Function_DoWhileNested
         %141 = OpLabel
         %a_2 = OpVariable %_ptr_Function_int Function
@@ -232,7 +232,7 @@
         %168 = OpLoad %int %a_2
                OpReturnValue %168
                OpFunctionEnd
-       %Main = OpFunction %void None %9
+       %Main = OpFunction %void None %11
      %self_5 = OpFunctionParameter %_ptr_Function_DoWhileNested
         %173 = OpLabel
         %ret = OpVariable %_ptr_Function_int Function
@@ -247,7 +247,7 @@
                OpStore %ret %182
                OpReturn
                OpFunctionEnd
-%DoWhileNested_Main_EntryPoint = OpFunction %void None %15
+%DoWhileNested_Main_EntryPoint = OpFunction %void None %17
         %187 = OpLabel
      %self_6 = OpVariable %_ptr_Function_DoWhileNested Function
         %189 = OpFunctionCall %void %DoWhileNested_DefaultConstructor %self_6

--- a/CSShadersTests/Tests/LanguageBasics/ControlFlow/For/ForBasic0.expected.spvtxt
+++ b/CSShadersTests/Tests/LanguageBasics/ControlFlow/For/ForBasic0.expected.spvtxt
@@ -51,29 +51,29 @@
                OpName %self_5 "self"
        %uint = OpTypeInt 32 0
         %int = OpTypeInt 32 1
-  %ForBasic0 = OpTypeStruct
-       %void = OpTypeVoid
-%_ptr_Function_ForBasic0 = OpTypePointer Function %ForBasic0
-          %9 = OpTypeFunction %void %_ptr_Function_ForBasic0
-         %11 = OpTypeFunction %int %_ptr_Function_ForBasic0
-%_ptr_Function_int = OpTypePointer Function %int
-       %bool = OpTypeBool
-         %15 = OpTypeFunction %void
       %int_0 = OpConstant %int 0
      %int_10 = OpConstant %int 10
       %int_1 = OpConstant %int 1
-%ForBasic0_PreConstructor = OpFunction %void None %9
+  %ForBasic0 = OpTypeStruct
+       %void = OpTypeVoid
+%_ptr_Function_ForBasic0 = OpTypePointer Function %ForBasic0
+         %12 = OpTypeFunction %void %_ptr_Function_ForBasic0
+         %14 = OpTypeFunction %int %_ptr_Function_ForBasic0
+%_ptr_Function_int = OpTypePointer Function %int
+       %bool = OpTypeBool
+         %18 = OpTypeFunction %void
+%ForBasic0_PreConstructor = OpFunction %void None %12
        %self = OpFunctionParameter %_ptr_Function_ForBasic0
          %23 = OpLabel
                OpReturn
                OpFunctionEnd
-%ForBasic0_DefaultConstructor = OpFunction %void None %9
+%ForBasic0_DefaultConstructor = OpFunction %void None %12
      %self_0 = OpFunctionParameter %_ptr_Function_ForBasic0
          %28 = OpLabel
          %29 = OpFunctionCall %void %ForBasic0_PreConstructor %self_0
                OpReturn
                OpFunctionEnd
-       %For0 = OpFunction %int None %11
+       %For0 = OpFunction %int None %14
      %self_1 = OpFunctionParameter %_ptr_Function_ForBasic0
          %34 = OpLabel
           %i = OpVariable %_ptr_Function_int Function
@@ -96,7 +96,7 @@
  %after_loop = OpLabel
                OpReturnValue %int_0
                OpFunctionEnd
-       %For1 = OpFunction %int None %11
+       %For1 = OpFunction %int None %14
      %self_2 = OpFunctionParameter %_ptr_Function_ForBasic0
          %57 = OpLabel
       %count = OpVariable %_ptr_Function_int Function
@@ -130,7 +130,7 @@
          %86 = OpLoad %int %result
                OpReturnValue %86
                OpFunctionEnd
-       %For2 = OpFunction %int None %11
+       %For2 = OpFunction %int None %14
      %self_3 = OpFunctionParameter %_ptr_Function_ForBasic0
          %91 = OpLabel
     %count_0 = OpVariable %_ptr_Function_int Function
@@ -164,7 +164,7 @@
         %120 = OpLoad %int %result_0
                OpReturnValue %120
                OpFunctionEnd
-       %Main = OpFunction %void None %9
+       %Main = OpFunction %void None %12
      %self_4 = OpFunctionParameter %_ptr_Function_ForBasic0
         %125 = OpLabel
         %ret = OpVariable %_ptr_Function_int Function
@@ -177,7 +177,7 @@
                OpStore %ret %132
                OpReturn
                OpFunctionEnd
-%ForBasic0_Main_EntryPoint = OpFunction %void None %15
+%ForBasic0_Main_EntryPoint = OpFunction %void None %18
         %137 = OpLabel
      %self_5 = OpVariable %_ptr_Function_ForBasic0 Function
         %139 = OpFunctionCall %void %ForBasic0_DefaultConstructor %self_5

--- a/CSShadersTests/Tests/LanguageBasics/ControlFlow/For/ForBasic1.expected.spvtxt
+++ b/CSShadersTests/Tests/LanguageBasics/ControlFlow/For/ForBasic1.expected.spvtxt
@@ -63,29 +63,29 @@
                OpName %self_6 "self"
        %uint = OpTypeInt 32 0
         %int = OpTypeInt 32 1
-  %ForBasic1 = OpTypeStruct
-       %void = OpTypeVoid
-%_ptr_Function_ForBasic1 = OpTypePointer Function %ForBasic1
-          %9 = OpTypeFunction %void %_ptr_Function_ForBasic1
-         %11 = OpTypeFunction %int %_ptr_Function_ForBasic1
-%_ptr_Function_int = OpTypePointer Function %int
-       %bool = OpTypeBool
-         %15 = OpTypeFunction %void
      %int_10 = OpConstant %int 10
       %int_1 = OpConstant %int 1
       %int_0 = OpConstant %int 0
-%ForBasic1_PreConstructor = OpFunction %void None %9
+  %ForBasic1 = OpTypeStruct
+       %void = OpTypeVoid
+%_ptr_Function_ForBasic1 = OpTypePointer Function %ForBasic1
+         %12 = OpTypeFunction %void %_ptr_Function_ForBasic1
+         %14 = OpTypeFunction %int %_ptr_Function_ForBasic1
+%_ptr_Function_int = OpTypePointer Function %int
+       %bool = OpTypeBool
+         %18 = OpTypeFunction %void
+%ForBasic1_PreConstructor = OpFunction %void None %12
        %self = OpFunctionParameter %_ptr_Function_ForBasic1
          %23 = OpLabel
                OpReturn
                OpFunctionEnd
-%ForBasic1_DefaultConstructor = OpFunction %void None %9
+%ForBasic1_DefaultConstructor = OpFunction %void None %12
      %self_0 = OpFunctionParameter %_ptr_Function_ForBasic1
          %28 = OpLabel
          %29 = OpFunctionCall %void %ForBasic1_PreConstructor %self_0
                OpReturn
                OpFunctionEnd
-       %For0 = OpFunction %int None %11
+       %For0 = OpFunction %int None %14
      %self_1 = OpFunctionParameter %_ptr_Function_ForBasic1
          %34 = OpLabel
       %count = OpVariable %_ptr_Function_int Function
@@ -118,7 +118,7 @@
          %62 = OpLoad %int %result
                OpReturnValue %62
                OpFunctionEnd
-       %For1 = OpFunction %int None %11
+       %For1 = OpFunction %int None %14
      %self_2 = OpFunctionParameter %_ptr_Function_ForBasic1
          %67 = OpLabel
     %count_0 = OpVariable %_ptr_Function_int Function
@@ -149,7 +149,7 @@
          %93 = OpLoad %int %result_0
                OpReturnValue %93
                OpFunctionEnd
-       %For2 = OpFunction %int None %11
+       %For2 = OpFunction %int None %14
      %self_3 = OpFunctionParameter %_ptr_Function_ForBasic1
          %98 = OpLabel
     %count_1 = OpVariable %_ptr_Function_int Function
@@ -183,7 +183,7 @@
         %127 = OpLoad %int %result_1
                OpReturnValue %127
                OpFunctionEnd
-       %For3 = OpFunction %int None %11
+       %For3 = OpFunction %int None %14
      %self_4 = OpFunctionParameter %_ptr_Function_ForBasic1
         %132 = OpLabel
     %count_2 = OpVariable %_ptr_Function_int Function
@@ -213,7 +213,7 @@
         %157 = OpLoad %int %result_2
                OpReturnValue %157
                OpFunctionEnd
-       %Main = OpFunction %void None %9
+       %Main = OpFunction %void None %12
      %self_5 = OpFunctionParameter %_ptr_Function_ForBasic1
         %162 = OpLabel
         %ret = OpVariable %_ptr_Function_int Function
@@ -228,7 +228,7 @@
                OpStore %ret %171
                OpReturn
                OpFunctionEnd
-%ForBasic1_Main_EntryPoint = OpFunction %void None %15
+%ForBasic1_Main_EntryPoint = OpFunction %void None %18
         %176 = OpLabel
      %self_6 = OpVariable %_ptr_Function_ForBasic1 Function
         %178 = OpFunctionCall %void %ForBasic1_DefaultConstructor %self_6

--- a/CSShadersTests/Tests/LanguageBasics/ControlFlow/For/ForBasic2.expected.spvtxt
+++ b/CSShadersTests/Tests/LanguageBasics/ControlFlow/For/ForBasic2.expected.spvtxt
@@ -42,29 +42,29 @@
                OpName %self_4 "self"
        %uint = OpTypeInt 32 0
         %int = OpTypeInt 32 1
-  %ForBasic2 = OpTypeStruct
-       %void = OpTypeVoid
-%_ptr_Function_ForBasic2 = OpTypePointer Function %ForBasic2
-          %9 = OpTypeFunction %void %_ptr_Function_ForBasic2
-         %11 = OpTypeFunction %int %_ptr_Function_ForBasic2
-%_ptr_Function_int = OpTypePointer Function %int
-       %bool = OpTypeBool
-         %15 = OpTypeFunction %void
       %int_0 = OpConstant %int 0
      %int_10 = OpConstant %int 10
       %int_1 = OpConstant %int 1
-%ForBasic2_PreConstructor = OpFunction %void None %9
+  %ForBasic2 = OpTypeStruct
+       %void = OpTypeVoid
+%_ptr_Function_ForBasic2 = OpTypePointer Function %ForBasic2
+         %12 = OpTypeFunction %void %_ptr_Function_ForBasic2
+         %14 = OpTypeFunction %int %_ptr_Function_ForBasic2
+%_ptr_Function_int = OpTypePointer Function %int
+       %bool = OpTypeBool
+         %18 = OpTypeFunction %void
+%ForBasic2_PreConstructor = OpFunction %void None %12
        %self = OpFunctionParameter %_ptr_Function_ForBasic2
          %23 = OpLabel
                OpReturn
                OpFunctionEnd
-%ForBasic2_DefaultConstructor = OpFunction %void None %9
+%ForBasic2_DefaultConstructor = OpFunction %void None %12
      %self_0 = OpFunctionParameter %_ptr_Function_ForBasic2
          %28 = OpLabel
          %29 = OpFunctionCall %void %ForBasic2_PreConstructor %self_0
                OpReturn
                OpFunctionEnd
-       %For0 = OpFunction %int None %11
+       %For0 = OpFunction %int None %14
      %self_1 = OpFunctionParameter %_ptr_Function_ForBasic2
          %34 = OpLabel
           %i = OpVariable %_ptr_Function_int Function
@@ -90,7 +90,7 @@
  %after_loop = OpLabel
                OpReturnValue %int_0
                OpFunctionEnd
-       %For1 = OpFunction %int None %11
+       %For1 = OpFunction %int None %14
      %self_2 = OpFunctionParameter %_ptr_Function_ForBasic2
          %60 = OpLabel
     %count_0 = OpVariable %_ptr_Function_int Function
@@ -127,7 +127,7 @@
          %92 = OpLoad %int %result
                OpReturnValue %92
                OpFunctionEnd
-       %Main = OpFunction %void None %9
+       %Main = OpFunction %void None %12
      %self_3 = OpFunctionParameter %_ptr_Function_ForBasic2
          %97 = OpLabel
         %ret = OpVariable %_ptr_Function_int Function
@@ -138,7 +138,7 @@
                OpStore %ret %102
                OpReturn
                OpFunctionEnd
-%ForBasic2_Main_EntryPoint = OpFunction %void None %15
+%ForBasic2_Main_EntryPoint = OpFunction %void None %18
         %107 = OpLabel
      %self_4 = OpVariable %_ptr_Function_ForBasic2 Function
         %109 = OpFunctionCall %void %ForBasic2_DefaultConstructor %self_4

--- a/CSShadersTests/Tests/LanguageBasics/ControlFlow/For/ForBreak.expected.spvtxt
+++ b/CSShadersTests/Tests/LanguageBasics/ControlFlow/For/ForBreak.expected.spvtxt
@@ -43,29 +43,29 @@
                OpName %self_4 "self"
        %uint = OpTypeInt 32 0
         %int = OpTypeInt 32 1
-   %ForBreak = OpTypeStruct
-       %void = OpTypeVoid
-%_ptr_Function_ForBreak = OpTypePointer Function %ForBreak
-          %9 = OpTypeFunction %void %_ptr_Function_ForBreak
-         %11 = OpTypeFunction %int %_ptr_Function_ForBreak %int
-%_ptr_Function_int = OpTypePointer Function %int
-       %bool = OpTypeBool
-         %15 = OpTypeFunction %void
       %int_0 = OpConstant %int 0
       %int_1 = OpConstant %int 1
      %int_10 = OpConstant %int 10
-%ForBreak_PreConstructor = OpFunction %void None %9
+   %ForBreak = OpTypeStruct
+       %void = OpTypeVoid
+%_ptr_Function_ForBreak = OpTypePointer Function %ForBreak
+         %12 = OpTypeFunction %void %_ptr_Function_ForBreak
+         %14 = OpTypeFunction %int %_ptr_Function_ForBreak %int
+%_ptr_Function_int = OpTypePointer Function %int
+       %bool = OpTypeBool
+         %18 = OpTypeFunction %void
+%ForBreak_PreConstructor = OpFunction %void None %12
        %self = OpFunctionParameter %_ptr_Function_ForBreak
          %23 = OpLabel
                OpReturn
                OpFunctionEnd
-%ForBreak_DefaultConstructor = OpFunction %void None %9
+%ForBreak_DefaultConstructor = OpFunction %void None %12
      %self_0 = OpFunctionParameter %_ptr_Function_ForBreak
          %28 = OpLabel
          %29 = OpFunctionCall %void %ForBreak_PreConstructor %self_0
                OpReturn
                OpFunctionEnd
-  %ForBreak0 = OpFunction %int None %11
+  %ForBreak0 = OpFunction %int None %14
      %self_1 = OpFunctionParameter %_ptr_Function_ForBreak
       %count = OpFunctionParameter %int
          %35 = OpLabel
@@ -95,7 +95,7 @@
          %59 = OpLoad %int %result
                OpReturnValue %59
                OpFunctionEnd
-  %ForBreak1 = OpFunction %int None %11
+  %ForBreak1 = OpFunction %int None %14
      %self_2 = OpFunctionParameter %_ptr_Function_ForBreak
     %count_0 = OpFunctionParameter %int
          %65 = OpLabel
@@ -122,7 +122,7 @@
          %86 = OpLoad %int %result_0
                OpReturnValue %86
                OpFunctionEnd
-       %Main = OpFunction %void None %9
+       %Main = OpFunction %void None %12
      %self_3 = OpFunctionParameter %_ptr_Function_ForBreak
          %91 = OpLabel
         %ret = OpVariable %_ptr_Function_int Function
@@ -133,7 +133,7 @@
                OpStore %ret %96
                OpReturn
                OpFunctionEnd
-%ForBreak_Main_EntryPoint = OpFunction %void None %15
+%ForBreak_Main_EntryPoint = OpFunction %void None %18
         %101 = OpLabel
      %self_4 = OpVariable %_ptr_Function_ForBreak Function
         %103 = OpFunctionCall %void %ForBreak_DefaultConstructor %self_4

--- a/CSShadersTests/Tests/LanguageBasics/ControlFlow/For/ForContinue.expected.spvtxt
+++ b/CSShadersTests/Tests/LanguageBasics/ControlFlow/For/ForContinue.expected.spvtxt
@@ -43,29 +43,29 @@
                OpName %self_4 "self"
        %uint = OpTypeInt 32 0
         %int = OpTypeInt 32 1
-%ForContinue = OpTypeStruct
-       %void = OpTypeVoid
-%_ptr_Function_ForContinue = OpTypePointer Function %ForContinue
-          %9 = OpTypeFunction %void %_ptr_Function_ForContinue
-         %11 = OpTypeFunction %int %_ptr_Function_ForContinue %int
-%_ptr_Function_int = OpTypePointer Function %int
-       %bool = OpTypeBool
-         %15 = OpTypeFunction %void
       %int_0 = OpConstant %int 0
       %int_1 = OpConstant %int 1
      %int_10 = OpConstant %int 10
-%ForContinue_PreConstructor = OpFunction %void None %9
+%ForContinue = OpTypeStruct
+       %void = OpTypeVoid
+%_ptr_Function_ForContinue = OpTypePointer Function %ForContinue
+         %12 = OpTypeFunction %void %_ptr_Function_ForContinue
+         %14 = OpTypeFunction %int %_ptr_Function_ForContinue %int
+%_ptr_Function_int = OpTypePointer Function %int
+       %bool = OpTypeBool
+         %18 = OpTypeFunction %void
+%ForContinue_PreConstructor = OpFunction %void None %12
        %self = OpFunctionParameter %_ptr_Function_ForContinue
          %23 = OpLabel
                OpReturn
                OpFunctionEnd
-%ForContinue_DefaultConstructor = OpFunction %void None %9
+%ForContinue_DefaultConstructor = OpFunction %void None %12
      %self_0 = OpFunctionParameter %_ptr_Function_ForContinue
          %28 = OpLabel
          %29 = OpFunctionCall %void %ForContinue_PreConstructor %self_0
                OpReturn
                OpFunctionEnd
-%ForContinue0 = OpFunction %int None %11
+%ForContinue0 = OpFunction %int None %14
      %self_1 = OpFunctionParameter %_ptr_Function_ForContinue
       %count = OpFunctionParameter %int
          %35 = OpLabel
@@ -92,7 +92,7 @@
          %56 = OpLoad %int %result
                OpReturnValue %56
                OpFunctionEnd
-%ForContinue1 = OpFunction %int None %11
+%ForContinue1 = OpFunction %int None %14
      %self_2 = OpFunctionParameter %_ptr_Function_ForContinue
     %count_0 = OpFunctionParameter %int
          %62 = OpLabel
@@ -122,7 +122,7 @@
          %86 = OpLoad %int %result_0
                OpReturnValue %86
                OpFunctionEnd
-       %Main = OpFunction %void None %9
+       %Main = OpFunction %void None %12
      %self_3 = OpFunctionParameter %_ptr_Function_ForContinue
          %91 = OpLabel
         %ret = OpVariable %_ptr_Function_int Function
@@ -133,7 +133,7 @@
                OpStore %ret %96
                OpReturn
                OpFunctionEnd
-%ForContinue_Main_EntryPoint = OpFunction %void None %15
+%ForContinue_Main_EntryPoint = OpFunction %void None %18
         %101 = OpLabel
      %self_4 = OpVariable %_ptr_Function_ForContinue Function
         %103 = OpFunctionCall %void %ForContinue_DefaultConstructor %self_4

--- a/CSShadersTests/Tests/LanguageBasics/ControlFlow/For/ForNested.expected.spvtxt
+++ b/CSShadersTests/Tests/LanguageBasics/ControlFlow/For/ForNested.expected.spvtxt
@@ -83,29 +83,29 @@
                OpName %self_6 "self"
        %uint = OpTypeInt 32 0
         %int = OpTypeInt 32 1
-  %ForNested = OpTypeStruct
-       %void = OpTypeVoid
-%_ptr_Function_ForNested = OpTypePointer Function %ForNested
-          %9 = OpTypeFunction %void %_ptr_Function_ForNested
-         %11 = OpTypeFunction %int %_ptr_Function_ForNested
-%_ptr_Function_int = OpTypePointer Function %int
-       %bool = OpTypeBool
-         %15 = OpTypeFunction %void
       %int_1 = OpConstant %int 1
       %int_0 = OpConstant %int 0
       %int_2 = OpConstant %int 2
-%ForNested_PreConstructor = OpFunction %void None %9
+  %ForNested = OpTypeStruct
+       %void = OpTypeVoid
+%_ptr_Function_ForNested = OpTypePointer Function %ForNested
+         %12 = OpTypeFunction %void %_ptr_Function_ForNested
+         %14 = OpTypeFunction %int %_ptr_Function_ForNested
+%_ptr_Function_int = OpTypePointer Function %int
+       %bool = OpTypeBool
+         %18 = OpTypeFunction %void
+%ForNested_PreConstructor = OpFunction %void None %12
        %self = OpFunctionParameter %_ptr_Function_ForNested
          %23 = OpLabel
                OpReturn
                OpFunctionEnd
-%ForNested_DefaultConstructor = OpFunction %void None %9
+%ForNested_DefaultConstructor = OpFunction %void None %12
      %self_0 = OpFunctionParameter %_ptr_Function_ForNested
          %28 = OpLabel
          %29 = OpFunctionCall %void %ForNested_PreConstructor %self_0
                OpReturn
                OpFunctionEnd
- %ForNested0 = OpFunction %int None %11
+ %ForNested0 = OpFunction %int None %14
      %self_1 = OpFunctionParameter %_ptr_Function_ForNested
          %34 = OpLabel
      %result = OpVariable %_ptr_Function_int Function
@@ -155,7 +155,7 @@
          %79 = OpLoad %int %result
                OpReturnValue %79
                OpFunctionEnd
- %ForNested1 = OpFunction %int None %11
+ %ForNested1 = OpFunction %int None %14
      %self_2 = OpFunctionParameter %_ptr_Function_ForNested
          %84 = OpLabel
    %result_0 = OpVariable %_ptr_Function_int Function
@@ -205,7 +205,7 @@
         %129 = OpLoad %int %result_0
                OpReturnValue %129
                OpFunctionEnd
- %ForNested2 = OpFunction %int None %11
+ %ForNested2 = OpFunction %int None %14
      %self_3 = OpFunctionParameter %_ptr_Function_ForNested
         %134 = OpLabel
    %result_1 = OpVariable %_ptr_Function_int Function
@@ -255,7 +255,7 @@
         %179 = OpLoad %int %result_1
                OpReturnValue %179
                OpFunctionEnd
- %ForNested3 = OpFunction %int None %11
+ %ForNested3 = OpFunction %int None %14
      %self_4 = OpFunctionParameter %_ptr_Function_ForNested
         %184 = OpLabel
    %result_2 = OpVariable %_ptr_Function_int Function
@@ -305,7 +305,7 @@
         %229 = OpLoad %int %result_2
                OpReturnValue %229
                OpFunctionEnd
-       %Main = OpFunction %void None %9
+       %Main = OpFunction %void None %12
      %self_5 = OpFunctionParameter %_ptr_Function_ForNested
         %234 = OpLabel
         %ret = OpVariable %_ptr_Function_int Function
@@ -320,7 +320,7 @@
                OpStore %ret %243
                OpReturn
                OpFunctionEnd
-%ForNested_Main_EntryPoint = OpFunction %void None %15
+%ForNested_Main_EntryPoint = OpFunction %void None %18
         %248 = OpLabel
      %self_6 = OpVariable %_ptr_Function_ForNested Function
         %250 = OpFunctionCall %void %ForNested_DefaultConstructor %self_6

--- a/CSShadersTests/Tests/LanguageBasics/ControlFlow/If/IfBasic.expected.spvtxt
+++ b/CSShadersTests/Tests/LanguageBasics/ControlFlow/If/IfBasic.expected.spvtxt
@@ -33,29 +33,29 @@
                OpName %self_4 "self"
        %uint = OpTypeInt 32 0
         %int = OpTypeInt 32 1
+      %int_0 = OpConstant %int 0
        %bool = OpTypeBool
+       %true = OpConstantTrue %bool
+      %int_1 = OpConstant %int 1
     %IfBasic = OpTypeStruct
        %void = OpTypeVoid
 %_ptr_Function_IfBasic = OpTypePointer Function %IfBasic
-         %11 = OpTypeFunction %void %_ptr_Function_IfBasic
-         %13 = OpTypeFunction %int %_ptr_Function_IfBasic
+         %14 = OpTypeFunction %void %_ptr_Function_IfBasic
+         %16 = OpTypeFunction %int %_ptr_Function_IfBasic
 %_ptr_Function_int = OpTypePointer Function %int
-         %15 = OpTypeFunction %void
-      %int_0 = OpConstant %int 0
-       %true = OpConstantTrue %bool
-      %int_1 = OpConstant %int 1
-%IfBasic_PreConstructor = OpFunction %void None %11
+         %18 = OpTypeFunction %void
+%IfBasic_PreConstructor = OpFunction %void None %14
        %self = OpFunctionParameter %_ptr_Function_IfBasic
          %23 = OpLabel
                OpReturn
                OpFunctionEnd
-%IfBasic_DefaultConstructor = OpFunction %void None %11
+%IfBasic_DefaultConstructor = OpFunction %void None %14
      %self_0 = OpFunctionParameter %_ptr_Function_IfBasic
          %28 = OpLabel
          %29 = OpFunctionCall %void %IfBasic_PreConstructor %self_0
                OpReturn
                OpFunctionEnd
-        %If0 = OpFunction %int None %13
+        %If0 = OpFunction %int None %16
      %self_1 = OpFunctionParameter %_ptr_Function_IfBasic
          %34 = OpLabel
           %a = OpVariable %_ptr_Function_int Function
@@ -69,7 +69,7 @@
          %43 = OpLoad %int %a
                OpReturnValue %43
                OpFunctionEnd
-        %If1 = OpFunction %int None %13
+        %If1 = OpFunction %int None %16
      %self_2 = OpFunctionParameter %_ptr_Function_IfBasic
          %48 = OpLabel
         %a_0 = OpVariable %_ptr_Function_int Function
@@ -86,7 +86,7 @@
          %60 = OpLoad %int %a_0
                OpReturnValue %60
                OpFunctionEnd
-       %Main = OpFunction %void None %11
+       %Main = OpFunction %void None %14
      %self_3 = OpFunctionParameter %_ptr_Function_IfBasic
          %65 = OpLabel
         %ret = OpVariable %_ptr_Function_int Function
@@ -97,7 +97,7 @@
                OpStore %ret %70
                OpReturn
                OpFunctionEnd
-%IfBasic_Main_EntryPoint = OpFunction %void None %15
+%IfBasic_Main_EntryPoint = OpFunction %void None %18
          %75 = OpLabel
      %self_4 = OpVariable %_ptr_Function_IfBasic Function
          %77 = OpFunctionCall %void %IfBasic_DefaultConstructor %self_4

--- a/CSShadersTests/Tests/LanguageBasics/ControlFlow/If/IfElseBasic.expected.spvtxt
+++ b/CSShadersTests/Tests/LanguageBasics/ControlFlow/If/IfElseBasic.expected.spvtxt
@@ -29,30 +29,30 @@
                OpName %self_3 "self"
        %uint = OpTypeInt 32 0
         %int = OpTypeInt 32 1
-       %bool = OpTypeBool
-%IfElseBasic = OpTypeStruct
-       %void = OpTypeVoid
-%_ptr_Function_IfElseBasic = OpTypePointer Function %IfElseBasic
-         %11 = OpTypeFunction %void %_ptr_Function_IfElseBasic
-         %13 = OpTypeFunction %int %_ptr_Function_IfElseBasic
-%_ptr_Function_int = OpTypePointer Function %int
-         %15 = OpTypeFunction %void
       %int_0 = OpConstant %int 0
+       %bool = OpTypeBool
        %true = OpConstantTrue %bool
       %int_1 = OpConstant %int 1
       %int_2 = OpConstant %int 2
-%IfElseBasic_PreConstructor = OpFunction %void None %11
+%IfElseBasic = OpTypeStruct
+       %void = OpTypeVoid
+%_ptr_Function_IfElseBasic = OpTypePointer Function %IfElseBasic
+         %15 = OpTypeFunction %void %_ptr_Function_IfElseBasic
+         %17 = OpTypeFunction %int %_ptr_Function_IfElseBasic
+%_ptr_Function_int = OpTypePointer Function %int
+         %19 = OpTypeFunction %void
+%IfElseBasic_PreConstructor = OpFunction %void None %15
        %self = OpFunctionParameter %_ptr_Function_IfElseBasic
          %24 = OpLabel
                OpReturn
                OpFunctionEnd
-%IfElseBasic_DefaultConstructor = OpFunction %void None %11
+%IfElseBasic_DefaultConstructor = OpFunction %void None %15
      %self_0 = OpFunctionParameter %_ptr_Function_IfElseBasic
          %29 = OpLabel
          %30 = OpFunctionCall %void %IfElseBasic_PreConstructor %self_0
                OpReturn
                OpFunctionEnd
-    %IfElse0 = OpFunction %int None %13
+    %IfElse0 = OpFunction %int None %17
      %self_1 = OpFunctionParameter %_ptr_Function_IfElseBasic
          %35 = OpLabel
           %a = OpVariable %_ptr_Function_int Function
@@ -72,7 +72,7 @@
          %50 = OpLoad %int %a
                OpReturnValue %50
                OpFunctionEnd
-       %Main = OpFunction %void None %11
+       %Main = OpFunction %void None %15
      %self_2 = OpFunctionParameter %_ptr_Function_IfElseBasic
          %55 = OpLabel
         %ret = OpVariable %_ptr_Function_int Function
@@ -81,7 +81,7 @@
                OpStore %ret %58
                OpReturn
                OpFunctionEnd
-%IfElseBasic_Main_EntryPoint = OpFunction %void None %15
+%IfElseBasic_Main_EntryPoint = OpFunction %void None %19
          %63 = OpLabel
      %self_3 = OpVariable %_ptr_Function_IfElseBasic Function
          %65 = OpFunctionCall %void %IfElseBasic_DefaultConstructor %self_3

--- a/CSShadersTests/Tests/LanguageBasics/ControlFlow/If/IfElseChainBasic.expected.spvtxt
+++ b/CSShadersTests/Tests/LanguageBasics/ControlFlow/If/IfElseChainBasic.expected.spvtxt
@@ -52,33 +52,33 @@
                OpName %self_5 "self"
        %uint = OpTypeInt 32 0
         %int = OpTypeInt 32 1
-       %bool = OpTypeBool
-%IfElseChainBasic = OpTypeStruct
-       %void = OpTypeVoid
-%_ptr_Function_IfElseChainBasic = OpTypePointer Function %IfElseChainBasic
-         %11 = OpTypeFunction %void %_ptr_Function_IfElseChainBasic
-         %13 = OpTypeFunction %int %_ptr_Function_IfElseChainBasic
-%_ptr_Function_int = OpTypePointer Function %int
-         %15 = OpTypeFunction %void
       %int_0 = OpConstant %int 0
+       %bool = OpTypeBool
        %true = OpConstantTrue %bool
       %int_1 = OpConstant %int 1
       %false = OpConstantFalse %bool
       %int_2 = OpConstant %int 2
       %int_3 = OpConstant %int 3
       %int_4 = OpConstant %int 4
-%IfElseChainBasic_PreConstructor = OpFunction %void None %11
+%IfElseChainBasic = OpTypeStruct
+       %void = OpTypeVoid
+%_ptr_Function_IfElseChainBasic = OpTypePointer Function %IfElseChainBasic
+         %18 = OpTypeFunction %void %_ptr_Function_IfElseChainBasic
+         %20 = OpTypeFunction %int %_ptr_Function_IfElseChainBasic
+%_ptr_Function_int = OpTypePointer Function %int
+         %22 = OpTypeFunction %void
+%IfElseChainBasic_PreConstructor = OpFunction %void None %18
        %self = OpFunctionParameter %_ptr_Function_IfElseChainBasic
          %27 = OpLabel
                OpReturn
                OpFunctionEnd
-%IfElseChainBasic_DefaultConstructor = OpFunction %void None %11
+%IfElseChainBasic_DefaultConstructor = OpFunction %void None %18
      %self_0 = OpFunctionParameter %_ptr_Function_IfElseChainBasic
          %32 = OpLabel
          %33 = OpFunctionCall %void %IfElseChainBasic_PreConstructor %self_0
                OpReturn
                OpFunctionEnd
-%IfElseChain0 = OpFunction %int None %13
+%IfElseChain0 = OpFunction %int None %20
      %self_1 = OpFunctionParameter %_ptr_Function_IfElseChainBasic
          %38 = OpLabel
           %a = OpVariable %_ptr_Function_int Function
@@ -103,7 +103,7 @@
          %58 = OpLoad %int %a
                OpReturnValue %58
                OpFunctionEnd
-%IfElseChain1 = OpFunction %int None %13
+%IfElseChain1 = OpFunction %int None %20
      %self_2 = OpFunctionParameter %_ptr_Function_IfElseChainBasic
          %63 = OpLabel
         %a_0 = OpVariable %_ptr_Function_int Function
@@ -131,7 +131,7 @@
          %86 = OpLoad %int %a_0
                OpReturnValue %86
                OpFunctionEnd
-%IfElseChain2 = OpFunction %int None %13
+%IfElseChain2 = OpFunction %int None %20
      %self_3 = OpFunctionParameter %_ptr_Function_IfElseChainBasic
          %91 = OpLabel
         %a_1 = OpVariable %_ptr_Function_int Function
@@ -169,7 +169,7 @@
         %124 = OpLoad %int %a_1
                OpReturnValue %124
                OpFunctionEnd
-       %Main = OpFunction %void None %11
+       %Main = OpFunction %void None %18
      %self_4 = OpFunctionParameter %_ptr_Function_IfElseChainBasic
         %129 = OpLabel
         %ret = OpVariable %_ptr_Function_int Function
@@ -182,7 +182,7 @@
                OpStore %ret %136
                OpReturn
                OpFunctionEnd
-%IfElseChainBasic_Main_EntryPoint = OpFunction %void None %15
+%IfElseChainBasic_Main_EntryPoint = OpFunction %void None %22
         %141 = OpLabel
      %self_5 = OpVariable %_ptr_Function_IfElseChainBasic Function
         %143 = OpFunctionCall %void %IfElseChainBasic_DefaultConstructor %self_5

--- a/CSShadersTests/Tests/LanguageBasics/ControlFlow/If/IfNested.expected.spvtxt
+++ b/CSShadersTests/Tests/LanguageBasics/ControlFlow/If/IfNested.expected.spvtxt
@@ -94,33 +94,33 @@
                OpName %self_7 "self"
        %uint = OpTypeInt 32 0
         %int = OpTypeInt 32 1
-       %bool = OpTypeBool
-   %IfNested = OpTypeStruct
-       %void = OpTypeVoid
-%_ptr_Function_IfNested = OpTypePointer Function %IfNested
-         %11 = OpTypeFunction %void %_ptr_Function_IfNested
-         %13 = OpTypeFunction %int %_ptr_Function_IfNested
-%_ptr_Function_int = OpTypePointer Function %int
-         %15 = OpTypeFunction %void
       %int_1 = OpConstant %int 1
       %int_0 = OpConstant %int 0
+       %bool = OpTypeBool
        %true = OpConstantTrue %bool
       %false = OpConstantFalse %bool
       %int_2 = OpConstant %int 2
       %int_3 = OpConstant %int 3
       %int_4 = OpConstant %int 4
-%IfNested_PreConstructor = OpFunction %void None %11
+   %IfNested = OpTypeStruct
+       %void = OpTypeVoid
+%_ptr_Function_IfNested = OpTypePointer Function %IfNested
+         %18 = OpTypeFunction %void %_ptr_Function_IfNested
+         %20 = OpTypeFunction %int %_ptr_Function_IfNested
+%_ptr_Function_int = OpTypePointer Function %int
+         %22 = OpTypeFunction %void
+%IfNested_PreConstructor = OpFunction %void None %18
        %self = OpFunctionParameter %_ptr_Function_IfNested
          %27 = OpLabel
                OpReturn
                OpFunctionEnd
-%IfNested_DefaultConstructor = OpFunction %void None %11
+%IfNested_DefaultConstructor = OpFunction %void None %18
      %self_0 = OpFunctionParameter %_ptr_Function_IfNested
          %32 = OpLabel
          %33 = OpFunctionCall %void %IfNested_PreConstructor %self_0
                OpReturn
                OpFunctionEnd
-  %IfNested0 = OpFunction %int None %13
+  %IfNested0 = OpFunction %int None %20
      %self_1 = OpFunctionParameter %_ptr_Function_IfNested
          %38 = OpLabel
         %one = OpVariable %_ptr_Function_int Function
@@ -163,7 +163,7 @@
          %76 = OpLoad %int %result
                OpReturnValue %76
                OpFunctionEnd
-  %IfNested1 = OpFunction %int None %13
+  %IfNested1 = OpFunction %int None %20
      %self_2 = OpFunctionParameter %_ptr_Function_IfNested
          %81 = OpLabel
       %one_0 = OpVariable %_ptr_Function_int Function
@@ -211,7 +211,7 @@
         %124 = OpLoad %int %result_0
                OpReturnValue %124
                OpFunctionEnd
-  %IfNested2 = OpFunction %int None %13
+  %IfNested2 = OpFunction %int None %20
      %self_3 = OpFunctionParameter %_ptr_Function_IfNested
         %129 = OpLabel
       %one_1 = OpVariable %_ptr_Function_int Function
@@ -273,7 +273,7 @@
         %186 = OpLoad %int %result_1
                OpReturnValue %186
                OpFunctionEnd
-  %IfNested3 = OpFunction %int None %13
+  %IfNested3 = OpFunction %int None %20
      %self_4 = OpFunctionParameter %_ptr_Function_IfNested
         %191 = OpLabel
       %one_2 = OpVariable %_ptr_Function_int Function
@@ -334,7 +334,7 @@
         %247 = OpLoad %int %result_2
                OpReturnValue %247
                OpFunctionEnd
-%SuperNestedIf0 = OpFunction %int None %13
+%SuperNestedIf0 = OpFunction %int None %20
      %self_5 = OpFunctionParameter %_ptr_Function_IfNested
         %252 = OpLabel
           %a = OpVariable %_ptr_Function_int Function
@@ -367,7 +367,7 @@
         %280 = OpLoad %int %a
                OpReturnValue %280
                OpFunctionEnd
-       %Main = OpFunction %void None %11
+       %Main = OpFunction %void None %18
      %self_6 = OpFunctionParameter %_ptr_Function_IfNested
         %285 = OpLabel
         %ret = OpVariable %_ptr_Function_int Function
@@ -384,7 +384,7 @@
                OpStore %ret %296
                OpReturn
                OpFunctionEnd
-%IfNested_Main_EntryPoint = OpFunction %void None %15
+%IfNested_Main_EntryPoint = OpFunction %void None %22
         %301 = OpLabel
      %self_7 = OpVariable %_ptr_Function_IfNested Function
         %303 = OpFunctionCall %void %IfNested_DefaultConstructor %self_7

--- a/CSShadersTests/Tests/LanguageBasics/ControlFlow/If/IfNestedStress.expected.spvtxt
+++ b/CSShadersTests/Tests/LanguageBasics/ControlFlow/If/IfNestedStress.expected.spvtxt
@@ -156,33 +156,33 @@
                OpName %self_5 "self"
        %uint = OpTypeInt 32 0
         %int = OpTypeInt 32 1
-       %bool = OpTypeBool
-%IfNestedStress = OpTypeStruct
-       %void = OpTypeVoid
-%_ptr_Function_IfNestedStress = OpTypePointer Function %IfNestedStress
-         %11 = OpTypeFunction %void %_ptr_Function_IfNestedStress
-         %13 = OpTypeFunction %int %_ptr_Function_IfNestedStress
-%_ptr_Function_int = OpTypePointer Function %int
-         %15 = OpTypeFunction %void
       %int_0 = OpConstant %int 0
+       %bool = OpTypeBool
        %true = OpConstantTrue %bool
       %int_1 = OpConstant %int 1
       %false = OpConstantFalse %bool
       %int_2 = OpConstant %int 2
       %int_3 = OpConstant %int 3
       %int_4 = OpConstant %int 4
-%IfNestedStress_PreConstructor = OpFunction %void None %11
+%IfNestedStress = OpTypeStruct
+       %void = OpTypeVoid
+%_ptr_Function_IfNestedStress = OpTypePointer Function %IfNestedStress
+         %18 = OpTypeFunction %void %_ptr_Function_IfNestedStress
+         %20 = OpTypeFunction %int %_ptr_Function_IfNestedStress
+%_ptr_Function_int = OpTypePointer Function %int
+         %22 = OpTypeFunction %void
+%IfNestedStress_PreConstructor = OpFunction %void None %18
        %self = OpFunctionParameter %_ptr_Function_IfNestedStress
          %27 = OpLabel
                OpReturn
                OpFunctionEnd
-%IfNestedStress_DefaultConstructor = OpFunction %void None %11
+%IfNestedStress_DefaultConstructor = OpFunction %void None %18
      %self_0 = OpFunctionParameter %_ptr_Function_IfNestedStress
          %32 = OpLabel
          %33 = OpFunctionCall %void %IfNestedStress_PreConstructor %self_0
                OpReturn
                OpFunctionEnd
-%IfNestedStress0 = OpFunction %int None %13
+%IfNestedStress0 = OpFunction %int None %20
      %self_1 = OpFunctionParameter %_ptr_Function_IfNestedStress
          %38 = OpLabel
           %a = OpVariable %_ptr_Function_int Function
@@ -215,7 +215,7 @@
          %66 = OpLoad %int %a
                OpReturnValue %66
                OpFunctionEnd
-%IfNestedStress1 = OpFunction %int None %13
+%IfNestedStress1 = OpFunction %int None %20
      %self_2 = OpFunctionParameter %_ptr_Function_IfNestedStress
          %71 = OpLabel
         %one = OpVariable %_ptr_Function_int Function
@@ -361,7 +361,7 @@
         %212 = OpLoad %int %result
                OpReturnValue %212
                OpFunctionEnd
-%IfNestedStress2 = OpFunction %int None %13
+%IfNestedStress2 = OpFunction %int None %20
      %self_3 = OpFunctionParameter %_ptr_Function_IfNestedStress
         %217 = OpLabel
       %one_0 = OpVariable %_ptr_Function_int Function
@@ -873,7 +873,7 @@
         %724 = OpLoad %int %result_0
                OpReturnValue %724
                OpFunctionEnd
-       %Main = OpFunction %void None %11
+       %Main = OpFunction %void None %18
      %self_4 = OpFunctionParameter %_ptr_Function_IfNestedStress
         %729 = OpLabel
         %ret = OpVariable %_ptr_Function_int Function
@@ -886,7 +886,7 @@
                OpStore %ret %736
                OpReturn
                OpFunctionEnd
-%IfNestedStress_Main_EntryPoint = OpFunction %void None %15
+%IfNestedStress_Main_EntryPoint = OpFunction %void None %22
         %741 = OpLabel
      %self_5 = OpVariable %_ptr_Function_IfNestedStress Function
         %743 = OpFunctionCall %void %IfNestedStress_DefaultConstructor %self_5

--- a/CSShadersTests/Tests/LanguageBasics/ControlFlow/If/IfVariable.expected.spvtxt
+++ b/CSShadersTests/Tests/LanguageBasics/ControlFlow/If/IfVariable.expected.spvtxt
@@ -31,32 +31,32 @@
                OpName %IfVariable_Main_EntryPoint "IfVariable_Main_EntryPoint"
                OpName %self_3 "self"
        %bool = OpTypeBool
+       %true = OpConstantTrue %bool
        %uint = OpTypeInt 32 0
         %int = OpTypeInt 32 1
- %IfVariable = OpTypeStruct
-       %void = OpTypeVoid
-%_ptr_Function_IfVariable = OpTypePointer Function %IfVariable
-         %11 = OpTypeFunction %void %_ptr_Function_IfVariable
-         %13 = OpTypeFunction %int %_ptr_Function_IfVariable
-%_ptr_Function_bool = OpTypePointer Function %bool
-%_ptr_Function_int = OpTypePointer Function %int
-         %15 = OpTypeFunction %void
-       %true = OpConstantTrue %bool
       %int_1 = OpConstant %int 1
       %int_2 = OpConstant %int 2
       %int_0 = OpConstant %int 0
-%IfVariable_PreConstructor = OpFunction %void None %11
+ %IfVariable = OpTypeStruct
+       %void = OpTypeVoid
+%_ptr_Function_IfVariable = OpTypePointer Function %IfVariable
+         %15 = OpTypeFunction %void %_ptr_Function_IfVariable
+         %17 = OpTypeFunction %int %_ptr_Function_IfVariable
+%_ptr_Function_bool = OpTypePointer Function %bool
+%_ptr_Function_int = OpTypePointer Function %int
+         %19 = OpTypeFunction %void
+%IfVariable_PreConstructor = OpFunction %void None %15
        %self = OpFunctionParameter %_ptr_Function_IfVariable
          %24 = OpLabel
                OpReturn
                OpFunctionEnd
-%IfVariable_DefaultConstructor = OpFunction %void None %11
+%IfVariable_DefaultConstructor = OpFunction %void None %15
      %self_0 = OpFunctionParameter %_ptr_Function_IfVariable
          %29 = OpLabel
          %30 = OpFunctionCall %void %IfVariable_PreConstructor %self_0
                OpReturn
                OpFunctionEnd
-%IfVariable0 = OpFunction %int None %13
+%IfVariable0 = OpFunction %int None %17
      %self_1 = OpFunctionParameter %_ptr_Function_IfVariable
          %35 = OpLabel
   %condition = OpVariable %_ptr_Function_bool Function
@@ -83,7 +83,7 @@
          %57 = OpLoad %int %value
                OpReturnValue %57
                OpFunctionEnd
-       %Main = OpFunction %void None %11
+       %Main = OpFunction %void None %15
      %self_2 = OpFunctionParameter %_ptr_Function_IfVariable
          %62 = OpLabel
         %ret = OpVariable %_ptr_Function_int Function
@@ -92,7 +92,7 @@
                OpStore %ret %65
                OpReturn
                OpFunctionEnd
-%IfVariable_Main_EntryPoint = OpFunction %void None %15
+%IfVariable_Main_EntryPoint = OpFunction %void None %19
          %70 = OpLabel
      %self_3 = OpVariable %_ptr_Function_IfVariable Function
          %72 = OpFunctionCall %void %IfVariable_DefaultConstructor %self_3

--- a/CSShadersTests/Tests/LanguageBasics/ControlFlow/If/IfWithReturn.expected.spvtxt
+++ b/CSShadersTests/Tests/LanguageBasics/ControlFlow/If/IfWithReturn.expected.spvtxt
@@ -26,26 +26,26 @@
                OpName %self_3 "self"
        %uint = OpTypeInt 32 0
         %int = OpTypeInt 32 1
+      %int_0 = OpConstant %int 0
 %IfWithReturn = OpTypeStruct
        %void = OpTypeVoid
 %_ptr_Function_IfWithReturn = OpTypePointer Function %IfWithReturn
-          %9 = OpTypeFunction %void %_ptr_Function_IfWithReturn
-         %11 = OpTypeFunction %int %_ptr_Function_IfWithReturn
+         %10 = OpTypeFunction %void %_ptr_Function_IfWithReturn
+         %12 = OpTypeFunction %int %_ptr_Function_IfWithReturn
 %_ptr_Function_int = OpTypePointer Function %int
-         %13 = OpTypeFunction %void
-      %int_0 = OpConstant %int 0
-%IfWithReturn_PreConstructor = OpFunction %void None %9
+         %14 = OpTypeFunction %void
+%IfWithReturn_PreConstructor = OpFunction %void None %10
        %self = OpFunctionParameter %_ptr_Function_IfWithReturn
          %19 = OpLabel
                OpReturn
                OpFunctionEnd
-%IfWithReturn_DefaultConstructor = OpFunction %void None %9
+%IfWithReturn_DefaultConstructor = OpFunction %void None %10
      %self_0 = OpFunctionParameter %_ptr_Function_IfWithReturn
          %24 = OpLabel
          %25 = OpFunctionCall %void %IfWithReturn_PreConstructor %self_0
                OpReturn
                OpFunctionEnd
-%IfWithReturn0 = OpFunction %int None %11
+%IfWithReturn0 = OpFunction %int None %12
      %self_1 = OpFunctionParameter %_ptr_Function_IfWithReturn
          %30 = OpLabel
           %a = OpVariable %_ptr_Function_int Function
@@ -53,7 +53,7 @@
          %33 = OpLoad %int %a
                OpReturnValue %33
                OpFunctionEnd
-       %Main = OpFunction %void None %9
+       %Main = OpFunction %void None %10
      %self_2 = OpFunctionParameter %_ptr_Function_IfWithReturn
          %38 = OpLabel
         %ret = OpVariable %_ptr_Function_int Function
@@ -62,7 +62,7 @@
                OpStore %ret %41
                OpReturn
                OpFunctionEnd
-%IfWithReturn_Main_EntryPoint = OpFunction %void None %13
+%IfWithReturn_Main_EntryPoint = OpFunction %void None %14
          %46 = OpLabel
      %self_3 = OpVariable %_ptr_Function_IfWithReturn Function
          %48 = OpFunctionCall %void %IfWithReturn_DefaultConstructor %self_3

--- a/CSShadersTests/Tests/LanguageBasics/ControlFlow/ShortCircuit/ComplexLogicalAndOr.expected.spvtxt
+++ b/CSShadersTests/Tests/LanguageBasics/ControlFlow/ShortCircuit/ComplexLogicalAndOr.expected.spvtxt
@@ -58,33 +58,33 @@
                OpName %ComplexLogicalAndOr_Main_EntryPoint "ComplexLogicalAndOr_Main_EntryPoint"
                OpName %self_6 "self"
        %bool = OpTypeBool
+      %false = OpConstantFalse %bool
+       %true = OpConstantTrue %bool
 %ComplexLogicalAndOr = OpTypeStruct
        %void = OpTypeVoid
 %_ptr_Function_ComplexLogicalAndOr = OpTypePointer Function %ComplexLogicalAndOr
-          %7 = OpTypeFunction %void %_ptr_Function_ComplexLogicalAndOr
-          %9 = OpTypeFunction %bool %_ptr_Function_ComplexLogicalAndOr
+          %9 = OpTypeFunction %void %_ptr_Function_ComplexLogicalAndOr
+         %11 = OpTypeFunction %bool %_ptr_Function_ComplexLogicalAndOr
 %_ptr_Function_bool = OpTypePointer Function %bool
        %uint = OpTypeInt 32 0
-         %13 = OpTypeFunction %void
-      %false = OpConstantFalse %bool
-       %true = OpConstantTrue %bool
-%ComplexLogicalAndOr_PreConstructor = OpFunction %void None %7
+         %15 = OpTypeFunction %void
+%ComplexLogicalAndOr_PreConstructor = OpFunction %void None %9
        %self = OpFunctionParameter %_ptr_Function_ComplexLogicalAndOr
          %20 = OpLabel
                OpReturn
                OpFunctionEnd
-%ComplexLogicalAndOr_DefaultConstructor = OpFunction %void None %7
+%ComplexLogicalAndOr_DefaultConstructor = OpFunction %void None %9
      %self_0 = OpFunctionParameter %_ptr_Function_ComplexLogicalAndOr
          %25 = OpLabel
          %26 = OpFunctionCall %void %ComplexLogicalAndOr_PreConstructor %self_0
                OpReturn
                OpFunctionEnd
-    %GetBool = OpFunction %bool None %9
+    %GetBool = OpFunction %bool None %11
      %self_1 = OpFunctionParameter %_ptr_Function_ComplexLogicalAndOr
          %31 = OpLabel
                OpReturnValue %false
                OpFunctionEnd
-%LogicalOrAnd0 = OpFunction %bool None %9
+%LogicalOrAnd0 = OpFunction %bool None %11
      %self_2 = OpFunctionParameter %_ptr_Function_ComplexLogicalAndOr
          %36 = OpLabel
      %tempOr = OpVariable %_ptr_Function_bool Function
@@ -111,7 +111,7 @@
          %58 = OpLoad %bool %tempOr
                OpReturnValue %58
                OpFunctionEnd
-%LogicalOrAnd1 = OpFunction %bool None %9
+%LogicalOrAnd1 = OpFunction %bool None %11
      %self_3 = OpFunctionParameter %_ptr_Function_ComplexLogicalAndOr
          %63 = OpLabel
    %tempOr_0 = OpVariable %_ptr_Function_bool Function
@@ -138,7 +138,7 @@
          %85 = OpLoad %bool %tempAnd_0
                OpReturnValue %85
                OpFunctionEnd
-%LogicalOrAnd2 = OpFunction %bool None %9
+%LogicalOrAnd2 = OpFunction %bool None %11
      %self_4 = OpFunctionParameter %_ptr_Function_ComplexLogicalAndOr
          %90 = OpLabel
    %tempOr_1 = OpVariable %_ptr_Function_bool Function
@@ -178,7 +178,7 @@
         %125 = OpLoad %bool %tempAnd_1
                OpReturnValue %125
                OpFunctionEnd
-       %Main = OpFunction %void None %7
+       %Main = OpFunction %void None %9
      %self_5 = OpFunctionParameter %_ptr_Function_ComplexLogicalAndOr
         %130 = OpLabel
         %ret = OpVariable %_ptr_Function_bool Function
@@ -191,7 +191,7 @@
                OpStore %ret %137
                OpReturn
                OpFunctionEnd
-%ComplexLogicalAndOr_Main_EntryPoint = OpFunction %void None %13
+%ComplexLogicalAndOr_Main_EntryPoint = OpFunction %void None %15
         %142 = OpLabel
      %self_6 = OpVariable %_ptr_Function_ComplexLogicalAndOr Function
         %144 = OpFunctionCall %void %ComplexLogicalAndOr_DefaultConstructor %self_6

--- a/CSShadersTests/Tests/LanguageBasics/ControlFlow/ShortCircuit/LogicalAnd.expected.spvtxt
+++ b/CSShadersTests/Tests/LanguageBasics/ControlFlow/ShortCircuit/LogicalAnd.expected.spvtxt
@@ -44,33 +44,33 @@
                OpName %LogicalAnd_Main_EntryPoint "LogicalAnd_Main_EntryPoint"
                OpName %self_6 "self"
        %bool = OpTypeBool
+      %false = OpConstantFalse %bool
+       %true = OpConstantTrue %bool
  %LogicalAnd = OpTypeStruct
        %void = OpTypeVoid
 %_ptr_Function_LogicalAnd = OpTypePointer Function %LogicalAnd
-          %7 = OpTypeFunction %void %_ptr_Function_LogicalAnd
-          %9 = OpTypeFunction %bool %_ptr_Function_LogicalAnd
+          %9 = OpTypeFunction %void %_ptr_Function_LogicalAnd
+         %11 = OpTypeFunction %bool %_ptr_Function_LogicalAnd
 %_ptr_Function_bool = OpTypePointer Function %bool
        %uint = OpTypeInt 32 0
-         %13 = OpTypeFunction %void
-      %false = OpConstantFalse %bool
-       %true = OpConstantTrue %bool
-%LogicalAnd_PreConstructor = OpFunction %void None %7
+         %15 = OpTypeFunction %void
+%LogicalAnd_PreConstructor = OpFunction %void None %9
        %self = OpFunctionParameter %_ptr_Function_LogicalAnd
          %20 = OpLabel
                OpReturn
                OpFunctionEnd
-%LogicalAnd_DefaultConstructor = OpFunction %void None %7
+%LogicalAnd_DefaultConstructor = OpFunction %void None %9
      %self_0 = OpFunctionParameter %_ptr_Function_LogicalAnd
          %25 = OpLabel
          %26 = OpFunctionCall %void %LogicalAnd_PreConstructor %self_0
                OpReturn
                OpFunctionEnd
-    %GetBool = OpFunction %bool None %9
+    %GetBool = OpFunction %bool None %11
      %self_1 = OpFunctionParameter %_ptr_Function_LogicalAnd
          %31 = OpLabel
                OpReturnValue %false
                OpFunctionEnd
-%LogicalAnd0 = OpFunction %bool None %9
+%LogicalAnd0 = OpFunction %bool None %11
      %self_2 = OpFunctionParameter %_ptr_Function_LogicalAnd
          %36 = OpLabel
     %tempAnd = OpVariable %_ptr_Function_bool Function
@@ -86,7 +86,7 @@
          %47 = OpLoad %bool %tempAnd
                OpReturnValue %47
                OpFunctionEnd
-%LogicalAnd1 = OpFunction %bool None %9
+%LogicalAnd1 = OpFunction %bool None %11
      %self_3 = OpFunctionParameter %_ptr_Function_LogicalAnd
          %52 = OpLabel
           %a = OpVariable %_ptr_Function_bool Function
@@ -108,7 +108,7 @@
          %69 = OpLoad %bool %tempAnd_0
                OpReturnValue %69
                OpFunctionEnd
-%LogicalAnd2 = OpFunction %bool None %9
+%LogicalAnd2 = OpFunction %bool None %11
      %self_4 = OpFunctionParameter %_ptr_Function_LogicalAnd
          %74 = OpLabel
   %tempAnd_1 = OpVariable %_ptr_Function_bool Function
@@ -126,7 +126,7 @@
          %87 = OpLoad %bool %tempAnd_1
                OpReturnValue %87
                OpFunctionEnd
-       %Main = OpFunction %void None %7
+       %Main = OpFunction %void None %9
      %self_5 = OpFunctionParameter %_ptr_Function_LogicalAnd
          %92 = OpLabel
         %ret = OpVariable %_ptr_Function_bool Function
@@ -139,7 +139,7 @@
                OpStore %ret %99
                OpReturn
                OpFunctionEnd
-%LogicalAnd_Main_EntryPoint = OpFunction %void None %13
+%LogicalAnd_Main_EntryPoint = OpFunction %void None %15
         %104 = OpLabel
      %self_6 = OpVariable %_ptr_Function_LogicalAnd Function
         %106 = OpFunctionCall %void %LogicalAnd_DefaultConstructor %self_6

--- a/CSShadersTests/Tests/LanguageBasics/ControlFlow/ShortCircuit/LogicalOr.expected.spvtxt
+++ b/CSShadersTests/Tests/LanguageBasics/ControlFlow/ShortCircuit/LogicalOr.expected.spvtxt
@@ -44,33 +44,33 @@
                OpName %LogicalOr_Main_EntryPoint "LogicalOr_Main_EntryPoint"
                OpName %self_6 "self"
        %bool = OpTypeBool
+      %false = OpConstantFalse %bool
+       %true = OpConstantTrue %bool
   %LogicalOr = OpTypeStruct
        %void = OpTypeVoid
 %_ptr_Function_LogicalOr = OpTypePointer Function %LogicalOr
-          %7 = OpTypeFunction %void %_ptr_Function_LogicalOr
-          %9 = OpTypeFunction %bool %_ptr_Function_LogicalOr
+          %9 = OpTypeFunction %void %_ptr_Function_LogicalOr
+         %11 = OpTypeFunction %bool %_ptr_Function_LogicalOr
 %_ptr_Function_bool = OpTypePointer Function %bool
        %uint = OpTypeInt 32 0
-         %13 = OpTypeFunction %void
-      %false = OpConstantFalse %bool
-       %true = OpConstantTrue %bool
-%LogicalOr_PreConstructor = OpFunction %void None %7
+         %15 = OpTypeFunction %void
+%LogicalOr_PreConstructor = OpFunction %void None %9
        %self = OpFunctionParameter %_ptr_Function_LogicalOr
          %20 = OpLabel
                OpReturn
                OpFunctionEnd
-%LogicalOr_DefaultConstructor = OpFunction %void None %7
+%LogicalOr_DefaultConstructor = OpFunction %void None %9
      %self_0 = OpFunctionParameter %_ptr_Function_LogicalOr
          %25 = OpLabel
          %26 = OpFunctionCall %void %LogicalOr_PreConstructor %self_0
                OpReturn
                OpFunctionEnd
-    %GetBool = OpFunction %bool None %9
+    %GetBool = OpFunction %bool None %11
      %self_1 = OpFunctionParameter %_ptr_Function_LogicalOr
          %31 = OpLabel
                OpReturnValue %false
                OpFunctionEnd
- %LogicalOr0 = OpFunction %bool None %9
+ %LogicalOr0 = OpFunction %bool None %11
      %self_2 = OpFunctionParameter %_ptr_Function_LogicalOr
          %36 = OpLabel
      %tempOr = OpVariable %_ptr_Function_bool Function
@@ -86,7 +86,7 @@
          %47 = OpLoad %bool %tempOr
                OpReturnValue %47
                OpFunctionEnd
- %LogicalOr1 = OpFunction %bool None %9
+ %LogicalOr1 = OpFunction %bool None %11
      %self_3 = OpFunctionParameter %_ptr_Function_LogicalOr
          %52 = OpLabel
           %a = OpVariable %_ptr_Function_bool Function
@@ -108,7 +108,7 @@
          %69 = OpLoad %bool %tempOr_0
                OpReturnValue %69
                OpFunctionEnd
- %LogicalOr2 = OpFunction %bool None %9
+ %LogicalOr2 = OpFunction %bool None %11
      %self_4 = OpFunctionParameter %_ptr_Function_LogicalOr
          %74 = OpLabel
    %tempOr_1 = OpVariable %_ptr_Function_bool Function
@@ -126,7 +126,7 @@
          %87 = OpLoad %bool %tempOr_1
                OpReturnValue %87
                OpFunctionEnd
-       %Main = OpFunction %void None %7
+       %Main = OpFunction %void None %9
      %self_5 = OpFunctionParameter %_ptr_Function_LogicalOr
          %92 = OpLabel
         %ret = OpVariable %_ptr_Function_bool Function
@@ -139,7 +139,7 @@
                OpStore %ret %99
                OpReturn
                OpFunctionEnd
-%LogicalOr_Main_EntryPoint = OpFunction %void None %13
+%LogicalOr_Main_EntryPoint = OpFunction %void None %15
         %104 = OpLabel
      %self_6 = OpVariable %_ptr_Function_LogicalOr Function
         %106 = OpFunctionCall %void %LogicalOr_DefaultConstructor %self_6

--- a/CSShadersTests/Tests/LanguageBasics/ControlFlow/While/While.expected.spvtxt
+++ b/CSShadersTests/Tests/LanguageBasics/ControlFlow/While/While.expected.spvtxt
@@ -31,28 +31,28 @@
                OpName %self_3 "self"
        %uint = OpTypeInt 32 0
         %int = OpTypeInt 32 1
+      %int_1 = OpConstant %int 1
+      %int_0 = OpConstant %int 0
   %WhileTest = OpTypeStruct
        %void = OpTypeVoid
 %_ptr_Function_WhileTest = OpTypePointer Function %WhileTest
-          %9 = OpTypeFunction %void %_ptr_Function_WhileTest
-         %11 = OpTypeFunction %int %_ptr_Function_WhileTest
+         %11 = OpTypeFunction %void %_ptr_Function_WhileTest
+         %13 = OpTypeFunction %int %_ptr_Function_WhileTest
 %_ptr_Function_int = OpTypePointer Function %int
        %bool = OpTypeBool
-         %15 = OpTypeFunction %void
-      %int_1 = OpConstant %int 1
-      %int_0 = OpConstant %int 0
-%WhileTest_PreConstructor = OpFunction %void None %9
+         %17 = OpTypeFunction %void
+%WhileTest_PreConstructor = OpFunction %void None %11
        %self = OpFunctionParameter %_ptr_Function_WhileTest
          %22 = OpLabel
                OpReturn
                OpFunctionEnd
-%WhileTest_DefaultConstructor = OpFunction %void None %9
+%WhileTest_DefaultConstructor = OpFunction %void None %11
      %self_0 = OpFunctionParameter %_ptr_Function_WhileTest
          %27 = OpLabel
          %28 = OpFunctionCall %void %WhileTest_PreConstructor %self_0
                OpReturn
                OpFunctionEnd
-     %While0 = OpFunction %int None %11
+     %While0 = OpFunction %int None %13
      %self_1 = OpFunctionParameter %_ptr_Function_WhileTest
          %33 = OpLabel
           %a = OpVariable %_ptr_Function_int Function
@@ -76,7 +76,7 @@
          %52 = OpLoad %int %a
                OpReturnValue %52
                OpFunctionEnd
-       %Main = OpFunction %void None %9
+       %Main = OpFunction %void None %11
      %self_2 = OpFunctionParameter %_ptr_Function_WhileTest
          %57 = OpLabel
         %ret = OpVariable %_ptr_Function_int Function
@@ -84,7 +84,7 @@
                OpStore %ret %59
                OpReturn
                OpFunctionEnd
-%WhileTest_Main_EntryPoint = OpFunction %void None %15
+%WhileTest_Main_EntryPoint = OpFunction %void None %17
          %64 = OpLabel
      %self_3 = OpVariable %_ptr_Function_WhileTest Function
          %66 = OpFunctionCall %void %WhileTest_DefaultConstructor %self_3

--- a/CSShadersTests/Tests/LanguageBasics/ControlFlow/While/WhileBreak.expected.spvtxt
+++ b/CSShadersTests/Tests/LanguageBasics/ControlFlow/While/WhileBreak.expected.spvtxt
@@ -31,28 +31,28 @@
                OpName %self_3 "self"
        %uint = OpTypeInt 32 0
         %int = OpTypeInt 32 1
+      %int_1 = OpConstant %int 1
+      %int_0 = OpConstant %int 0
  %WhileBreak = OpTypeStruct
        %void = OpTypeVoid
 %_ptr_Function_WhileBreak = OpTypePointer Function %WhileBreak
-          %9 = OpTypeFunction %void %_ptr_Function_WhileBreak
-         %11 = OpTypeFunction %int %_ptr_Function_WhileBreak
+         %11 = OpTypeFunction %void %_ptr_Function_WhileBreak
+         %13 = OpTypeFunction %int %_ptr_Function_WhileBreak
 %_ptr_Function_int = OpTypePointer Function %int
        %bool = OpTypeBool
-         %15 = OpTypeFunction %void
-      %int_1 = OpConstant %int 1
-      %int_0 = OpConstant %int 0
-%WhileBreak_PreConstructor = OpFunction %void None %9
+         %17 = OpTypeFunction %void
+%WhileBreak_PreConstructor = OpFunction %void None %11
        %self = OpFunctionParameter %_ptr_Function_WhileBreak
          %22 = OpLabel
                OpReturn
                OpFunctionEnd
-%WhileBreak_DefaultConstructor = OpFunction %void None %9
+%WhileBreak_DefaultConstructor = OpFunction %void None %11
      %self_0 = OpFunctionParameter %_ptr_Function_WhileBreak
          %27 = OpLabel
          %28 = OpFunctionCall %void %WhileBreak_PreConstructor %self_0
                OpReturn
                OpFunctionEnd
-%WhileBreak0 = OpFunction %int None %11
+%WhileBreak0 = OpFunction %int None %13
      %self_1 = OpFunctionParameter %_ptr_Function_WhileBreak
          %33 = OpLabel
           %a = OpVariable %_ptr_Function_int Function
@@ -73,7 +73,7 @@
          %49 = OpLoad %int %a
                OpReturnValue %49
                OpFunctionEnd
-       %Main = OpFunction %void None %9
+       %Main = OpFunction %void None %11
      %self_2 = OpFunctionParameter %_ptr_Function_WhileBreak
          %54 = OpLabel
         %ret = OpVariable %_ptr_Function_int Function
@@ -81,7 +81,7 @@
                OpStore %ret %56
                OpReturn
                OpFunctionEnd
-%WhileBreak_Main_EntryPoint = OpFunction %void None %15
+%WhileBreak_Main_EntryPoint = OpFunction %void None %17
          %61 = OpLabel
      %self_3 = OpVariable %_ptr_Function_WhileBreak Function
          %63 = OpFunctionCall %void %WhileBreak_DefaultConstructor %self_3

--- a/CSShadersTests/Tests/LanguageBasics/ControlFlow/While/WhileContinue.expected.spvtxt
+++ b/CSShadersTests/Tests/LanguageBasics/ControlFlow/While/WhileContinue.expected.spvtxt
@@ -31,28 +31,28 @@
                OpName %self_3 "self"
        %uint = OpTypeInt 32 0
         %int = OpTypeInt 32 1
+      %int_1 = OpConstant %int 1
+      %int_0 = OpConstant %int 0
 %WhileContinue = OpTypeStruct
        %void = OpTypeVoid
 %_ptr_Function_WhileContinue = OpTypePointer Function %WhileContinue
-          %9 = OpTypeFunction %void %_ptr_Function_WhileContinue
-         %11 = OpTypeFunction %int %_ptr_Function_WhileContinue
+         %11 = OpTypeFunction %void %_ptr_Function_WhileContinue
+         %13 = OpTypeFunction %int %_ptr_Function_WhileContinue
 %_ptr_Function_int = OpTypePointer Function %int
        %bool = OpTypeBool
-         %15 = OpTypeFunction %void
-      %int_1 = OpConstant %int 1
-      %int_0 = OpConstant %int 0
-%WhileContinue_PreConstructor = OpFunction %void None %9
+         %17 = OpTypeFunction %void
+%WhileContinue_PreConstructor = OpFunction %void None %11
        %self = OpFunctionParameter %_ptr_Function_WhileContinue
          %22 = OpLabel
                OpReturn
                OpFunctionEnd
-%WhileContinue_DefaultConstructor = OpFunction %void None %9
+%WhileContinue_DefaultConstructor = OpFunction %void None %11
      %self_0 = OpFunctionParameter %_ptr_Function_WhileContinue
          %27 = OpLabel
          %28 = OpFunctionCall %void %WhileContinue_PreConstructor %self_0
                OpReturn
                OpFunctionEnd
-%WhileContinue0 = OpFunction %int None %11
+%WhileContinue0 = OpFunction %int None %13
      %self_1 = OpFunctionParameter %_ptr_Function_WhileContinue
          %33 = OpLabel
           %a = OpVariable %_ptr_Function_int Function
@@ -73,7 +73,7 @@
          %49 = OpLoad %int %a
                OpReturnValue %49
                OpFunctionEnd
-       %Main = OpFunction %void None %9
+       %Main = OpFunction %void None %11
      %self_2 = OpFunctionParameter %_ptr_Function_WhileContinue
          %54 = OpLabel
         %ret = OpVariable %_ptr_Function_int Function
@@ -81,7 +81,7 @@
                OpStore %ret %56
                OpReturn
                OpFunctionEnd
-%WhileContinue_Main_EntryPoint = OpFunction %void None %15
+%WhileContinue_Main_EntryPoint = OpFunction %void None %17
          %61 = OpLabel
      %self_3 = OpVariable %_ptr_Function_WhileContinue Function
          %63 = OpFunctionCall %void %WhileContinue_DefaultConstructor %self_3

--- a/CSShadersTests/Tests/LanguageBasics/ControlFlow/While/WhileNested.expected.spvtxt
+++ b/CSShadersTests/Tests/LanguageBasics/ControlFlow/While/WhileNested.expected.spvtxt
@@ -79,28 +79,28 @@
                OpName %self_6 "self"
        %uint = OpTypeInt 32 0
         %int = OpTypeInt 32 1
+      %int_1 = OpConstant %int 1
+      %int_0 = OpConstant %int 0
 %WhileNested = OpTypeStruct
        %void = OpTypeVoid
 %_ptr_Function_WhileNested = OpTypePointer Function %WhileNested
-          %9 = OpTypeFunction %void %_ptr_Function_WhileNested
-         %11 = OpTypeFunction %int %_ptr_Function_WhileNested
+         %11 = OpTypeFunction %void %_ptr_Function_WhileNested
+         %13 = OpTypeFunction %int %_ptr_Function_WhileNested
 %_ptr_Function_int = OpTypePointer Function %int
        %bool = OpTypeBool
-         %15 = OpTypeFunction %void
-      %int_1 = OpConstant %int 1
-      %int_0 = OpConstant %int 0
-%WhileNested_PreConstructor = OpFunction %void None %9
+         %17 = OpTypeFunction %void
+%WhileNested_PreConstructor = OpFunction %void None %11
        %self = OpFunctionParameter %_ptr_Function_WhileNested
          %22 = OpLabel
                OpReturn
                OpFunctionEnd
-%WhileNested_DefaultConstructor = OpFunction %void None %9
+%WhileNested_DefaultConstructor = OpFunction %void None %11
      %self_0 = OpFunctionParameter %_ptr_Function_WhileNested
          %27 = OpLabel
          %28 = OpFunctionCall %void %WhileNested_PreConstructor %self_0
                OpReturn
                OpFunctionEnd
-%WhileNested0 = OpFunction %int None %11
+%WhileNested0 = OpFunction %int None %13
      %self_1 = OpFunctionParameter %_ptr_Function_WhileNested
          %33 = OpLabel
           %a = OpVariable %_ptr_Function_int Function
@@ -142,7 +142,7 @@
          %70 = OpLoad %int %a
                OpReturnValue %70
                OpFunctionEnd
-%WhileNested1 = OpFunction %int None %11
+%WhileNested1 = OpFunction %int None %13
      %self_2 = OpFunctionParameter %_ptr_Function_WhileNested
          %75 = OpLabel
         %a_0 = OpVariable %_ptr_Function_int Function
@@ -184,7 +184,7 @@
         %112 = OpLoad %int %a_0
                OpReturnValue %112
                OpFunctionEnd
-%WhileNested2 = OpFunction %int None %11
+%WhileNested2 = OpFunction %int None %13
      %self_3 = OpFunctionParameter %_ptr_Function_WhileNested
         %117 = OpLabel
         %a_1 = OpVariable %_ptr_Function_int Function
@@ -226,7 +226,7 @@
         %154 = OpLoad %int %a_1
                OpReturnValue %154
                OpFunctionEnd
-%WhileNested3 = OpFunction %int None %11
+%WhileNested3 = OpFunction %int None %13
      %self_4 = OpFunctionParameter %_ptr_Function_WhileNested
         %159 = OpLabel
         %a_2 = OpVariable %_ptr_Function_int Function
@@ -265,7 +265,7 @@
         %193 = OpLoad %int %a_2
                OpReturnValue %193
                OpFunctionEnd
-       %Main = OpFunction %void None %9
+       %Main = OpFunction %void None %11
      %self_5 = OpFunctionParameter %_ptr_Function_WhileNested
         %198 = OpLabel
         %ret = OpVariable %_ptr_Function_int Function
@@ -280,7 +280,7 @@
                OpStore %ret %207
                OpReturn
                OpFunctionEnd
-%WhileNested_Main_EntryPoint = OpFunction %void None %15
+%WhileNested_Main_EntryPoint = OpFunction %void None %17
         %212 = OpLabel
      %self_6 = OpVariable %_ptr_Function_WhileNested Function
         %214 = OpFunctionCall %void %WhileNested_DefaultConstructor %self_6

--- a/CSShadersTests/Tests/LanguageBasics/OverloadedBinaryOps/PrimitiveBinaryIntrinsicOp.expected.spvtxt
+++ b/CSShadersTests/Tests/LanguageBasics/OverloadedBinaryOps/PrimitiveBinaryIntrinsicOp.expected.spvtxt
@@ -25,26 +25,26 @@
                OpName %self_2 "self"
        %uint = OpTypeInt 32 0
       %float = OpTypeFloat 32
+    %float_0 = OpConstant %float 0
      %TestV2 = OpTypeVector %float 2
 %PrimitiveBinaryIntrinsicOp = OpTypeStruct
        %void = OpTypeVoid
 %_ptr_Function_PrimitiveBinaryIntrinsicOp = OpTypePointer Function %PrimitiveBinaryIntrinsicOp
-         %11 = OpTypeFunction %void %_ptr_Function_PrimitiveBinaryIntrinsicOp
+         %12 = OpTypeFunction %void %_ptr_Function_PrimitiveBinaryIntrinsicOp
 %_ptr_Function_TestV2 = OpTypePointer Function %TestV2
-         %13 = OpTypeFunction %void
-    %float_0 = OpConstant %float 0
-%PrimitiveBinaryIntrinsicOp_PreConstructor = OpFunction %void None %11
+         %14 = OpTypeFunction %void
+%PrimitiveBinaryIntrinsicOp_PreConstructor = OpFunction %void None %12
        %self = OpFunctionParameter %_ptr_Function_PrimitiveBinaryIntrinsicOp
          %19 = OpLabel
                OpReturn
                OpFunctionEnd
-%PrimitiveBinaryIntrinsicOp_DefaultConstructor = OpFunction %void None %11
+%PrimitiveBinaryIntrinsicOp_DefaultConstructor = OpFunction %void None %12
      %self_0 = OpFunctionParameter %_ptr_Function_PrimitiveBinaryIntrinsicOp
          %24 = OpLabel
          %25 = OpFunctionCall %void %PrimitiveBinaryIntrinsicOp_PreConstructor %self_0
                OpReturn
                OpFunctionEnd
-       %Main = OpFunction %void None %11
+       %Main = OpFunction %void None %12
      %self_1 = OpFunctionParameter %_ptr_Function_PrimitiveBinaryIntrinsicOp
          %30 = OpLabel
       %value = OpVariable %_ptr_Function_TestV2 Function
@@ -57,7 +57,7 @@
                OpStore %result %37
                OpReturn
                OpFunctionEnd
-%PrimitiveBinaryIntrinsicOp_Main_EntryPoint = OpFunction %void None %13
+%PrimitiveBinaryIntrinsicOp_Main_EntryPoint = OpFunction %void None %14
          %42 = OpLabel
      %self_2 = OpVariable %_ptr_Function_PrimitiveBinaryIntrinsicOp Function
          %44 = OpFunctionCall %void %PrimitiveBinaryIntrinsicOp_DefaultConstructor %self_2

--- a/CSShadersTests/Tests/LanguageBasics/OverloadedBinaryOps/PrimitiveBinaryOp.expected.spvtxt
+++ b/CSShadersTests/Tests/LanguageBasics/OverloadedBinaryOps/PrimitiveBinaryOp.expected.spvtxt
@@ -28,34 +28,34 @@
                OpName %self_2 "self"
        %uint = OpTypeInt 32 0
       %float = OpTypeFloat 32
+    %float_0 = OpConstant %float 0
      %TestV2 = OpTypeVector %float 2
-          %7 = OpTypeFunction %TestV2 %TestV2 %TestV2
+          %8 = OpTypeFunction %TestV2 %TestV2 %TestV2
 %PrimitiveBinaryOp = OpTypeStruct
        %void = OpTypeVoid
 %_ptr_Function_PrimitiveBinaryOp = OpTypePointer Function %PrimitiveBinaryOp
-         %13 = OpTypeFunction %void %_ptr_Function_PrimitiveBinaryOp
+         %14 = OpTypeFunction %void %_ptr_Function_PrimitiveBinaryOp
 %_ptr_Function_TestV2 = OpTypePointer Function %TestV2
-         %15 = OpTypeFunction %void
-    %float_0 = OpConstant %float 0
-%op_Addition = OpFunction %TestV2 None %7
+         %16 = OpTypeFunction %void
+%op_Addition = OpFunction %TestV2 None %8
         %lhs = OpFunctionParameter %TestV2
         %rhs = OpFunctionParameter %TestV2
          %22 = OpLabel
          %23 = OpFAdd %TestV2 %lhs %rhs
                OpReturnValue %23
                OpFunctionEnd
-%PrimitiveBinaryOp_PreConstructor = OpFunction %void None %13
+%PrimitiveBinaryOp_PreConstructor = OpFunction %void None %14
        %self = OpFunctionParameter %_ptr_Function_PrimitiveBinaryOp
          %28 = OpLabel
                OpReturn
                OpFunctionEnd
-%PrimitiveBinaryOp_DefaultConstructor = OpFunction %void None %13
+%PrimitiveBinaryOp_DefaultConstructor = OpFunction %void None %14
      %self_0 = OpFunctionParameter %_ptr_Function_PrimitiveBinaryOp
          %33 = OpLabel
          %34 = OpFunctionCall %void %PrimitiveBinaryOp_PreConstructor %self_0
                OpReturn
                OpFunctionEnd
-       %Main = OpFunction %void None %13
+       %Main = OpFunction %void None %14
      %self_1 = OpFunctionParameter %_ptr_Function_PrimitiveBinaryOp
          %39 = OpLabel
       %value = OpVariable %_ptr_Function_TestV2 Function
@@ -68,7 +68,7 @@
                OpStore %result %46
                OpReturn
                OpFunctionEnd
-%PrimitiveBinaryOp_Main_EntryPoint = OpFunction %void None %15
+%PrimitiveBinaryOp_Main_EntryPoint = OpFunction %void None %16
          %51 = OpLabel
      %self_2 = OpVariable %_ptr_Function_PrimitiveBinaryOp Function
          %53 = OpFunctionCall %void %PrimitiveBinaryOp_DefaultConstructor %self_2

--- a/CSShadersTests/Tests/LanguageBasics/OverloadedBinaryOps/StructBinaryOp.expected.spvtxt
+++ b/CSShadersTests/Tests/LanguageBasics/OverloadedBinaryOps/StructBinaryOp.expected.spvtxt
@@ -37,20 +37,20 @@
                OpName %self_4 "self"
        %uint = OpTypeInt 32 0
       %float = OpTypeFloat 32
-     %TestV2 = OpTypeStruct %float %float
-       %void = OpTypeVoid
-%_ptr_Function_TestV2 = OpTypePointer Function %TestV2
-          %9 = OpTypeFunction %void %_ptr_Function_TestV2
-%_ptr_Function_float = OpTypePointer Function %float
-         %11 = OpTypeFunction %TestV2 %TestV2 %TestV2
-%StructUnaryOp = OpTypeStruct
-%_ptr_Function_StructUnaryOp = OpTypePointer Function %StructUnaryOp
-         %15 = OpTypeFunction %void %_ptr_Function_StructUnaryOp
-         %17 = OpTypeFunction %void
     %float_0 = OpConstant %float 0
      %uint_0 = OpConstant %uint 0
      %uint_1 = OpConstant %uint 1
-%TestV2_PreConstructor = OpFunction %void None %9
+     %TestV2 = OpTypeStruct %float %float
+       %void = OpTypeVoid
+%_ptr_Function_TestV2 = OpTypePointer Function %TestV2
+         %12 = OpTypeFunction %void %_ptr_Function_TestV2
+%_ptr_Function_float = OpTypePointer Function %float
+         %14 = OpTypeFunction %TestV2 %TestV2 %TestV2
+%StructUnaryOp = OpTypeStruct
+%_ptr_Function_StructUnaryOp = OpTypePointer Function %StructUnaryOp
+         %18 = OpTypeFunction %void %_ptr_Function_StructUnaryOp
+         %20 = OpTypeFunction %void
+%TestV2_PreConstructor = OpFunction %void None %12
        %self = OpFunctionParameter %_ptr_Function_TestV2
          %25 = OpLabel
          %26 = OpAccessChain %_ptr_Function_float %self %uint_0
@@ -59,13 +59,13 @@
                OpStore %28 %float_0
                OpReturn
                OpFunctionEnd
-%TestV2_DefaultConstructor = OpFunction %void None %9
+%TestV2_DefaultConstructor = OpFunction %void None %12
      %self_0 = OpFunctionParameter %_ptr_Function_TestV2
          %34 = OpLabel
          %35 = OpFunctionCall %void %TestV2_PreConstructor %self_0
                OpReturn
                OpFunctionEnd
-%op_Addition = OpFunction %TestV2 None %11
+%op_Addition = OpFunction %TestV2 None %14
         %lhs = OpFunctionParameter %TestV2
         %rhs = OpFunctionParameter %TestV2
          %41 = OpLabel
@@ -87,18 +87,18 @@
          %57 = OpLoad %TestV2 %result
                OpReturnValue %57
                OpFunctionEnd
-%StructUnaryOp_PreConstructor = OpFunction %void None %15
+%StructUnaryOp_PreConstructor = OpFunction %void None %18
      %self_1 = OpFunctionParameter %_ptr_Function_StructUnaryOp
          %62 = OpLabel
                OpReturn
                OpFunctionEnd
-%StructUnaryOp_DefaultConstructor = OpFunction %void None %15
+%StructUnaryOp_DefaultConstructor = OpFunction %void None %18
      %self_2 = OpFunctionParameter %_ptr_Function_StructUnaryOp
          %67 = OpLabel
          %68 = OpFunctionCall %void %StructUnaryOp_PreConstructor %self_2
                OpReturn
                OpFunctionEnd
-       %Main = OpFunction %void None %15
+       %Main = OpFunction %void None %18
      %self_3 = OpFunctionParameter %_ptr_Function_StructUnaryOp
          %73 = OpLabel
       %value = OpVariable %_ptr_Function_TestV2 Function
@@ -113,7 +113,7 @@
                OpStore %result_0 %82
                OpReturn
                OpFunctionEnd
-%StructUnaryOp_Main_EntryPoint = OpFunction %void None %17
+%StructUnaryOp_Main_EntryPoint = OpFunction %void None %20
          %87 = OpLabel
      %self_4 = OpVariable %_ptr_Function_StructUnaryOp Function
          %89 = OpFunctionCall %void %StructUnaryOp_DefaultConstructor %self_4

--- a/CSShadersTests/Tests/LanguageBasics/OverloadedUnaryOps/PrimitiveUnaryIntrinsicOp.expected.spvtxt
+++ b/CSShadersTests/Tests/LanguageBasics/OverloadedUnaryOps/PrimitiveUnaryIntrinsicOp.expected.spvtxt
@@ -24,26 +24,26 @@
                OpName %self_2 "self"
        %uint = OpTypeInt 32 0
       %float = OpTypeFloat 32
+    %float_0 = OpConstant %float 0
      %TestV2 = OpTypeVector %float 2
 %PrimitiveUnaryIntrinsicOp = OpTypeStruct
        %void = OpTypeVoid
 %_ptr_Function_PrimitiveUnaryIntrinsicOp = OpTypePointer Function %PrimitiveUnaryIntrinsicOp
-         %11 = OpTypeFunction %void %_ptr_Function_PrimitiveUnaryIntrinsicOp
+         %12 = OpTypeFunction %void %_ptr_Function_PrimitiveUnaryIntrinsicOp
 %_ptr_Function_TestV2 = OpTypePointer Function %TestV2
-         %13 = OpTypeFunction %void
-    %float_0 = OpConstant %float 0
-%PrimitiveUnaryIntrinsicOp_PreConstructor = OpFunction %void None %11
+         %14 = OpTypeFunction %void
+%PrimitiveUnaryIntrinsicOp_PreConstructor = OpFunction %void None %12
        %self = OpFunctionParameter %_ptr_Function_PrimitiveUnaryIntrinsicOp
          %19 = OpLabel
                OpReturn
                OpFunctionEnd
-%PrimitiveUnaryIntrinsicOp_DefaultConstructor = OpFunction %void None %11
+%PrimitiveUnaryIntrinsicOp_DefaultConstructor = OpFunction %void None %12
      %self_0 = OpFunctionParameter %_ptr_Function_PrimitiveUnaryIntrinsicOp
          %24 = OpLabel
          %25 = OpFunctionCall %void %PrimitiveUnaryIntrinsicOp_PreConstructor %self_0
                OpReturn
                OpFunctionEnd
-       %Main = OpFunction %void None %11
+       %Main = OpFunction %void None %12
      %self_1 = OpFunctionParameter %_ptr_Function_PrimitiveUnaryIntrinsicOp
          %30 = OpLabel
      %result = OpVariable %_ptr_Function_TestV2 Function
@@ -53,7 +53,7 @@
                OpStore %result %34
                OpReturn
                OpFunctionEnd
-%PrimitiveUnaryIntrinsicOp_Main_EntryPoint = OpFunction %void None %13
+%PrimitiveUnaryIntrinsicOp_Main_EntryPoint = OpFunction %void None %14
          %39 = OpLabel
      %self_2 = OpVariable %_ptr_Function_PrimitiveUnaryIntrinsicOp Function
          %41 = OpFunctionCall %void %PrimitiveUnaryIntrinsicOp_DefaultConstructor %self_2

--- a/CSShadersTests/Tests/LanguageBasics/OverloadedUnaryOps/PrimitiveUnaryOp.expected.spvtxt
+++ b/CSShadersTests/Tests/LanguageBasics/OverloadedUnaryOps/PrimitiveUnaryOp.expected.spvtxt
@@ -26,33 +26,33 @@
                OpName %self_2 "self"
        %uint = OpTypeInt 32 0
       %float = OpTypeFloat 32
+    %float_0 = OpConstant %float 0
      %TestV2 = OpTypeVector %float 2
-          %7 = OpTypeFunction %TestV2 %TestV2
+          %8 = OpTypeFunction %TestV2 %TestV2
 %PrimitiveUnaryOp = OpTypeStruct
        %void = OpTypeVoid
 %_ptr_Function_PrimitiveUnaryOp = OpTypePointer Function %PrimitiveUnaryOp
-         %13 = OpTypeFunction %void %_ptr_Function_PrimitiveUnaryOp
+         %14 = OpTypeFunction %void %_ptr_Function_PrimitiveUnaryOp
 %_ptr_Function_TestV2 = OpTypePointer Function %TestV2
-         %15 = OpTypeFunction %void
-    %float_0 = OpConstant %float 0
-%op_UnaryNegation = OpFunction %TestV2 None %7
+         %16 = OpTypeFunction %void
+%op_UnaryNegation = OpFunction %TestV2 None %8
       %value = OpFunctionParameter %TestV2
          %21 = OpLabel
          %22 = OpFNegate %TestV2 %value
                OpReturnValue %22
                OpFunctionEnd
-%PrimitiveUnaryOp_PreConstructor = OpFunction %void None %13
+%PrimitiveUnaryOp_PreConstructor = OpFunction %void None %14
        %self = OpFunctionParameter %_ptr_Function_PrimitiveUnaryOp
          %27 = OpLabel
                OpReturn
                OpFunctionEnd
-%PrimitiveUnaryOp_DefaultConstructor = OpFunction %void None %13
+%PrimitiveUnaryOp_DefaultConstructor = OpFunction %void None %14
      %self_0 = OpFunctionParameter %_ptr_Function_PrimitiveUnaryOp
          %32 = OpLabel
          %33 = OpFunctionCall %void %PrimitiveUnaryOp_PreConstructor %self_0
                OpReturn
                OpFunctionEnd
-       %Main = OpFunction %void None %13
+       %Main = OpFunction %void None %14
      %self_1 = OpFunctionParameter %_ptr_Function_PrimitiveUnaryOp
          %38 = OpLabel
      %result = OpVariable %_ptr_Function_TestV2 Function
@@ -61,7 +61,7 @@
                OpStore %result %41
                OpReturn
                OpFunctionEnd
-%PrimitiveUnaryOp_Main_EntryPoint = OpFunction %void None %15
+%PrimitiveUnaryOp_Main_EntryPoint = OpFunction %void None %16
          %46 = OpLabel
      %self_2 = OpVariable %_ptr_Function_PrimitiveUnaryOp Function
          %48 = OpFunctionCall %void %PrimitiveUnaryOp_DefaultConstructor %self_2

--- a/CSShadersTests/Tests/LanguageBasics/OverloadedUnaryOps/StructIncrementDecrement.expected.spvtxt
+++ b/CSShadersTests/Tests/LanguageBasics/OverloadedUnaryOps/StructIncrementDecrement.expected.spvtxt
@@ -41,21 +41,21 @@
                OpName %self_4 "self"
        %uint = OpTypeInt 32 0
       %float = OpTypeFloat 32
-     %TestV2 = OpTypeStruct %float %float
-       %void = OpTypeVoid
-%_ptr_Function_TestV2 = OpTypePointer Function %TestV2
-          %9 = OpTypeFunction %void %_ptr_Function_TestV2
-%_ptr_Function_float = OpTypePointer Function %float
-         %11 = OpTypeFunction %TestV2 %TestV2
-%StructIncrementDecrement = OpTypeStruct
-%_ptr_Function_StructIncrementDecrement = OpTypePointer Function %StructIncrementDecrement
-         %15 = OpTypeFunction %void %_ptr_Function_StructIncrementDecrement
-         %17 = OpTypeFunction %void
     %float_0 = OpConstant %float 0
      %uint_0 = OpConstant %uint 0
      %uint_1 = OpConstant %uint 1
     %float_1 = OpConstant %float 1
-%TestV2_PreConstructor = OpFunction %void None %9
+     %TestV2 = OpTypeStruct %float %float
+       %void = OpTypeVoid
+%_ptr_Function_TestV2 = OpTypePointer Function %TestV2
+         %13 = OpTypeFunction %void %_ptr_Function_TestV2
+%_ptr_Function_float = OpTypePointer Function %float
+         %15 = OpTypeFunction %TestV2 %TestV2
+%StructIncrementDecrement = OpTypeStruct
+%_ptr_Function_StructIncrementDecrement = OpTypePointer Function %StructIncrementDecrement
+         %19 = OpTypeFunction %void %_ptr_Function_StructIncrementDecrement
+         %21 = OpTypeFunction %void
+%TestV2_PreConstructor = OpFunction %void None %13
        %self = OpFunctionParameter %_ptr_Function_TestV2
          %26 = OpLabel
          %27 = OpAccessChain %_ptr_Function_float %self %uint_0
@@ -64,13 +64,13 @@
                OpStore %29 %float_0
                OpReturn
                OpFunctionEnd
-%TestV2_DefaultConstructor = OpFunction %void None %9
+%TestV2_DefaultConstructor = OpFunction %void None %13
      %self_0 = OpFunctionParameter %_ptr_Function_TestV2
          %35 = OpLabel
          %36 = OpFunctionCall %void %TestV2_PreConstructor %self_0
                OpReturn
                OpFunctionEnd
-%op_Increment = OpFunction %TestV2 None %11
+%op_Increment = OpFunction %TestV2 None %15
       %value = OpFunctionParameter %TestV2
          %41 = OpLabel
      %result = OpVariable %_ptr_Function_TestV2 Function
@@ -89,7 +89,7 @@
          %55 = OpLoad %TestV2 %result
                OpReturnValue %55
                OpFunctionEnd
-%op_Decrement = OpFunction %TestV2 None %11
+%op_Decrement = OpFunction %TestV2 None %15
     %value_0 = OpFunctionParameter %TestV2
          %60 = OpLabel
    %result_0 = OpVariable %_ptr_Function_TestV2 Function
@@ -108,18 +108,18 @@
          %74 = OpLoad %TestV2 %result_0
                OpReturnValue %74
                OpFunctionEnd
-%StructIncrementDecrement_PreConstructor = OpFunction %void None %15
+%StructIncrementDecrement_PreConstructor = OpFunction %void None %19
      %self_1 = OpFunctionParameter %_ptr_Function_StructIncrementDecrement
          %79 = OpLabel
                OpReturn
                OpFunctionEnd
-%StructIncrementDecrement_DefaultConstructor = OpFunction %void None %15
+%StructIncrementDecrement_DefaultConstructor = OpFunction %void None %19
      %self_2 = OpFunctionParameter %_ptr_Function_StructIncrementDecrement
          %84 = OpLabel
          %85 = OpFunctionCall %void %StructIncrementDecrement_PreConstructor %self_2
                OpReturn
                OpFunctionEnd
-       %Main = OpFunction %void None %15
+       %Main = OpFunction %void None %19
      %self_3 = OpFunctionParameter %_ptr_Function_StructIncrementDecrement
          %90 = OpLabel
          %v2 = OpVariable %_ptr_Function_TestV2 Function
@@ -164,7 +164,7 @@
                OpStore %r %127
                OpReturn
                OpFunctionEnd
-%StructIncrementDecrement_Main_EntryPoint = OpFunction %void None %17
+%StructIncrementDecrement_Main_EntryPoint = OpFunction %void None %21
         %134 = OpLabel
      %self_4 = OpVariable %_ptr_Function_StructIncrementDecrement Function
         %136 = OpFunctionCall %void %StructIncrementDecrement_DefaultConstructor %self_4

--- a/CSShadersTests/Tests/LanguageBasics/OverloadedUnaryOps/StructUnaryOp.expected.spvtxt
+++ b/CSShadersTests/Tests/LanguageBasics/OverloadedUnaryOps/StructUnaryOp.expected.spvtxt
@@ -35,20 +35,20 @@
                OpName %self_4 "self"
        %uint = OpTypeInt 32 0
       %float = OpTypeFloat 32
-     %TestV2 = OpTypeStruct %float %float
-       %void = OpTypeVoid
-%_ptr_Function_TestV2 = OpTypePointer Function %TestV2
-          %9 = OpTypeFunction %void %_ptr_Function_TestV2
-%_ptr_Function_float = OpTypePointer Function %float
-         %11 = OpTypeFunction %TestV2 %TestV2
-%StructUnaryOp = OpTypeStruct
-%_ptr_Function_StructUnaryOp = OpTypePointer Function %StructUnaryOp
-         %15 = OpTypeFunction %void %_ptr_Function_StructUnaryOp
-         %17 = OpTypeFunction %void
     %float_0 = OpConstant %float 0
      %uint_0 = OpConstant %uint 0
      %uint_1 = OpConstant %uint 1
-%TestV2_PreConstructor = OpFunction %void None %9
+     %TestV2 = OpTypeStruct %float %float
+       %void = OpTypeVoid
+%_ptr_Function_TestV2 = OpTypePointer Function %TestV2
+         %12 = OpTypeFunction %void %_ptr_Function_TestV2
+%_ptr_Function_float = OpTypePointer Function %float
+         %14 = OpTypeFunction %TestV2 %TestV2
+%StructUnaryOp = OpTypeStruct
+%_ptr_Function_StructUnaryOp = OpTypePointer Function %StructUnaryOp
+         %18 = OpTypeFunction %void %_ptr_Function_StructUnaryOp
+         %20 = OpTypeFunction %void
+%TestV2_PreConstructor = OpFunction %void None %12
        %self = OpFunctionParameter %_ptr_Function_TestV2
          %25 = OpLabel
          %26 = OpAccessChain %_ptr_Function_float %self %uint_0
@@ -57,13 +57,13 @@
                OpStore %28 %float_0
                OpReturn
                OpFunctionEnd
-%TestV2_DefaultConstructor = OpFunction %void None %9
+%TestV2_DefaultConstructor = OpFunction %void None %12
      %self_0 = OpFunctionParameter %_ptr_Function_TestV2
          %34 = OpLabel
          %35 = OpFunctionCall %void %TestV2_PreConstructor %self_0
                OpReturn
                OpFunctionEnd
-%op_UnaryNegation = OpFunction %TestV2 None %11
+%op_UnaryNegation = OpFunction %TestV2 None %14
       %value = OpFunctionParameter %TestV2
          %40 = OpLabel
      %result = OpVariable %_ptr_Function_TestV2 Function
@@ -82,18 +82,18 @@
          %54 = OpLoad %TestV2 %result
                OpReturnValue %54
                OpFunctionEnd
-%StructUnaryOp_PreConstructor = OpFunction %void None %15
+%StructUnaryOp_PreConstructor = OpFunction %void None %18
      %self_1 = OpFunctionParameter %_ptr_Function_StructUnaryOp
          %59 = OpLabel
                OpReturn
                OpFunctionEnd
-%StructUnaryOp_DefaultConstructor = OpFunction %void None %15
+%StructUnaryOp_DefaultConstructor = OpFunction %void None %18
      %self_2 = OpFunctionParameter %_ptr_Function_StructUnaryOp
          %64 = OpLabel
          %65 = OpFunctionCall %void %StructUnaryOp_PreConstructor %self_2
                OpReturn
                OpFunctionEnd
-       %Main = OpFunction %void None %15
+       %Main = OpFunction %void None %18
      %self_3 = OpFunctionParameter %_ptr_Function_StructUnaryOp
          %70 = OpLabel
    %result_0 = OpVariable %_ptr_Function_TestV2 Function
@@ -104,7 +104,7 @@
                OpStore %result_0 %75
                OpReturn
                OpFunctionEnd
-%StructUnaryOp_Main_EntryPoint = OpFunction %void None %17
+%StructUnaryOp_Main_EntryPoint = OpFunction %void None %20
          %80 = OpLabel
      %self_4 = OpVariable %_ptr_Function_StructUnaryOp Function
          %82 = OpFunctionCall %void %StructUnaryOp_DefaultConstructor %self_4

--- a/CSShadersTests/Tests/LanguageBasics/Returns/ReturnParameter.expected.spvtxt
+++ b/CSShadersTests/Tests/LanguageBasics/Returns/ReturnParameter.expected.spvtxt
@@ -27,32 +27,32 @@
                OpName %self_3 "self"
        %uint = OpTypeInt 32 0
         %int = OpTypeInt 32 1
+      %int_1 = OpConstant %int 1
 %ReturnParameter = OpTypeStruct
        %void = OpTypeVoid
 %_ptr_Function_ReturnParameter = OpTypePointer Function %ReturnParameter
-          %9 = OpTypeFunction %void %_ptr_Function_ReturnParameter
-         %11 = OpTypeFunction %int %_ptr_Function_ReturnParameter %int
+         %10 = OpTypeFunction %void %_ptr_Function_ReturnParameter
+         %12 = OpTypeFunction %int %_ptr_Function_ReturnParameter %int
 %_ptr_Function_int = OpTypePointer Function %int
-         %13 = OpTypeFunction %void
-      %int_1 = OpConstant %int 1
-%ReturnParameter_PreConstructor = OpFunction %void None %9
+         %14 = OpTypeFunction %void
+%ReturnParameter_PreConstructor = OpFunction %void None %10
        %self = OpFunctionParameter %_ptr_Function_ReturnParameter
          %19 = OpLabel
                OpReturn
                OpFunctionEnd
-%ReturnParameter_DefaultConstructor = OpFunction %void None %9
+%ReturnParameter_DefaultConstructor = OpFunction %void None %10
      %self_0 = OpFunctionParameter %_ptr_Function_ReturnParameter
          %24 = OpLabel
          %25 = OpFunctionCall %void %ReturnParameter_PreConstructor %self_0
                OpReturn
                OpFunctionEnd
-%ReturnParam = OpFunction %int None %11
+%ReturnParam = OpFunction %int None %12
      %self_1 = OpFunctionParameter %_ptr_Function_ReturnParameter
       %value = OpFunctionParameter %int
          %31 = OpLabel
                OpReturnValue %value
                OpFunctionEnd
-       %Main = OpFunction %void None %9
+       %Main = OpFunction %void None %10
      %self_2 = OpFunctionParameter %_ptr_Function_ReturnParameter
          %36 = OpLabel
       %param = OpVariable %_ptr_Function_int Function
@@ -63,7 +63,7 @@
                OpStore %i %41
                OpReturn
                OpFunctionEnd
-%ReturnParameter_Main_EntryPoint = OpFunction %void None %13
+%ReturnParameter_Main_EntryPoint = OpFunction %void None %14
          %46 = OpLabel
      %self_3 = OpVariable %_ptr_Function_ReturnParameter Function
          %48 = OpFunctionCall %void %ReturnParameter_DefaultConstructor %self_3

--- a/CSShadersTests/Tests/LanguageBasics/Returns/ReturnPrimitive.expected.spvtxt
+++ b/CSShadersTests/Tests/LanguageBasics/Returns/ReturnPrimitive.expected.spvtxt
@@ -25,31 +25,31 @@
                OpName %self_3 "self"
        %uint = OpTypeInt 32 0
         %int = OpTypeInt 32 1
+      %int_1 = OpConstant %int 1
 %ReturnPrimitive = OpTypeStruct
        %void = OpTypeVoid
 %_ptr_Function_ReturnPrimitive = OpTypePointer Function %ReturnPrimitive
-          %9 = OpTypeFunction %void %_ptr_Function_ReturnPrimitive
-         %11 = OpTypeFunction %int %_ptr_Function_ReturnPrimitive
+         %10 = OpTypeFunction %void %_ptr_Function_ReturnPrimitive
+         %12 = OpTypeFunction %int %_ptr_Function_ReturnPrimitive
 %_ptr_Function_int = OpTypePointer Function %int
-         %13 = OpTypeFunction %void
-      %int_1 = OpConstant %int 1
-%ReturnPrimitive_PreConstructor = OpFunction %void None %9
+         %14 = OpTypeFunction %void
+%ReturnPrimitive_PreConstructor = OpFunction %void None %10
        %self = OpFunctionParameter %_ptr_Function_ReturnPrimitive
          %19 = OpLabel
                OpReturn
                OpFunctionEnd
-%ReturnPrimitive_DefaultConstructor = OpFunction %void None %9
+%ReturnPrimitive_DefaultConstructor = OpFunction %void None %10
      %self_0 = OpFunctionParameter %_ptr_Function_ReturnPrimitive
          %24 = OpLabel
          %25 = OpFunctionCall %void %ReturnPrimitive_PreConstructor %self_0
                OpReturn
                OpFunctionEnd
-  %IntReturn = OpFunction %int None %11
+  %IntReturn = OpFunction %int None %12
      %self_1 = OpFunctionParameter %_ptr_Function_ReturnPrimitive
          %30 = OpLabel
                OpReturnValue %int_1
                OpFunctionEnd
-       %Main = OpFunction %void None %9
+       %Main = OpFunction %void None %10
      %self_2 = OpFunctionParameter %_ptr_Function_ReturnPrimitive
          %35 = OpLabel
           %i = OpVariable %_ptr_Function_int Function
@@ -57,7 +57,7 @@
                OpStore %i %37
                OpReturn
                OpFunctionEnd
-%ReturnPrimitive_Main_EntryPoint = OpFunction %void None %13
+%ReturnPrimitive_Main_EntryPoint = OpFunction %void None %14
          %42 = OpLabel
      %self_3 = OpVariable %_ptr_Function_ReturnPrimitive Function
          %44 = OpFunctionCall %void %ReturnPrimitive_DefaultConstructor %self_3

--- a/CSShadersTests/Tests/LanguageBasics/UnaryOps/BooleanUnaryOps.expected.spvtxt
+++ b/CSShadersTests/Tests/LanguageBasics/UnaryOps/BooleanUnaryOps.expected.spvtxt
@@ -23,25 +23,25 @@
                OpName %BooleanUnaryOps_Main_EntryPoint "BooleanUnaryOps_Main_EntryPoint"
                OpName %self_2 "self"
        %bool = OpTypeBool
+      %false = OpConstantFalse %bool
 %BooleanUnaryOps = OpTypeStruct
        %void = OpTypeVoid
 %_ptr_Function_BooleanUnaryOps = OpTypePointer Function %BooleanUnaryOps
-          %7 = OpTypeFunction %void %_ptr_Function_BooleanUnaryOps
+          %8 = OpTypeFunction %void %_ptr_Function_BooleanUnaryOps
 %_ptr_Function_bool = OpTypePointer Function %bool
-          %9 = OpTypeFunction %void
-      %false = OpConstantFalse %bool
-%BooleanUnaryOps_PreConstructor = OpFunction %void None %7
+         %10 = OpTypeFunction %void
+%BooleanUnaryOps_PreConstructor = OpFunction %void None %8
        %self = OpFunctionParameter %_ptr_Function_BooleanUnaryOps
          %15 = OpLabel
                OpReturn
                OpFunctionEnd
-%BooleanUnaryOps_DefaultConstructor = OpFunction %void None %7
+%BooleanUnaryOps_DefaultConstructor = OpFunction %void None %8
      %self_0 = OpFunctionParameter %_ptr_Function_BooleanUnaryOps
          %20 = OpLabel
          %21 = OpFunctionCall %void %BooleanUnaryOps_PreConstructor %self_0
                OpReturn
                OpFunctionEnd
-       %Main = OpFunction %void None %7
+       %Main = OpFunction %void None %8
      %self_1 = OpFunctionParameter %_ptr_Function_BooleanUnaryOps
          %26 = OpLabel
           %b = OpVariable %_ptr_Function_bool Function
@@ -52,7 +52,7 @@
                OpStore %r %31
                OpReturn
                OpFunctionEnd
-%BooleanUnaryOps_Main_EntryPoint = OpFunction %void None %9
+%BooleanUnaryOps_Main_EntryPoint = OpFunction %void None %10
          %36 = OpLabel
      %self_2 = OpVariable %_ptr_Function_BooleanUnaryOps Function
          %38 = OpFunctionCall %void %BooleanUnaryOps_DefaultConstructor %self_2

--- a/CSShadersTests/Tests/LanguageBasics/UnaryOps/FloatIncrementDecrement.expected.spvtxt
+++ b/CSShadersTests/Tests/LanguageBasics/UnaryOps/FloatIncrementDecrement.expected.spvtxt
@@ -24,26 +24,26 @@
                OpName %self_2 "self"
        %uint = OpTypeInt 32 0
       %float = OpTypeFloat 32
+    %float_0 = OpConstant %float 0
+    %float_1 = OpConstant %float 1
 %FloatIncementDecrement = OpTypeStruct
        %void = OpTypeVoid
 %_ptr_Function_FloatIncementDecrement = OpTypePointer Function %FloatIncementDecrement
-          %9 = OpTypeFunction %void %_ptr_Function_FloatIncementDecrement
+         %11 = OpTypeFunction %void %_ptr_Function_FloatIncementDecrement
 %_ptr_Function_float = OpTypePointer Function %float
-         %11 = OpTypeFunction %void
-    %float_0 = OpConstant %float 0
-    %float_1 = OpConstant %float 1
-%FloatIncementDecrement_PreConstructor = OpFunction %void None %9
+         %13 = OpTypeFunction %void
+%FloatIncementDecrement_PreConstructor = OpFunction %void None %11
        %self = OpFunctionParameter %_ptr_Function_FloatIncementDecrement
          %18 = OpLabel
                OpReturn
                OpFunctionEnd
-%FloatIncementDecrement_DefaultConstructor = OpFunction %void None %9
+%FloatIncementDecrement_DefaultConstructor = OpFunction %void None %11
      %self_0 = OpFunctionParameter %_ptr_Function_FloatIncementDecrement
          %23 = OpLabel
          %24 = OpFunctionCall %void %FloatIncementDecrement_PreConstructor %self_0
                OpReturn
                OpFunctionEnd
-       %Main = OpFunction %void None %9
+       %Main = OpFunction %void None %11
      %self_1 = OpFunctionParameter %_ptr_Function_FloatIncementDecrement
          %29 = OpLabel
           %f = OpVariable %_ptr_Function_float Function
@@ -82,7 +82,7 @@
                OpStore %r %60
                OpReturn
                OpFunctionEnd
-%FloatIncementDecrement_Main_EntryPoint = OpFunction %void None %11
+%FloatIncementDecrement_Main_EntryPoint = OpFunction %void None %13
          %67 = OpLabel
      %self_2 = OpVariable %_ptr_Function_FloatIncementDecrement Function
          %69 = OpFunctionCall %void %FloatIncementDecrement_DefaultConstructor %self_2

--- a/CSShadersTests/Tests/LanguageBasics/UnaryOps/FloatUnaryOps.expected.spvtxt
+++ b/CSShadersTests/Tests/LanguageBasics/UnaryOps/FloatUnaryOps.expected.spvtxt
@@ -24,25 +24,25 @@
                OpName %self_2 "self"
        %uint = OpTypeInt 32 0
       %float = OpTypeFloat 32
+    %float_0 = OpConstant %float 0
 %FloatUnaryOps = OpTypeStruct
        %void = OpTypeVoid
 %_ptr_Function_FloatUnaryOps = OpTypePointer Function %FloatUnaryOps
-          %9 = OpTypeFunction %void %_ptr_Function_FloatUnaryOps
+         %10 = OpTypeFunction %void %_ptr_Function_FloatUnaryOps
 %_ptr_Function_float = OpTypePointer Function %float
-         %11 = OpTypeFunction %void
-    %float_0 = OpConstant %float 0
-%FloatUnaryOps_PreConstructor = OpFunction %void None %9
+         %12 = OpTypeFunction %void
+%FloatUnaryOps_PreConstructor = OpFunction %void None %10
        %self = OpFunctionParameter %_ptr_Function_FloatUnaryOps
          %17 = OpLabel
                OpReturn
                OpFunctionEnd
-%FloatUnaryOps_DefaultConstructor = OpFunction %void None %9
+%FloatUnaryOps_DefaultConstructor = OpFunction %void None %10
      %self_0 = OpFunctionParameter %_ptr_Function_FloatUnaryOps
          %22 = OpLabel
          %23 = OpFunctionCall %void %FloatUnaryOps_PreConstructor %self_0
                OpReturn
                OpFunctionEnd
-       %Main = OpFunction %void None %9
+       %Main = OpFunction %void None %10
      %self_1 = OpFunctionParameter %_ptr_Function_FloatUnaryOps
          %28 = OpLabel
           %f = OpVariable %_ptr_Function_float Function
@@ -53,7 +53,7 @@
                OpStore %r %33
                OpReturn
                OpFunctionEnd
-%FloatUnaryOps_Main_EntryPoint = OpFunction %void None %11
+%FloatUnaryOps_Main_EntryPoint = OpFunction %void None %12
          %38 = OpLabel
      %self_2 = OpVariable %_ptr_Function_FloatUnaryOps Function
          %40 = OpFunctionCall %void %FloatUnaryOps_DefaultConstructor %self_2

--- a/CSShadersTests/Tests/LanguageBasics/UnaryOps/IntegerIncrementDecrement.expected.spvtxt
+++ b/CSShadersTests/Tests/LanguageBasics/UnaryOps/IntegerIncrementDecrement.expected.spvtxt
@@ -24,26 +24,26 @@
                OpName %self_2 "self"
        %uint = OpTypeInt 32 0
         %int = OpTypeInt 32 1
+      %int_0 = OpConstant %int 0
+      %int_1 = OpConstant %int 1
 %IntegerIncementDecrement = OpTypeStruct
        %void = OpTypeVoid
 %_ptr_Function_IntegerIncementDecrement = OpTypePointer Function %IntegerIncementDecrement
-          %9 = OpTypeFunction %void %_ptr_Function_IntegerIncementDecrement
+         %11 = OpTypeFunction %void %_ptr_Function_IntegerIncementDecrement
 %_ptr_Function_int = OpTypePointer Function %int
-         %11 = OpTypeFunction %void
-      %int_0 = OpConstant %int 0
-      %int_1 = OpConstant %int 1
-%IntegerIncementDecrement_PreConstructor = OpFunction %void None %9
+         %13 = OpTypeFunction %void
+%IntegerIncementDecrement_PreConstructor = OpFunction %void None %11
        %self = OpFunctionParameter %_ptr_Function_IntegerIncementDecrement
          %18 = OpLabel
                OpReturn
                OpFunctionEnd
-%IntegerIncementDecrement_DefaultConstructor = OpFunction %void None %9
+%IntegerIncementDecrement_DefaultConstructor = OpFunction %void None %11
      %self_0 = OpFunctionParameter %_ptr_Function_IntegerIncementDecrement
          %23 = OpLabel
          %24 = OpFunctionCall %void %IntegerIncementDecrement_PreConstructor %self_0
                OpReturn
                OpFunctionEnd
-       %Main = OpFunction %void None %9
+       %Main = OpFunction %void None %11
      %self_1 = OpFunctionParameter %_ptr_Function_IntegerIncementDecrement
          %29 = OpLabel
           %i = OpVariable %_ptr_Function_int Function
@@ -82,7 +82,7 @@
                OpStore %r %60
                OpReturn
                OpFunctionEnd
-%IntegerIncementDecrement_Main_EntryPoint = OpFunction %void None %11
+%IntegerIncementDecrement_Main_EntryPoint = OpFunction %void None %13
          %67 = OpLabel
      %self_2 = OpVariable %_ptr_Function_IntegerIncementDecrement Function
          %69 = OpFunctionCall %void %IntegerIncementDecrement_DefaultConstructor %self_2

--- a/CSShadersTests/Tests/LanguageBasics/UnaryOps/IntegerUnaryOps.expected.spvtxt
+++ b/CSShadersTests/Tests/LanguageBasics/UnaryOps/IntegerUnaryOps.expected.spvtxt
@@ -24,25 +24,25 @@
                OpName %self_2 "self"
        %uint = OpTypeInt 32 0
         %int = OpTypeInt 32 1
+      %int_0 = OpConstant %int 0
 %IntegerUnaryOps = OpTypeStruct
        %void = OpTypeVoid
 %_ptr_Function_IntegerUnaryOps = OpTypePointer Function %IntegerUnaryOps
-          %9 = OpTypeFunction %void %_ptr_Function_IntegerUnaryOps
+         %10 = OpTypeFunction %void %_ptr_Function_IntegerUnaryOps
 %_ptr_Function_int = OpTypePointer Function %int
-         %11 = OpTypeFunction %void
-      %int_0 = OpConstant %int 0
-%IntegerUnaryOps_PreConstructor = OpFunction %void None %9
+         %12 = OpTypeFunction %void
+%IntegerUnaryOps_PreConstructor = OpFunction %void None %10
        %self = OpFunctionParameter %_ptr_Function_IntegerUnaryOps
          %17 = OpLabel
                OpReturn
                OpFunctionEnd
-%IntegerUnaryOps_DefaultConstructor = OpFunction %void None %9
+%IntegerUnaryOps_DefaultConstructor = OpFunction %void None %10
      %self_0 = OpFunctionParameter %_ptr_Function_IntegerUnaryOps
          %22 = OpLabel
          %23 = OpFunctionCall %void %IntegerUnaryOps_PreConstructor %self_0
                OpReturn
                OpFunctionEnd
-       %Main = OpFunction %void None %9
+       %Main = OpFunction %void None %10
      %self_1 = OpFunctionParameter %_ptr_Function_IntegerUnaryOps
          %28 = OpLabel
           %i = OpVariable %_ptr_Function_int Function
@@ -57,7 +57,7 @@
                OpStore %r %37
                OpReturn
                OpFunctionEnd
-%IntegerUnaryOps_Main_EntryPoint = OpFunction %void None %11
+%IntegerUnaryOps_Main_EntryPoint = OpFunction %void None %12
          %42 = OpLabel
      %self_2 = OpVariable %_ptr_Function_IntegerUnaryOps Function
          %44 = OpFunctionCall %void %IntegerUnaryOps_DefaultConstructor %self_2

--- a/CSShadersTests/Tests/LanguageBasics/UnaryOps/UnsignedIntegerIncrementDecrement.expected.spvtxt
+++ b/CSShadersTests/Tests/LanguageBasics/UnaryOps/UnsignedIntegerIncrementDecrement.expected.spvtxt
@@ -24,26 +24,26 @@
                OpName %self_2 "self"
        %uint = OpTypeInt 32 0
         %int = OpTypeInt 32 1
+      %int_0 = OpConstant %int 0
+      %int_1 = OpConstant %int 1
    %Unsigned = OpTypeStruct
        %void = OpTypeVoid
 %_ptr_Function_Unsigned = OpTypePointer Function %Unsigned
-          %9 = OpTypeFunction %void %_ptr_Function_Unsigned
+         %11 = OpTypeFunction %void %_ptr_Function_Unsigned
 %_ptr_Function_int = OpTypePointer Function %int
-         %11 = OpTypeFunction %void
-      %int_0 = OpConstant %int 0
-      %int_1 = OpConstant %int 1
-%Unsigned_PreConstructor = OpFunction %void None %9
+         %13 = OpTypeFunction %void
+%Unsigned_PreConstructor = OpFunction %void None %11
        %self = OpFunctionParameter %_ptr_Function_Unsigned
          %18 = OpLabel
                OpReturn
                OpFunctionEnd
-%Unsigned_DefaultConstructor = OpFunction %void None %9
+%Unsigned_DefaultConstructor = OpFunction %void None %11
      %self_0 = OpFunctionParameter %_ptr_Function_Unsigned
          %23 = OpLabel
          %24 = OpFunctionCall %void %Unsigned_PreConstructor %self_0
                OpReturn
                OpFunctionEnd
-       %Main = OpFunction %void None %9
+       %Main = OpFunction %void None %11
      %self_1 = OpFunctionParameter %_ptr_Function_Unsigned
          %29 = OpLabel
           %u = OpVariable %_ptr_Function_int Function
@@ -82,7 +82,7 @@
                OpStore %r %60
                OpReturn
                OpFunctionEnd
-%Unsigned_Main_EntryPoint = OpFunction %void None %11
+%Unsigned_Main_EntryPoint = OpFunction %void None %13
          %67 = OpLabel
      %self_2 = OpVariable %_ptr_Function_Unsigned Function
          %69 = OpFunctionCall %void %Unsigned_DefaultConstructor %self_2

--- a/CSShadersTests/Tests/LanguageBasics/UnaryOps/UnsignedIntegerUnaryOps.expected.spvtxt
+++ b/CSShadersTests/Tests/LanguageBasics/UnaryOps/UnsignedIntegerUnaryOps.expected.spvtxt
@@ -23,25 +23,25 @@
                OpName %UnsignedIntegerUnaryOps_Main_EntryPoint "UnsignedIntegerUnaryOps_Main_EntryPoint"
                OpName %self_2 "self"
        %uint = OpTypeInt 32 0
+     %uint_0 = OpConstant %uint 0
 %UnsignedIntegerUnaryOps = OpTypeStruct
        %void = OpTypeVoid
 %_ptr_Function_UnsignedIntegerUnaryOps = OpTypePointer Function %UnsignedIntegerUnaryOps
-          %7 = OpTypeFunction %void %_ptr_Function_UnsignedIntegerUnaryOps
+          %8 = OpTypeFunction %void %_ptr_Function_UnsignedIntegerUnaryOps
 %_ptr_Function_uint = OpTypePointer Function %uint
-          %9 = OpTypeFunction %void
-     %uint_0 = OpConstant %uint 0
-%UnsignedIntegerUnaryOps_PreConstructor = OpFunction %void None %7
+         %10 = OpTypeFunction %void
+%UnsignedIntegerUnaryOps_PreConstructor = OpFunction %void None %8
        %self = OpFunctionParameter %_ptr_Function_UnsignedIntegerUnaryOps
          %15 = OpLabel
                OpReturn
                OpFunctionEnd
-%UnsignedIntegerUnaryOps_DefaultConstructor = OpFunction %void None %7
+%UnsignedIntegerUnaryOps_DefaultConstructor = OpFunction %void None %8
      %self_0 = OpFunctionParameter %_ptr_Function_UnsignedIntegerUnaryOps
          %20 = OpLabel
          %21 = OpFunctionCall %void %UnsignedIntegerUnaryOps_PreConstructor %self_0
                OpReturn
                OpFunctionEnd
-       %Main = OpFunction %void None %7
+       %Main = OpFunction %void None %8
      %self_1 = OpFunctionParameter %_ptr_Function_UnsignedIntegerUnaryOps
          %26 = OpLabel
           %u = OpVariable %_ptr_Function_uint Function
@@ -52,7 +52,7 @@
                OpStore %r %31
                OpReturn
                OpFunctionEnd
-%UnsignedIntegerUnaryOps_Main_EntryPoint = OpFunction %void None %9
+%UnsignedIntegerUnaryOps_Main_EntryPoint = OpFunction %void None %10
          %36 = OpLabel
      %self_2 = OpVariable %_ptr_Function_UnsignedIntegerUnaryOps Function
          %38 = OpFunctionCall %void %UnsignedIntegerUnaryOps_DefaultConstructor %self_2

--- a/CSShadersTests/Tests/PrimitiveIntrinsics/Float/Float16PrimitiveDeclaration.expected.spvtxt
+++ b/CSShadersTests/Tests/PrimitiveIntrinsics/Float/Float16PrimitiveDeclaration.expected.spvtxt
@@ -25,32 +25,32 @@
                OpName %self_2 "self"
        %uint = OpTypeInt 32 0
     %Float16 = OpTypeFloat 16
+%Float16_0x0p_0 = OpConstant %Float16 0x0p+0
 %Float16PrimitiveDeclarationTest = OpTypeStruct
        %void = OpTypeVoid
 %_ptr_Function_Float16PrimitiveDeclarationTest = OpTypePointer Function %Float16PrimitiveDeclarationTest
-          %9 = OpTypeFunction %void %_ptr_Function_Float16PrimitiveDeclarationTest
+         %10 = OpTypeFunction %void %_ptr_Function_Float16PrimitiveDeclarationTest
 %_ptr_Function_Float16 = OpTypePointer Function %Float16
-         %11 = OpTypeFunction %void
-%Float16_0x0p_0 = OpConstant %Float16 0x0p+0
-%Float16PrimitiveDeclarationTest_PreConstructor = OpFunction %void None %9
+         %12 = OpTypeFunction %void
+%Float16PrimitiveDeclarationTest_PreConstructor = OpFunction %void None %10
        %self = OpFunctionParameter %_ptr_Function_Float16PrimitiveDeclarationTest
          %17 = OpLabel
                OpReturn
                OpFunctionEnd
-%Float16PrimitiveDeclarationTest_DefaultConstructor = OpFunction %void None %9
+%Float16PrimitiveDeclarationTest_DefaultConstructor = OpFunction %void None %10
      %self_0 = OpFunctionParameter %_ptr_Function_Float16PrimitiveDeclarationTest
          %22 = OpLabel
          %23 = OpFunctionCall %void %Float16PrimitiveDeclarationTest_PreConstructor %self_0
                OpReturn
                OpFunctionEnd
-       %Main = OpFunction %void None %9
+       %Main = OpFunction %void None %10
      %self_1 = OpFunctionParameter %_ptr_Function_Float16PrimitiveDeclarationTest
          %28 = OpLabel
  %float16Val = OpVariable %_ptr_Function_Float16 Function
                OpStore %float16Val %Float16_0x0p_0
                OpReturn
                OpFunctionEnd
-%Float16PrimitiveDeclarationTest_Main_EntryPoint = OpFunction %void None %11
+%Float16PrimitiveDeclarationTest_Main_EntryPoint = OpFunction %void None %12
          %34 = OpLabel
      %self_2 = OpVariable %_ptr_Function_Float16PrimitiveDeclarationTest Function
          %36 = OpFunctionCall %void %Float16PrimitiveDeclarationTest_DefaultConstructor %self_2

--- a/CSShadersTests/Tests/PrimitiveIntrinsics/Float/Float32PrimitiveDeclaration.expected.spvtxt
+++ b/CSShadersTests/Tests/PrimitiveIntrinsics/Float/Float32PrimitiveDeclaration.expected.spvtxt
@@ -24,32 +24,32 @@
                OpName %self_2 "self"
        %uint = OpTypeInt 32 0
     %Float32 = OpTypeFloat 32
+  %Float32_0 = OpConstant %Float32 0
 %Float32PrimitiveDeclarationTest = OpTypeStruct
        %void = OpTypeVoid
 %_ptr_Function_Float32PrimitiveDeclarationTest = OpTypePointer Function %Float32PrimitiveDeclarationTest
-          %9 = OpTypeFunction %void %_ptr_Function_Float32PrimitiveDeclarationTest
+         %10 = OpTypeFunction %void %_ptr_Function_Float32PrimitiveDeclarationTest
 %_ptr_Function_Float32 = OpTypePointer Function %Float32
-         %11 = OpTypeFunction %void
-  %Float32_0 = OpConstant %Float32 0
-%Float32PrimitiveDeclarationTest_PreConstructor = OpFunction %void None %9
+         %12 = OpTypeFunction %void
+%Float32PrimitiveDeclarationTest_PreConstructor = OpFunction %void None %10
        %self = OpFunctionParameter %_ptr_Function_Float32PrimitiveDeclarationTest
          %17 = OpLabel
                OpReturn
                OpFunctionEnd
-%Float32PrimitiveDeclarationTest_DefaultConstructor = OpFunction %void None %9
+%Float32PrimitiveDeclarationTest_DefaultConstructor = OpFunction %void None %10
      %self_0 = OpFunctionParameter %_ptr_Function_Float32PrimitiveDeclarationTest
          %22 = OpLabel
          %23 = OpFunctionCall %void %Float32PrimitiveDeclarationTest_PreConstructor %self_0
                OpReturn
                OpFunctionEnd
-       %Main = OpFunction %void None %9
+       %Main = OpFunction %void None %10
      %self_1 = OpFunctionParameter %_ptr_Function_Float32PrimitiveDeclarationTest
          %28 = OpLabel
  %float32Val = OpVariable %_ptr_Function_Float32 Function
                OpStore %float32Val %Float32_0
                OpReturn
                OpFunctionEnd
-%Float32PrimitiveDeclarationTest_Main_EntryPoint = OpFunction %void None %11
+%Float32PrimitiveDeclarationTest_Main_EntryPoint = OpFunction %void None %12
          %34 = OpLabel
      %self_2 = OpVariable %_ptr_Function_Float32PrimitiveDeclarationTest Function
          %36 = OpFunctionCall %void %Float32PrimitiveDeclarationTest_DefaultConstructor %self_2

--- a/CSShadersTests/Tests/PrimitiveIntrinsics/Image/ImagePrimitiveDeclaration.expected.spvtxt
+++ b/CSShadersTests/Tests/PrimitiveIntrinsics/Image/ImagePrimitiveDeclaration.expected.spvtxt
@@ -10,9 +10,13 @@
                OpExecutionMode %ImagePrimitiveDeclarationTest_EntryPoint OriginUpperLeft
                OpSource Unknown 100
                OpName %SimpleFloatImage2d "SimpleFloatImage2d"
+               OpName %SimpleFloatImage2d_0 "SimpleFloatImage2d"
                OpName %SimpleFloatImage3d "SimpleFloatImage3d"
+               OpName %SimpleFloatImage3d_0 "SimpleFloatImage3d"
                OpName %SimpleIntImage2d_Rgba8 "SimpleIntImage2d_Rgba8"
+               OpName %SimpleIntImage2d_Rgba8_0 "SimpleIntImage2d_Rgba8"
                OpName %ComplexIntImage2d_Rgba8 "ComplexIntImage2d_Rgba8"
+               OpName %ComplexIntImage2d_Rgba8_0 "ComplexIntImage2d_Rgba8"
                OpName %ImagePrimitiveDeclarationTest "ImagePrimitiveDeclarationTest"
                OpName %ImagePrimitiveDeclarationTest_PreConstructor "ImagePrimitiveDeclarationTest_PreConstructor"
                OpName %self "self"
@@ -20,44 +24,40 @@
                OpName %self_0 "self"
                OpName %ImagePrimitiveDeclarationTest_EntryPoint "ImagePrimitiveDeclarationTest_EntryPoint"
                OpName %self_1 "self"
-               OpName %SimpleFloatImage2d_0 "SimpleFloatImage2d"
-               OpName %SimpleFloatImage3d_0 "SimpleFloatImage3d"
-               OpName %SimpleIntImage2d_Rgba8_0 "SimpleIntImage2d_Rgba8"
-               OpName %ComplexIntImage2d_Rgba8_0 "ComplexIntImage2d_Rgba8"
                OpName %ImagePrimitiveDeclarationTest_EntryPoint "ImagePrimitiveDeclarationTest_EntryPoint"
                OpName %self_1 "self"
        %uint = OpTypeInt 32 0
       %float = OpTypeFloat 32
 %SimpleFloatImage2d = OpTypeImage %float 2D 0 0 0 1 Unknown
 %_ptr_UniformConstant_SimpleFloatImage2d = OpTypePointer UniformConstant %SimpleFloatImage2d
+%SimpleFloatImage2d_0 = OpVariable %_ptr_UniformConstant_SimpleFloatImage2d UniformConstant
 %SimpleFloatImage3d = OpTypeImage %float 3D 0 0 0 1 Unknown
 %_ptr_UniformConstant_SimpleFloatImage3d = OpTypePointer UniformConstant %SimpleFloatImage3d
+%SimpleFloatImage3d_0 = OpVariable %_ptr_UniformConstant_SimpleFloatImage3d UniformConstant
         %int = OpTypeInt 32 1
 %SimpleIntImage2d_Rgba8 = OpTypeImage %int 2D 0 0 0 1 Rgba8
 %_ptr_UniformConstant_SimpleIntImage2d_Rgba8 = OpTypePointer UniformConstant %SimpleIntImage2d_Rgba8
+%SimpleIntImage2d_Rgba8_0 = OpVariable %_ptr_UniformConstant_SimpleIntImage2d_Rgba8 UniformConstant
 %ComplexIntImage2d_Rgba8 = OpTypeImage %int 2D 1 0 0 1 Rgba8
 %_ptr_UniformConstant_ComplexIntImage2d_Rgba8 = OpTypePointer UniformConstant %ComplexIntImage2d_Rgba8
+%ComplexIntImage2d_Rgba8_0 = OpVariable %_ptr_UniformConstant_ComplexIntImage2d_Rgba8 UniformConstant
 %ImagePrimitiveDeclarationTest = OpTypeStruct
        %void = OpTypeVoid
 %_ptr_Function_ImagePrimitiveDeclarationTest = OpTypePointer Function %ImagePrimitiveDeclarationTest
-         %23 = OpTypeFunction %void %_ptr_Function_ImagePrimitiveDeclarationTest
-         %25 = OpTypeFunction %void
-%SimpleFloatImage2d_0 = OpVariable %_ptr_UniformConstant_SimpleFloatImage2d UniformConstant
-%SimpleFloatImage3d_0 = OpVariable %_ptr_UniformConstant_SimpleFloatImage3d UniformConstant
-%SimpleIntImage2d_Rgba8_0 = OpVariable %_ptr_UniformConstant_SimpleIntImage2d_Rgba8 UniformConstant
-%ComplexIntImage2d_Rgba8_0 = OpVariable %_ptr_UniformConstant_ComplexIntImage2d_Rgba8 UniformConstant
-%ImagePrimitiveDeclarationTest_PreConstructor = OpFunction %void None %23
+         %27 = OpTypeFunction %void %_ptr_Function_ImagePrimitiveDeclarationTest
+         %29 = OpTypeFunction %void
+%ImagePrimitiveDeclarationTest_PreConstructor = OpFunction %void None %27
        %self = OpFunctionParameter %_ptr_Function_ImagePrimitiveDeclarationTest
          %34 = OpLabel
                OpReturn
                OpFunctionEnd
-%ImagePrimitiveDeclarationTest_DefaultConstructor = OpFunction %void None %23
+%ImagePrimitiveDeclarationTest_DefaultConstructor = OpFunction %void None %27
      %self_0 = OpFunctionParameter %_ptr_Function_ImagePrimitiveDeclarationTest
          %39 = OpLabel
          %40 = OpFunctionCall %void %ImagePrimitiveDeclarationTest_PreConstructor %self_0
                OpReturn
                OpFunctionEnd
-%ImagePrimitiveDeclarationTest_EntryPoint = OpFunction %void None %25
+%ImagePrimitiveDeclarationTest_EntryPoint = OpFunction %void None %29
          %44 = OpLabel
      %self_1 = OpVariable %_ptr_Function_ImagePrimitiveDeclarationTest Function
          %46 = OpFunctionCall %void %ImagePrimitiveDeclarationTest_DefaultConstructor %self_1

--- a/CSShadersTests/Tests/PrimitiveIntrinsics/Integer/Int16PrimitiveDeclaration.expected.spvtxt
+++ b/CSShadersTests/Tests/PrimitiveIntrinsics/Integer/Int16PrimitiveDeclaration.expected.spvtxt
@@ -25,32 +25,32 @@
                OpName %self_2 "self"
        %uint = OpTypeInt 32 0
       %Int16 = OpTypeInt 16 1
+    %Int16_0 = OpConstant %Int16 0
 %Int16PrimitiveDeclarationTest = OpTypeStruct
        %void = OpTypeVoid
 %_ptr_Function_Int16PrimitiveDeclarationTest = OpTypePointer Function %Int16PrimitiveDeclarationTest
-          %9 = OpTypeFunction %void %_ptr_Function_Int16PrimitiveDeclarationTest
+         %10 = OpTypeFunction %void %_ptr_Function_Int16PrimitiveDeclarationTest
 %_ptr_Function_Int16 = OpTypePointer Function %Int16
-         %11 = OpTypeFunction %void
-    %Int16_0 = OpConstant %Int16 0
-%Int16PrimitiveDeclarationTest_PreConstructor = OpFunction %void None %9
+         %12 = OpTypeFunction %void
+%Int16PrimitiveDeclarationTest_PreConstructor = OpFunction %void None %10
        %self = OpFunctionParameter %_ptr_Function_Int16PrimitiveDeclarationTest
          %17 = OpLabel
                OpReturn
                OpFunctionEnd
-%Int16PrimitiveDeclarationTest_DefaultConstructor = OpFunction %void None %9
+%Int16PrimitiveDeclarationTest_DefaultConstructor = OpFunction %void None %10
      %self_0 = OpFunctionParameter %_ptr_Function_Int16PrimitiveDeclarationTest
          %22 = OpLabel
          %23 = OpFunctionCall %void %Int16PrimitiveDeclarationTest_PreConstructor %self_0
                OpReturn
                OpFunctionEnd
-       %Main = OpFunction %void None %9
+       %Main = OpFunction %void None %10
      %self_1 = OpFunctionParameter %_ptr_Function_Int16PrimitiveDeclarationTest
          %28 = OpLabel
    %int16Val = OpVariable %_ptr_Function_Int16 Function
                OpStore %int16Val %Int16_0
                OpReturn
                OpFunctionEnd
-%Int16PrimitiveDeclarationTest_Main_EntryPoint = OpFunction %void None %11
+%Int16PrimitiveDeclarationTest_Main_EntryPoint = OpFunction %void None %12
          %34 = OpLabel
      %self_2 = OpVariable %_ptr_Function_Int16PrimitiveDeclarationTest Function
          %36 = OpFunctionCall %void %Int16PrimitiveDeclarationTest_DefaultConstructor %self_2

--- a/CSShadersTests/Tests/PrimitiveIntrinsics/Integer/Int32PrimitiveDeclaration.expected.spvtxt
+++ b/CSShadersTests/Tests/PrimitiveIntrinsics/Integer/Int32PrimitiveDeclaration.expected.spvtxt
@@ -24,32 +24,32 @@
                OpName %self_2 "self"
        %uint = OpTypeInt 32 0
       %Int32 = OpTypeInt 32 1
+    %Int32_0 = OpConstant %Int32 0
 %Int32PrimitiveDeclarationTest = OpTypeStruct
        %void = OpTypeVoid
 %_ptr_Function_Int32PrimitiveDeclarationTest = OpTypePointer Function %Int32PrimitiveDeclarationTest
-          %9 = OpTypeFunction %void %_ptr_Function_Int32PrimitiveDeclarationTest
+         %10 = OpTypeFunction %void %_ptr_Function_Int32PrimitiveDeclarationTest
 %_ptr_Function_Int32 = OpTypePointer Function %Int32
-         %11 = OpTypeFunction %void
-    %Int32_0 = OpConstant %Int32 0
-%Int32PrimitiveDeclarationTest_PreConstructor = OpFunction %void None %9
+         %12 = OpTypeFunction %void
+%Int32PrimitiveDeclarationTest_PreConstructor = OpFunction %void None %10
        %self = OpFunctionParameter %_ptr_Function_Int32PrimitiveDeclarationTest
          %17 = OpLabel
                OpReturn
                OpFunctionEnd
-%Int32PrimitiveDeclarationTest_DefaultConstructor = OpFunction %void None %9
+%Int32PrimitiveDeclarationTest_DefaultConstructor = OpFunction %void None %10
      %self_0 = OpFunctionParameter %_ptr_Function_Int32PrimitiveDeclarationTest
          %22 = OpLabel
          %23 = OpFunctionCall %void %Int32PrimitiveDeclarationTest_PreConstructor %self_0
                OpReturn
                OpFunctionEnd
-       %Main = OpFunction %void None %9
+       %Main = OpFunction %void None %10
      %self_1 = OpFunctionParameter %_ptr_Function_Int32PrimitiveDeclarationTest
          %28 = OpLabel
    %int32Val = OpVariable %_ptr_Function_Int32 Function
                OpStore %int32Val %Int32_0
                OpReturn
                OpFunctionEnd
-%Int32PrimitiveDeclarationTest_Main_EntryPoint = OpFunction %void None %11
+%Int32PrimitiveDeclarationTest_Main_EntryPoint = OpFunction %void None %12
          %34 = OpLabel
      %self_2 = OpVariable %_ptr_Function_Int32PrimitiveDeclarationTest Function
          %36 = OpFunctionCall %void %Int32PrimitiveDeclarationTest_DefaultConstructor %self_2

--- a/CSShadersTests/Tests/PrimitiveIntrinsics/Integer/Int8PrimitiveDeclaration.expected.spvtxt
+++ b/CSShadersTests/Tests/PrimitiveIntrinsics/Integer/Int8PrimitiveDeclaration.expected.spvtxt
@@ -25,32 +25,32 @@
                OpName %self_2 "self"
        %uint = OpTypeInt 32 0
        %Int8 = OpTypeInt 8 1
+     %Int8_0 = OpConstant %Int8 0
 %Int8PrimitiveDeclarationTest = OpTypeStruct
        %void = OpTypeVoid
 %_ptr_Function_Int8PrimitiveDeclarationTest = OpTypePointer Function %Int8PrimitiveDeclarationTest
-          %9 = OpTypeFunction %void %_ptr_Function_Int8PrimitiveDeclarationTest
+         %10 = OpTypeFunction %void %_ptr_Function_Int8PrimitiveDeclarationTest
 %_ptr_Function_Int8 = OpTypePointer Function %Int8
-         %11 = OpTypeFunction %void
-     %Int8_0 = OpConstant %Int8 0
-%Int8PrimitiveDeclarationTest_PreConstructor = OpFunction %void None %9
+         %12 = OpTypeFunction %void
+%Int8PrimitiveDeclarationTest_PreConstructor = OpFunction %void None %10
        %self = OpFunctionParameter %_ptr_Function_Int8PrimitiveDeclarationTest
          %17 = OpLabel
                OpReturn
                OpFunctionEnd
-%Int8PrimitiveDeclarationTest_DefaultConstructor = OpFunction %void None %9
+%Int8PrimitiveDeclarationTest_DefaultConstructor = OpFunction %void None %10
      %self_0 = OpFunctionParameter %_ptr_Function_Int8PrimitiveDeclarationTest
          %22 = OpLabel
          %23 = OpFunctionCall %void %Int8PrimitiveDeclarationTest_PreConstructor %self_0
                OpReturn
                OpFunctionEnd
-       %Main = OpFunction %void None %9
+       %Main = OpFunction %void None %10
      %self_1 = OpFunctionParameter %_ptr_Function_Int8PrimitiveDeclarationTest
          %28 = OpLabel
     %int8Val = OpVariable %_ptr_Function_Int8 Function
                OpStore %int8Val %Int8_0
                OpReturn
                OpFunctionEnd
-%Int8PrimitiveDeclarationTest_Main_EntryPoint = OpFunction %void None %11
+%Int8PrimitiveDeclarationTest_Main_EntryPoint = OpFunction %void None %12
          %34 = OpLabel
      %self_2 = OpVariable %_ptr_Function_Int8PrimitiveDeclarationTest Function
          %36 = OpFunctionCall %void %Int8PrimitiveDeclarationTest_DefaultConstructor %self_2

--- a/CSShadersTests/Tests/PrimitiveIntrinsics/Integer/UInt16PrimitiveDeclaration.expected.spvtxt
+++ b/CSShadersTests/Tests/PrimitiveIntrinsics/Integer/UInt16PrimitiveDeclaration.expected.spvtxt
@@ -25,32 +25,32 @@
                OpName %self_2 "self"
        %uint = OpTypeInt 32 0
      %UInt16 = OpTypeInt 16 0
+   %UInt16_0 = OpConstant %UInt16 0
 %UInt16PrimitiveDeclarationTest = OpTypeStruct
        %void = OpTypeVoid
 %_ptr_Function_UInt16PrimitiveDeclarationTest = OpTypePointer Function %UInt16PrimitiveDeclarationTest
-          %9 = OpTypeFunction %void %_ptr_Function_UInt16PrimitiveDeclarationTest
+         %10 = OpTypeFunction %void %_ptr_Function_UInt16PrimitiveDeclarationTest
 %_ptr_Function_UInt16 = OpTypePointer Function %UInt16
-         %11 = OpTypeFunction %void
-   %UInt16_0 = OpConstant %UInt16 0
-%UInt16PrimitiveDeclarationTest_PreConstructor = OpFunction %void None %9
+         %12 = OpTypeFunction %void
+%UInt16PrimitiveDeclarationTest_PreConstructor = OpFunction %void None %10
        %self = OpFunctionParameter %_ptr_Function_UInt16PrimitiveDeclarationTest
          %17 = OpLabel
                OpReturn
                OpFunctionEnd
-%UInt16PrimitiveDeclarationTest_DefaultConstructor = OpFunction %void None %9
+%UInt16PrimitiveDeclarationTest_DefaultConstructor = OpFunction %void None %10
      %self_0 = OpFunctionParameter %_ptr_Function_UInt16PrimitiveDeclarationTest
          %22 = OpLabel
          %23 = OpFunctionCall %void %UInt16PrimitiveDeclarationTest_PreConstructor %self_0
                OpReturn
                OpFunctionEnd
-       %Main = OpFunction %void None %9
+       %Main = OpFunction %void None %10
      %self_1 = OpFunctionParameter %_ptr_Function_UInt16PrimitiveDeclarationTest
          %28 = OpLabel
   %uint16Val = OpVariable %_ptr_Function_UInt16 Function
                OpStore %uint16Val %UInt16_0
                OpReturn
                OpFunctionEnd
-%UInt16PrimitiveDeclarationTest_Main_EntryPoint = OpFunction %void None %11
+%UInt16PrimitiveDeclarationTest_Main_EntryPoint = OpFunction %void None %12
          %34 = OpLabel
      %self_2 = OpVariable %_ptr_Function_UInt16PrimitiveDeclarationTest Function
          %36 = OpFunctionCall %void %UInt16PrimitiveDeclarationTest_DefaultConstructor %self_2

--- a/CSShadersTests/Tests/PrimitiveIntrinsics/Matrix/MatrixPrimitiveCompositeConstructors.expected.spvtxt
+++ b/CSShadersTests/Tests/PrimitiveIntrinsics/Matrix/MatrixPrimitiveCompositeConstructors.expected.spvtxt
@@ -27,28 +27,28 @@
                OpName %self_2 "self"
        %uint = OpTypeInt 32 0
       %float = OpTypeFloat 32
+    %float_0 = OpConstant %float 0
 %TestVectorPrimitive = OpTypeVector %float 2
 %TestMatrixPrimitive = OpTypeMatrix %TestVectorPrimitive 2
 %VectorPrimitiveCompositeConstructorsTest = OpTypeStruct
        %void = OpTypeVoid
 %_ptr_Function_VectorPrimitiveCompositeConstructorsTest = OpTypePointer Function %VectorPrimitiveCompositeConstructorsTest
-         %13 = OpTypeFunction %void %_ptr_Function_VectorPrimitiveCompositeConstructorsTest
+         %14 = OpTypeFunction %void %_ptr_Function_VectorPrimitiveCompositeConstructorsTest
 %_ptr_Function_TestVectorPrimitive = OpTypePointer Function %TestVectorPrimitive
 %_ptr_Function_TestMatrixPrimitive = OpTypePointer Function %TestMatrixPrimitive
-         %15 = OpTypeFunction %void
-    %float_0 = OpConstant %float 0
-%VectorPrimitiveCompositeConstructorsTest_PreConstructor = OpFunction %void None %13
+         %16 = OpTypeFunction %void
+%VectorPrimitiveCompositeConstructorsTest_PreConstructor = OpFunction %void None %14
        %self = OpFunctionParameter %_ptr_Function_VectorPrimitiveCompositeConstructorsTest
          %21 = OpLabel
                OpReturn
                OpFunctionEnd
-%VectorPrimitiveCompositeConstructorsTest_DefaultConstructor = OpFunction %void None %13
+%VectorPrimitiveCompositeConstructorsTest_DefaultConstructor = OpFunction %void None %14
      %self_0 = OpFunctionParameter %_ptr_Function_VectorPrimitiveCompositeConstructorsTest
          %26 = OpLabel
          %27 = OpFunctionCall %void %VectorPrimitiveCompositeConstructorsTest_PreConstructor %self_0
                OpReturn
                OpFunctionEnd
-       %Main = OpFunction %void None %13
+       %Main = OpFunction %void None %14
      %self_1 = OpFunctionParameter %_ptr_Function_VectorPrimitiveCompositeConstructorsTest
          %32 = OpLabel
     %vector0 = OpVariable %_ptr_Function_TestVectorPrimitive Function
@@ -64,7 +64,7 @@
                OpStore %matrix0 %42
                OpReturn
                OpFunctionEnd
-%VectorPrimitiveCompositeConstructorsTest_Main_EntryPoint = OpFunction %void None %15
+%VectorPrimitiveCompositeConstructorsTest_Main_EntryPoint = OpFunction %void None %16
          %47 = OpLabel
      %self_2 = OpVariable %_ptr_Function_VectorPrimitiveCompositeConstructorsTest Function
          %49 = OpFunctionCall %void %VectorPrimitiveCompositeConstructorsTest_DefaultConstructor %self_2

--- a/CSShadersTests/Tests/PrimitiveIntrinsics/Matrix/MatrixPrimitiveDeclaration.expected.spvtxt
+++ b/CSShadersTests/Tests/PrimitiveIntrinsics/Matrix/MatrixPrimitiveDeclaration.expected.spvtxt
@@ -25,27 +25,27 @@
                OpName %self_2 "self"
        %uint = OpTypeInt 32 0
       %float = OpTypeFloat 32
+    %float_0 = OpConstant %float 0
 %TestVectorPrimitive = OpTypeVector %float 2
 %TestMatrixPrimitive = OpTypeMatrix %TestVectorPrimitive 2
 %MatrixPrimitiveDeclarationTest = OpTypeStruct
        %void = OpTypeVoid
 %_ptr_Function_MatrixPrimitiveDeclarationTest = OpTypePointer Function %MatrixPrimitiveDeclarationTest
-         %13 = OpTypeFunction %void %_ptr_Function_MatrixPrimitiveDeclarationTest
+         %14 = OpTypeFunction %void %_ptr_Function_MatrixPrimitiveDeclarationTest
 %_ptr_Function_TestMatrixPrimitive = OpTypePointer Function %TestMatrixPrimitive
-         %15 = OpTypeFunction %void
-    %float_0 = OpConstant %float 0
-%MatrixPrimitiveDeclarationTest_PreConstructor = OpFunction %void None %13
+         %16 = OpTypeFunction %void
+%MatrixPrimitiveDeclarationTest_PreConstructor = OpFunction %void None %14
        %self = OpFunctionParameter %_ptr_Function_MatrixPrimitiveDeclarationTest
          %21 = OpLabel
                OpReturn
                OpFunctionEnd
-%MatrixPrimitiveDeclarationTest_DefaultConstructor = OpFunction %void None %13
+%MatrixPrimitiveDeclarationTest_DefaultConstructor = OpFunction %void None %14
      %self_0 = OpFunctionParameter %_ptr_Function_MatrixPrimitiveDeclarationTest
          %26 = OpLabel
          %27 = OpFunctionCall %void %MatrixPrimitiveDeclarationTest_PreConstructor %self_0
                OpReturn
                OpFunctionEnd
-       %Main = OpFunction %void None %13
+       %Main = OpFunction %void None %14
      %self_1 = OpFunctionParameter %_ptr_Function_MatrixPrimitiveDeclarationTest
          %32 = OpLabel
     %matrix0 = OpVariable %_ptr_Function_TestMatrixPrimitive Function
@@ -54,7 +54,7 @@
                OpStore %matrix0 %35
                OpReturn
                OpFunctionEnd
-%MatrixPrimitiveDeclarationTest_Main_EntryPoint = OpFunction %void None %15
+%MatrixPrimitiveDeclarationTest_Main_EntryPoint = OpFunction %void None %16
          %40 = OpLabel
      %self_2 = OpVariable %_ptr_Function_MatrixPrimitiveDeclarationTest Function
          %42 = OpFunctionCall %void %MatrixPrimitiveDeclarationTest_DefaultConstructor %self_2

--- a/CSShadersTests/Tests/PrimitiveIntrinsics/Matrix/MatrixPrimitiveFieldSwizzles.expected.spvtxt
+++ b/CSShadersTests/Tests/PrimitiveIntrinsics/Matrix/MatrixPrimitiveFieldSwizzles.expected.spvtxt
@@ -25,29 +25,29 @@
                OpName %self_2 "self"
        %uint = OpTypeInt 32 0
       %float = OpTypeFloat 32
+    %float_0 = OpConstant %float 0
+     %uint_1 = OpConstant %uint 1
 %TestVectorPrimitive = OpTypeVector %float 2
 %TestMatrixPrimitive = OpTypeMatrix %TestVectorPrimitive 2
 %MatrixPrimitiveFieldSwizzlesTest = OpTypeStruct
        %void = OpTypeVoid
 %_ptr_Function_MatrixPrimitiveFieldSwizzlesTest = OpTypePointer Function %MatrixPrimitiveFieldSwizzlesTest
-         %13 = OpTypeFunction %void %_ptr_Function_MatrixPrimitiveFieldSwizzlesTest
+         %15 = OpTypeFunction %void %_ptr_Function_MatrixPrimitiveFieldSwizzlesTest
 %_ptr_Function_TestMatrixPrimitive = OpTypePointer Function %TestMatrixPrimitive
 %_ptr_Function_TestVectorPrimitive = OpTypePointer Function %TestVectorPrimitive
-         %15 = OpTypeFunction %void
-    %float_0 = OpConstant %float 0
-     %uint_1 = OpConstant %uint 1
-%MatrixPrimitiveFieldSwizzlesTest_PreConstructor = OpFunction %void None %13
+         %17 = OpTypeFunction %void
+%MatrixPrimitiveFieldSwizzlesTest_PreConstructor = OpFunction %void None %15
        %self = OpFunctionParameter %_ptr_Function_MatrixPrimitiveFieldSwizzlesTest
          %22 = OpLabel
                OpReturn
                OpFunctionEnd
-%MatrixPrimitiveFieldSwizzlesTest_DefaultConstructor = OpFunction %void None %13
+%MatrixPrimitiveFieldSwizzlesTest_DefaultConstructor = OpFunction %void None %15
      %self_0 = OpFunctionParameter %_ptr_Function_MatrixPrimitiveFieldSwizzlesTest
          %27 = OpLabel
          %28 = OpFunctionCall %void %MatrixPrimitiveFieldSwizzlesTest_PreConstructor %self_0
                OpReturn
                OpFunctionEnd
-       %Main = OpFunction %void None %13
+       %Main = OpFunction %void None %15
      %self_1 = OpFunctionParameter %_ptr_Function_MatrixPrimitiveFieldSwizzlesTest
          %33 = OpLabel
     %matrix0 = OpVariable %_ptr_Function_TestMatrixPrimitive Function
@@ -61,7 +61,7 @@
                OpStore %41 %39
                OpReturn
                OpFunctionEnd
-%MatrixPrimitiveFieldSwizzlesTest_Main_EntryPoint = OpFunction %void None %15
+%MatrixPrimitiveFieldSwizzlesTest_Main_EntryPoint = OpFunction %void None %17
          %46 = OpLabel
      %self_2 = OpVariable %_ptr_Function_MatrixPrimitiveFieldSwizzlesTest Function
          %48 = OpFunctionCall %void %MatrixPrimitiveFieldSwizzlesTest_DefaultConstructor %self_2

--- a/CSShadersTests/Tests/PrimitiveIntrinsics/Matrix/MatrixPrimitiveImplicitExplicitThisTests.expected.spvtxt
+++ b/CSShadersTests/Tests/PrimitiveIntrinsics/Matrix/MatrixPrimitiveImplicitExplicitThisTests.expected.spvtxt
@@ -31,43 +31,43 @@
                OpName %self_4 "self"
        %uint = OpTypeInt 32 0
       %float = OpTypeFloat 32
+    %float_0 = OpConstant %float 0
 %TestVectorPrimitive = OpTypeVector %float 2
 %TestMatrixPrimitive = OpTypeMatrix %TestVectorPrimitive 2
 %_ptr_Function_TestMatrixPrimitive = OpTypePointer Function %TestMatrixPrimitive
-          %9 = OpTypeFunction %TestVectorPrimitive %_ptr_Function_TestMatrixPrimitive
+         %10 = OpTypeFunction %TestVectorPrimitive %_ptr_Function_TestMatrixPrimitive
 %MatrixPrimitiveImplicitExplicitThisTests = OpTypeStruct
        %void = OpTypeVoid
 %_ptr_Function_MatrixPrimitiveImplicitExplicitThisTests = OpTypePointer Function %MatrixPrimitiveImplicitExplicitThisTests
-         %15 = OpTypeFunction %void %_ptr_Function_MatrixPrimitiveImplicitExplicitThisTests
+         %16 = OpTypeFunction %void %_ptr_Function_MatrixPrimitiveImplicitExplicitThisTests
 %_ptr_Function_TestVectorPrimitive = OpTypePointer Function %TestVectorPrimitive
-         %17 = OpTypeFunction %void
-    %float_0 = OpConstant %float 0
-%FieldThisExplicit = OpFunction %TestVectorPrimitive None %9
+         %18 = OpTypeFunction %void
+%FieldThisExplicit = OpFunction %TestVectorPrimitive None %10
        %self = OpFunctionParameter %_ptr_Function_TestMatrixPrimitive
          %23 = OpLabel
          %24 = OpLoad %TestMatrixPrimitive %self
          %25 = OpCompositeExtract %TestVectorPrimitive %24 0
                OpReturnValue %25
                OpFunctionEnd
-%FieldThisImplicit = OpFunction %TestVectorPrimitive None %9
+%FieldThisImplicit = OpFunction %TestVectorPrimitive None %10
      %self_0 = OpFunctionParameter %_ptr_Function_TestMatrixPrimitive
          %30 = OpLabel
          %31 = OpLoad %TestMatrixPrimitive %self_0
          %32 = OpCompositeExtract %TestVectorPrimitive %31 0
                OpReturnValue %32
                OpFunctionEnd
-%MatrixPrimitiveImplicitExplicitThisTests_PreConstructor = OpFunction %void None %15
+%MatrixPrimitiveImplicitExplicitThisTests_PreConstructor = OpFunction %void None %16
      %self_1 = OpFunctionParameter %_ptr_Function_MatrixPrimitiveImplicitExplicitThisTests
          %37 = OpLabel
                OpReturn
                OpFunctionEnd
-%MatrixPrimitiveImplicitExplicitThisTests_DefaultConstructor = OpFunction %void None %15
+%MatrixPrimitiveImplicitExplicitThisTests_DefaultConstructor = OpFunction %void None %16
      %self_2 = OpFunctionParameter %_ptr_Function_MatrixPrimitiveImplicitExplicitThisTests
          %42 = OpLabel
          %43 = OpFunctionCall %void %MatrixPrimitiveImplicitExplicitThisTests_PreConstructor %self_2
                OpReturn
                OpFunctionEnd
-       %Main = OpFunction %void None %15
+       %Main = OpFunction %void None %16
      %self_3 = OpFunctionParameter %_ptr_Function_MatrixPrimitiveImplicitExplicitThisTests
          %48 = OpLabel
     %matrix0 = OpVariable %_ptr_Function_TestMatrixPrimitive Function
@@ -82,7 +82,7 @@
                OpStore %fieldThisImplicit %57
                OpReturn
                OpFunctionEnd
-%MatrixPrimitiveImplicitExplicitThisTests_Main_EntryPoint = OpFunction %void None %17
+%MatrixPrimitiveImplicitExplicitThisTests_Main_EntryPoint = OpFunction %void None %18
          %62 = OpLabel
      %self_4 = OpVariable %_ptr_Function_MatrixPrimitiveImplicitExplicitThisTests Function
          %64 = OpFunctionCall %void %MatrixPrimitiveImplicitExplicitThisTests_DefaultConstructor %self_4

--- a/CSShadersTests/Tests/PrimitiveIntrinsics/SampledImage/ComplexSampledImageIntrinsicFunction.expected.spvtxt
+++ b/CSShadersTests/Tests/PrimitiveIntrinsics/SampledImage/ComplexSampledImageIntrinsicFunction.expected.spvtxt
@@ -11,6 +11,7 @@
                OpSource Unknown 100
                OpName %SimpleFloatImage2d "SimpleFloatImage2d"
                OpName %SimpleSampledFloatImage2d "SimpleSampledFloatImage2d"
+               OpName %SimpleSampledFloatImage2d_0 "SimpleSampledFloatImage2d"
                OpName %TestIntrinsics "TestIntrinsics"
                OpName %ComplexImageIntrinsicFunction "ComplexImageIntrinsicFunction"
                OpName %Vector2 "Vector2"
@@ -30,53 +31,52 @@
                OpName %value "value"
                OpName %ComplexImageIntrinsicFunction_Main_EntryPoint "ComplexImageIntrinsicFunction_Main_EntryPoint"
                OpName %self_4 "self"
-               OpName %SimpleSampledFloatImage2d_0 "SimpleSampledFloatImage2d"
                OpName %ComplexImageIntrinsicFunction_Main_EntryPoint "ComplexImageIntrinsicFunction_Main_EntryPoint"
                OpName %self_4 "self"
        %uint = OpTypeInt 32 0
       %float = OpTypeFloat 32
+    %float_0 = OpConstant %float 0
+    %float_1 = OpConstant %float 1
 %SimpleFloatImage2d = OpTypeImage %float 2D 0 0 0 1 Unknown
 %SimpleSampledFloatImage2d = OpTypeSampledImage %SimpleFloatImage2d
 %_ptr_UniformConstant_SimpleSampledFloatImage2d = OpTypePointer UniformConstant %SimpleSampledFloatImage2d
+%SimpleSampledFloatImage2d_0 = OpVariable %_ptr_UniformConstant_SimpleSampledFloatImage2d UniformConstant
 %TestIntrinsics = OpTypeStruct
        %void = OpTypeVoid
 %_ptr_Function_TestIntrinsics = OpTypePointer Function %TestIntrinsics
-         %14 = OpTypeFunction %void %_ptr_Function_TestIntrinsics
+         %17 = OpTypeFunction %void %_ptr_Function_TestIntrinsics
 %ComplexImageIntrinsicFunction = OpTypeStruct
 %_ptr_Function_ComplexImageIntrinsicFunction = OpTypePointer Function %ComplexImageIntrinsicFunction
-         %18 = OpTypeFunction %void %_ptr_Function_ComplexImageIntrinsicFunction
+         %21 = OpTypeFunction %void %_ptr_Function_ComplexImageIntrinsicFunction
     %Vector2 = OpTypeVector %float 2
 %_ptr_Function_Vector2 = OpTypePointer Function %Vector2
 %_ptr_Function_float = OpTypePointer Function %float
     %Vector4 = OpTypeVector %float 4
 %_ptr_Function_Vector4 = OpTypePointer Function %Vector4
-         %24 = OpTypeFunction %void
-    %float_0 = OpConstant %float 0
-    %float_1 = OpConstant %float 1
-%SimpleSampledFloatImage2d_0 = OpVariable %_ptr_UniformConstant_SimpleSampledFloatImage2d UniformConstant
-%TestIntrinsics_PreConstructor = OpFunction %void None %14
+         %27 = OpTypeFunction %void
+%TestIntrinsics_PreConstructor = OpFunction %void None %17
        %self = OpFunctionParameter %_ptr_Function_TestIntrinsics
          %32 = OpLabel
                OpReturn
                OpFunctionEnd
-%TestIntrinsics_DefaultConstructor = OpFunction %void None %14
+%TestIntrinsics_DefaultConstructor = OpFunction %void None %17
      %self_0 = OpFunctionParameter %_ptr_Function_TestIntrinsics
          %37 = OpLabel
          %38 = OpFunctionCall %void %TestIntrinsics_PreConstructor %self_0
                OpReturn
                OpFunctionEnd
-%ComplexImageIntrinsicFunction_PreConstructor = OpFunction %void None %18
+%ComplexImageIntrinsicFunction_PreConstructor = OpFunction %void None %21
      %self_1 = OpFunctionParameter %_ptr_Function_ComplexImageIntrinsicFunction
          %43 = OpLabel
                OpReturn
                OpFunctionEnd
-%ComplexImageIntrinsicFunction_DefaultConstructor = OpFunction %void None %18
+%ComplexImageIntrinsicFunction_DefaultConstructor = OpFunction %void None %21
      %self_2 = OpFunctionParameter %_ptr_Function_ComplexImageIntrinsicFunction
          %48 = OpLabel
          %49 = OpFunctionCall %void %ComplexImageIntrinsicFunction_PreConstructor %self_2
                OpReturn
                OpFunctionEnd
-       %Main = OpFunction %void None %18
+       %Main = OpFunction %void None %21
      %self_3 = OpFunctionParameter %_ptr_Function_ComplexImageIntrinsicFunction
          %54 = OpLabel
         %uvs = OpVariable %_ptr_Function_Vector2 Function
@@ -92,7 +92,7 @@
                OpStore %value %64
                OpReturn
                OpFunctionEnd
-%ComplexImageIntrinsicFunction_Main_EntryPoint = OpFunction %void None %24
+%ComplexImageIntrinsicFunction_Main_EntryPoint = OpFunction %void None %27
          %69 = OpLabel
      %self_4 = OpVariable %_ptr_Function_ComplexImageIntrinsicFunction Function
          %71 = OpFunctionCall %void %ComplexImageIntrinsicFunction_DefaultConstructor %self_4

--- a/CSShadersTests/Tests/PrimitiveIntrinsics/SampledImage/SampledImagePrimitiveDeclaration.expected.spvtxt
+++ b/CSShadersTests/Tests/PrimitiveIntrinsics/SampledImage/SampledImagePrimitiveDeclaration.expected.spvtxt
@@ -11,6 +11,7 @@
                OpSource Unknown 100
                OpName %SimpleFloatImage2d "SimpleFloatImage2d"
                OpName %SimpleSampledFloatImage2d "SimpleSampledFloatImage2d"
+               OpName %SimpleSampledFloatImage2d_0 "SimpleSampledFloatImage2d"
                OpName %SampledImagePrimitiveDeclaration "SampledImagePrimitiveDeclaration"
                OpName %SampledImagePrimitiveDeclaration_PreConstructor "SampledImagePrimitiveDeclaration_PreConstructor"
                OpName %self "self"
@@ -18,7 +19,6 @@
                OpName %self_0 "self"
                OpName %SampledImagePrimitiveDeclaration_EntryPoint "SampledImagePrimitiveDeclaration_EntryPoint"
                OpName %self_1 "self"
-               OpName %SimpleSampledFloatImage2d_0 "SimpleSampledFloatImage2d"
                OpName %SampledImagePrimitiveDeclaration_EntryPoint "SampledImagePrimitiveDeclaration_EntryPoint"
                OpName %self_1 "self"
        %uint = OpTypeInt 32 0
@@ -26,24 +26,24 @@
 %SimpleFloatImage2d = OpTypeImage %float 2D 0 0 0 1 Unknown
 %SimpleSampledFloatImage2d = OpTypeSampledImage %SimpleFloatImage2d
 %_ptr_UniformConstant_SimpleSampledFloatImage2d = OpTypePointer UniformConstant %SimpleSampledFloatImage2d
+%SimpleSampledFloatImage2d_0 = OpVariable %_ptr_UniformConstant_SimpleSampledFloatImage2d UniformConstant
 %SampledImagePrimitiveDeclaration = OpTypeStruct
        %void = OpTypeVoid
 %_ptr_Function_SampledImagePrimitiveDeclaration = OpTypePointer Function %SampledImagePrimitiveDeclaration
-         %14 = OpTypeFunction %void %_ptr_Function_SampledImagePrimitiveDeclaration
-         %16 = OpTypeFunction %void
-%SimpleSampledFloatImage2d_0 = OpVariable %_ptr_UniformConstant_SimpleSampledFloatImage2d UniformConstant
-%SampledImagePrimitiveDeclaration_PreConstructor = OpFunction %void None %14
+         %15 = OpTypeFunction %void %_ptr_Function_SampledImagePrimitiveDeclaration
+         %17 = OpTypeFunction %void
+%SampledImagePrimitiveDeclaration_PreConstructor = OpFunction %void None %15
        %self = OpFunctionParameter %_ptr_Function_SampledImagePrimitiveDeclaration
          %22 = OpLabel
                OpReturn
                OpFunctionEnd
-%SampledImagePrimitiveDeclaration_DefaultConstructor = OpFunction %void None %14
+%SampledImagePrimitiveDeclaration_DefaultConstructor = OpFunction %void None %15
      %self_0 = OpFunctionParameter %_ptr_Function_SampledImagePrimitiveDeclaration
          %27 = OpLabel
          %28 = OpFunctionCall %void %SampledImagePrimitiveDeclaration_PreConstructor %self_0
                OpReturn
                OpFunctionEnd
-%SampledImagePrimitiveDeclaration_EntryPoint = OpFunction %void None %16
+%SampledImagePrimitiveDeclaration_EntryPoint = OpFunction %void None %17
          %32 = OpLabel
      %self_1 = OpVariable %_ptr_Function_SampledImagePrimitiveDeclaration Function
          %34 = OpFunctionCall %void %SampledImagePrimitiveDeclaration_DefaultConstructor %self_1

--- a/CSShadersTests/Tests/PrimitiveIntrinsics/SampledImage/SimpleImageIntrinsicFunction.expected.spvtxt
+++ b/CSShadersTests/Tests/PrimitiveIntrinsics/SampledImage/SimpleImageIntrinsicFunction.expected.spvtxt
@@ -11,6 +11,7 @@
                OpSource Unknown 100
                OpName %SimpleFloatImage2d "SimpleFloatImage2d"
                OpName %SimpleSampledFloatImage2d "SimpleSampledFloatImage2d"
+               OpName %SimpleSampledFloatImage2d_0 "SimpleSampledFloatImage2d"
                OpName %SimpleImageIntrinsicFunction "SimpleImageIntrinsicFunction"
                OpName %Vector2 "Vector2"
                OpName %Vector4 "Vector4"
@@ -24,37 +25,36 @@
                OpName %value "value"
                OpName %SimpleImageIntrinsicFunction_Main_EntryPoint "SimpleImageIntrinsicFunction_Main_EntryPoint"
                OpName %self_2 "self"
-               OpName %SimpleSampledFloatImage2d_0 "SimpleSampledFloatImage2d"
                OpName %SimpleImageIntrinsicFunction_Main_EntryPoint "SimpleImageIntrinsicFunction_Main_EntryPoint"
                OpName %self_2 "self"
        %uint = OpTypeInt 32 0
       %float = OpTypeFloat 32
+    %float_0 = OpConstant %float 0
 %SimpleFloatImage2d = OpTypeImage %float 2D 0 0 0 1 Unknown
 %SimpleSampledFloatImage2d = OpTypeSampledImage %SimpleFloatImage2d
 %_ptr_UniformConstant_SimpleSampledFloatImage2d = OpTypePointer UniformConstant %SimpleSampledFloatImage2d
+%SimpleSampledFloatImage2d_0 = OpVariable %_ptr_UniformConstant_SimpleSampledFloatImage2d UniformConstant
 %SimpleImageIntrinsicFunction = OpTypeStruct
        %void = OpTypeVoid
 %_ptr_Function_SimpleImageIntrinsicFunction = OpTypePointer Function %SimpleImageIntrinsicFunction
-         %14 = OpTypeFunction %void %_ptr_Function_SimpleImageIntrinsicFunction
+         %16 = OpTypeFunction %void %_ptr_Function_SimpleImageIntrinsicFunction
     %Vector2 = OpTypeVector %float 2
 %_ptr_Function_Vector2 = OpTypePointer Function %Vector2
     %Vector4 = OpTypeVector %float 4
 %_ptr_Function_Vector4 = OpTypePointer Function %Vector4
-         %20 = OpTypeFunction %void
-    %float_0 = OpConstant %float 0
-%SimpleSampledFloatImage2d_0 = OpVariable %_ptr_UniformConstant_SimpleSampledFloatImage2d UniformConstant
-%SimpleImageIntrinsicFunction_PreConstructor = OpFunction %void None %14
+         %22 = OpTypeFunction %void
+%SimpleImageIntrinsicFunction_PreConstructor = OpFunction %void None %16
        %self = OpFunctionParameter %_ptr_Function_SimpleImageIntrinsicFunction
          %27 = OpLabel
                OpReturn
                OpFunctionEnd
-%SimpleImageIntrinsicFunction_DefaultConstructor = OpFunction %void None %14
+%SimpleImageIntrinsicFunction_DefaultConstructor = OpFunction %void None %16
      %self_0 = OpFunctionParameter %_ptr_Function_SimpleImageIntrinsicFunction
          %32 = OpLabel
          %33 = OpFunctionCall %void %SimpleImageIntrinsicFunction_PreConstructor %self_0
                OpReturn
                OpFunctionEnd
-       %Main = OpFunction %void None %14
+       %Main = OpFunction %void None %16
      %self_1 = OpFunctionParameter %_ptr_Function_SimpleImageIntrinsicFunction
          %38 = OpLabel
         %uvs = OpVariable %_ptr_Function_Vector2 Function
@@ -67,7 +67,7 @@
                OpStore %value %45
                OpReturn
                OpFunctionEnd
-%SimpleImageIntrinsicFunction_Main_EntryPoint = OpFunction %void None %20
+%SimpleImageIntrinsicFunction_Main_EntryPoint = OpFunction %void None %22
          %50 = OpLabel
      %self_2 = OpVariable %_ptr_Function_SimpleImageIntrinsicFunction Function
          %52 = OpFunctionCall %void %SimpleImageIntrinsicFunction_DefaultConstructor %self_2

--- a/CSShadersTests/Tests/PrimitiveIntrinsics/SampledImage/SplitSampledImageIntrinsicFunction.expected.spvtxt
+++ b/CSShadersTests/Tests/PrimitiveIntrinsics/SampledImage/SplitSampledImageIntrinsicFunction.expected.spvtxt
@@ -10,7 +10,9 @@
                OpExecutionMode %SimpleImageIntrinsicFunction_Main_EntryPoint OriginUpperLeft
                OpSource Unknown 100
                OpName %SimpleSampler "SimpleSampler"
+               OpName %SimpleSampler_0 "SimpleSampler"
                OpName %SimpleFloatImage2d "SimpleFloatImage2d"
+               OpName %SimpleFloatImage2d_0 "SimpleFloatImage2d"
                OpName %SimpleSampledFloatImage2d "SimpleSampledFloatImage2d"
                OpName %TestIntrinsics "TestIntrinsics"
                OpName %SimpleImageIntrinsicFunction "SimpleImageIntrinsicFunction"
@@ -31,55 +33,53 @@
                OpName %value "value"
                OpName %SimpleImageIntrinsicFunction_Main_EntryPoint "SimpleImageIntrinsicFunction_Main_EntryPoint"
                OpName %self_4 "self"
-               OpName %SimpleSampler_0 "SimpleSampler"
-               OpName %SimpleFloatImage2d_0 "SimpleFloatImage2d"
                OpName %SimpleImageIntrinsicFunction_Main_EntryPoint "SimpleImageIntrinsicFunction_Main_EntryPoint"
                OpName %self_4 "self"
        %uint = OpTypeInt 32 0
       %float = OpTypeFloat 32
+    %float_0 = OpConstant %float 0
 %SimpleSampler = OpTypeSampler
 %_ptr_UniformConstant_SimpleSampler = OpTypePointer UniformConstant %SimpleSampler
+%SimpleSampler_0 = OpVariable %_ptr_UniformConstant_SimpleSampler UniformConstant
 %SimpleFloatImage2d = OpTypeImage %float 2D 0 0 0 1 Unknown
 %_ptr_UniformConstant_SimpleFloatImage2d = OpTypePointer UniformConstant %SimpleFloatImage2d
+%SimpleFloatImage2d_0 = OpVariable %_ptr_UniformConstant_SimpleFloatImage2d UniformConstant
 %SimpleSampledFloatImage2d = OpTypeSampledImage %SimpleFloatImage2d
 %TestIntrinsics = OpTypeStruct
        %void = OpTypeVoid
 %_ptr_Function_TestIntrinsics = OpTypePointer Function %TestIntrinsics
-         %17 = OpTypeFunction %void %_ptr_Function_TestIntrinsics
+         %20 = OpTypeFunction %void %_ptr_Function_TestIntrinsics
 %SimpleImageIntrinsicFunction = OpTypeStruct
 %_ptr_Function_SimpleImageIntrinsicFunction = OpTypePointer Function %SimpleImageIntrinsicFunction
-         %21 = OpTypeFunction %void %_ptr_Function_SimpleImageIntrinsicFunction
+         %24 = OpTypeFunction %void %_ptr_Function_SimpleImageIntrinsicFunction
     %Vector2 = OpTypeVector %float 2
 %_ptr_Function_Vector2 = OpTypePointer Function %Vector2
     %Vector4 = OpTypeVector %float 4
 %_ptr_Function_Vector4 = OpTypePointer Function %Vector4
-         %27 = OpTypeFunction %void
-    %float_0 = OpConstant %float 0
-%SimpleSampler_0 = OpVariable %_ptr_UniformConstant_SimpleSampler UniformConstant
-%SimpleFloatImage2d_0 = OpVariable %_ptr_UniformConstant_SimpleFloatImage2d UniformConstant
-%TestIntrinsics_PreConstructor = OpFunction %void None %17
+         %30 = OpTypeFunction %void
+%TestIntrinsics_PreConstructor = OpFunction %void None %20
        %self = OpFunctionParameter %_ptr_Function_TestIntrinsics
          %35 = OpLabel
                OpReturn
                OpFunctionEnd
-%TestIntrinsics_DefaultConstructor = OpFunction %void None %17
+%TestIntrinsics_DefaultConstructor = OpFunction %void None %20
      %self_0 = OpFunctionParameter %_ptr_Function_TestIntrinsics
          %40 = OpLabel
          %41 = OpFunctionCall %void %TestIntrinsics_PreConstructor %self_0
                OpReturn
                OpFunctionEnd
-%SimpleImageIntrinsicFunction_PreConstructor = OpFunction %void None %21
+%SimpleImageIntrinsicFunction_PreConstructor = OpFunction %void None %24
      %self_1 = OpFunctionParameter %_ptr_Function_SimpleImageIntrinsicFunction
          %46 = OpLabel
                OpReturn
                OpFunctionEnd
-%SimpleImageIntrinsicFunction_DefaultConstructor = OpFunction %void None %21
+%SimpleImageIntrinsicFunction_DefaultConstructor = OpFunction %void None %24
      %self_2 = OpFunctionParameter %_ptr_Function_SimpleImageIntrinsicFunction
          %51 = OpLabel
          %52 = OpFunctionCall %void %SimpleImageIntrinsicFunction_PreConstructor %self_2
                OpReturn
                OpFunctionEnd
-       %Main = OpFunction %void None %21
+       %Main = OpFunction %void None %24
      %self_3 = OpFunctionParameter %_ptr_Function_SimpleImageIntrinsicFunction
          %57 = OpLabel
         %uvs = OpVariable %_ptr_Function_Vector2 Function
@@ -94,7 +94,7 @@
                OpStore %value %66
                OpReturn
                OpFunctionEnd
-%SimpleImageIntrinsicFunction_Main_EntryPoint = OpFunction %void None %27
+%SimpleImageIntrinsicFunction_Main_EntryPoint = OpFunction %void None %30
          %71 = OpLabel
      %self_4 = OpVariable %_ptr_Function_SimpleImageIntrinsicFunction Function
          %73 = OpFunctionCall %void %SimpleImageIntrinsicFunction_DefaultConstructor %self_4

--- a/CSShadersTests/Tests/PrimitiveIntrinsics/Sampler/SamplerPrimitiveDeclaration.expected.spvtxt
+++ b/CSShadersTests/Tests/PrimitiveIntrinsics/Sampler/SamplerPrimitiveDeclaration.expected.spvtxt
@@ -10,6 +10,7 @@
                OpExecutionMode %SamplerPrimitiveDeclarationTest_EntryPoint OriginUpperLeft
                OpSource Unknown 100
                OpName %TestSamplerPrimitive "TestSamplerPrimitive"
+               OpName %Sampler "Sampler"
                OpName %SamplerPrimitiveDeclarationTest "SamplerPrimitiveDeclarationTest"
                OpName %SamplerPrimitiveDeclarationTest_PreConstructor "SamplerPrimitiveDeclarationTest_PreConstructor"
                OpName %self "self"
@@ -17,29 +18,28 @@
                OpName %self_0 "self"
                OpName %SamplerPrimitiveDeclarationTest_EntryPoint "SamplerPrimitiveDeclarationTest_EntryPoint"
                OpName %self_1 "self"
-               OpName %Sampler "Sampler"
                OpName %SamplerPrimitiveDeclarationTest_EntryPoint "SamplerPrimitiveDeclarationTest_EntryPoint"
                OpName %self_1 "self"
 %TestSamplerPrimitive = OpTypeSampler
 %_ptr_UniformConstant_TestSamplerPrimitive = OpTypePointer UniformConstant %TestSamplerPrimitive
+    %Sampler = OpVariable %_ptr_UniformConstant_TestSamplerPrimitive UniformConstant
 %SamplerPrimitiveDeclarationTest = OpTypeStruct
        %void = OpTypeVoid
 %_ptr_Function_SamplerPrimitiveDeclarationTest = OpTypePointer Function %SamplerPrimitiveDeclarationTest
-          %8 = OpTypeFunction %void %_ptr_Function_SamplerPrimitiveDeclarationTest
-         %10 = OpTypeFunction %void
-    %Sampler = OpVariable %_ptr_UniformConstant_TestSamplerPrimitive UniformConstant
-%SamplerPrimitiveDeclarationTest_PreConstructor = OpFunction %void None %8
+          %9 = OpTypeFunction %void %_ptr_Function_SamplerPrimitiveDeclarationTest
+         %11 = OpTypeFunction %void
+%SamplerPrimitiveDeclarationTest_PreConstructor = OpFunction %void None %9
        %self = OpFunctionParameter %_ptr_Function_SamplerPrimitiveDeclarationTest
          %16 = OpLabel
                OpReturn
                OpFunctionEnd
-%SamplerPrimitiveDeclarationTest_DefaultConstructor = OpFunction %void None %8
+%SamplerPrimitiveDeclarationTest_DefaultConstructor = OpFunction %void None %9
      %self_0 = OpFunctionParameter %_ptr_Function_SamplerPrimitiveDeclarationTest
          %21 = OpLabel
          %22 = OpFunctionCall %void %SamplerPrimitiveDeclarationTest_PreConstructor %self_0
                OpReturn
                OpFunctionEnd
-%SamplerPrimitiveDeclarationTest_EntryPoint = OpFunction %void None %10
+%SamplerPrimitiveDeclarationTest_EntryPoint = OpFunction %void None %11
          %26 = OpLabel
      %self_1 = OpVariable %_ptr_Function_SamplerPrimitiveDeclarationTest Function
          %28 = OpFunctionCall %void %SamplerPrimitiveDeclarationTest_DefaultConstructor %self_1

--- a/CSShadersTests/Tests/PrimitiveIntrinsics/Vector/VectorPrimitiveCompositeConstructors.expected.spvtxt
+++ b/CSShadersTests/Tests/PrimitiveIntrinsics/Vector/VectorPrimitiveCompositeConstructors.expected.spvtxt
@@ -25,27 +25,27 @@
                OpName %self_2 "self"
        %uint = OpTypeInt 32 0
       %float = OpTypeFloat 32
+    %float_1 = OpConstant %float 1
+    %float_2 = OpConstant %float 2
 %TestVectorPrimitive = OpTypeVector %float 2
 %VectorPrimitiveCompositeConstructorsTest = OpTypeStruct
        %void = OpTypeVoid
 %_ptr_Function_VectorPrimitiveCompositeConstructorsTest = OpTypePointer Function %VectorPrimitiveCompositeConstructorsTest
-         %11 = OpTypeFunction %void %_ptr_Function_VectorPrimitiveCompositeConstructorsTest
+         %13 = OpTypeFunction %void %_ptr_Function_VectorPrimitiveCompositeConstructorsTest
 %_ptr_Function_TestVectorPrimitive = OpTypePointer Function %TestVectorPrimitive
-         %13 = OpTypeFunction %void
-    %float_1 = OpConstant %float 1
-    %float_2 = OpConstant %float 2
-%VectorPrimitiveCompositeConstructorsTest_PreConstructor = OpFunction %void None %11
+         %15 = OpTypeFunction %void
+%VectorPrimitiveCompositeConstructorsTest_PreConstructor = OpFunction %void None %13
        %self = OpFunctionParameter %_ptr_Function_VectorPrimitiveCompositeConstructorsTest
          %20 = OpLabel
                OpReturn
                OpFunctionEnd
-%VectorPrimitiveCompositeConstructorsTest_DefaultConstructor = OpFunction %void None %11
+%VectorPrimitiveCompositeConstructorsTest_DefaultConstructor = OpFunction %void None %13
      %self_0 = OpFunctionParameter %_ptr_Function_VectorPrimitiveCompositeConstructorsTest
          %25 = OpLabel
          %26 = OpFunctionCall %void %VectorPrimitiveCompositeConstructorsTest_PreConstructor %self_0
                OpReturn
                OpFunctionEnd
-       %Main = OpFunction %void None %11
+       %Main = OpFunction %void None %13
      %self_1 = OpFunctionParameter %_ptr_Function_VectorPrimitiveCompositeConstructorsTest
          %31 = OpLabel
     %vector0 = OpVariable %_ptr_Function_TestVectorPrimitive Function
@@ -56,7 +56,7 @@
                OpStore %vector1 %36
                OpReturn
                OpFunctionEnd
-%VectorPrimitiveCompositeConstructorsTest_Main_EntryPoint = OpFunction %void None %13
+%VectorPrimitiveCompositeConstructorsTest_Main_EntryPoint = OpFunction %void None %15
          %41 = OpLabel
      %self_2 = OpVariable %_ptr_Function_VectorPrimitiveCompositeConstructorsTest Function
          %43 = OpFunctionCall %void %VectorPrimitiveCompositeConstructorsTest_DefaultConstructor %self_2

--- a/CSShadersTests/Tests/PrimitiveIntrinsics/Vector/VectorPrimitiveDeclaration.expected.spvtxt
+++ b/CSShadersTests/Tests/PrimitiveIntrinsics/Vector/VectorPrimitiveDeclaration.expected.spvtxt
@@ -24,26 +24,26 @@
                OpName %self_2 "self"
        %uint = OpTypeInt 32 0
       %float = OpTypeFloat 32
+    %float_0 = OpConstant %float 0
 %TestVectorPrimitive = OpTypeVector %float 2
 %VectorPrimitiveDeclarationTest = OpTypeStruct
        %void = OpTypeVoid
 %_ptr_Function_VectorPrimitiveDeclarationTest = OpTypePointer Function %VectorPrimitiveDeclarationTest
-         %11 = OpTypeFunction %void %_ptr_Function_VectorPrimitiveDeclarationTest
+         %12 = OpTypeFunction %void %_ptr_Function_VectorPrimitiveDeclarationTest
 %_ptr_Function_TestVectorPrimitive = OpTypePointer Function %TestVectorPrimitive
-         %13 = OpTypeFunction %void
-    %float_0 = OpConstant %float 0
-%VectorPrimitiveDeclarationTest_PreConstructor = OpFunction %void None %11
+         %14 = OpTypeFunction %void
+%VectorPrimitiveDeclarationTest_PreConstructor = OpFunction %void None %12
        %self = OpFunctionParameter %_ptr_Function_VectorPrimitiveDeclarationTest
          %19 = OpLabel
                OpReturn
                OpFunctionEnd
-%VectorPrimitiveDeclarationTest_DefaultConstructor = OpFunction %void None %11
+%VectorPrimitiveDeclarationTest_DefaultConstructor = OpFunction %void None %12
      %self_0 = OpFunctionParameter %_ptr_Function_VectorPrimitiveDeclarationTest
          %24 = OpLabel
          %25 = OpFunctionCall %void %VectorPrimitiveDeclarationTest_PreConstructor %self_0
                OpReturn
                OpFunctionEnd
-       %Main = OpFunction %void None %11
+       %Main = OpFunction %void None %12
      %self_1 = OpFunctionParameter %_ptr_Function_VectorPrimitiveDeclarationTest
          %30 = OpLabel
     %vector0 = OpVariable %_ptr_Function_TestVectorPrimitive Function
@@ -51,7 +51,7 @@
                OpStore %vector0 %32
                OpReturn
                OpFunctionEnd
-%VectorPrimitiveDeclarationTest_Main_EntryPoint = OpFunction %void None %13
+%VectorPrimitiveDeclarationTest_Main_EntryPoint = OpFunction %void None %14
          %37 = OpLabel
      %self_2 = OpVariable %_ptr_Function_VectorPrimitiveDeclarationTest Function
          %39 = OpFunctionCall %void %VectorPrimitiveDeclarationTest_DefaultConstructor %self_2

--- a/CSShadersTests/Tests/PrimitiveIntrinsics/Vector/VectorPrimitiveFieldSwizzles.expected.spvtxt
+++ b/CSShadersTests/Tests/PrimitiveIntrinsics/Vector/VectorPrimitiveFieldSwizzles.expected.spvtxt
@@ -24,28 +24,28 @@
                OpName %self_2 "self"
        %uint = OpTypeInt 32 0
       %float = OpTypeFloat 32
+    %float_0 = OpConstant %float 0
+     %uint_1 = OpConstant %uint 1
 %TestVectorPrimitive = OpTypeVector %float 2
 %VectorPrimitiveFieldSwizzlesTest = OpTypeStruct
        %void = OpTypeVoid
 %_ptr_Function_VectorPrimitiveFieldSwizzlesTest = OpTypePointer Function %VectorPrimitiveFieldSwizzlesTest
-         %11 = OpTypeFunction %void %_ptr_Function_VectorPrimitiveFieldSwizzlesTest
+         %13 = OpTypeFunction %void %_ptr_Function_VectorPrimitiveFieldSwizzlesTest
 %_ptr_Function_TestVectorPrimitive = OpTypePointer Function %TestVectorPrimitive
 %_ptr_Function_float = OpTypePointer Function %float
-         %13 = OpTypeFunction %void
-    %float_0 = OpConstant %float 0
-     %uint_1 = OpConstant %uint 1
-%VectorPrimitiveFieldSwizzlesTest_PreConstructor = OpFunction %void None %11
+         %15 = OpTypeFunction %void
+%VectorPrimitiveFieldSwizzlesTest_PreConstructor = OpFunction %void None %13
        %self = OpFunctionParameter %_ptr_Function_VectorPrimitiveFieldSwizzlesTest
          %20 = OpLabel
                OpReturn
                OpFunctionEnd
-%VectorPrimitiveFieldSwizzlesTest_DefaultConstructor = OpFunction %void None %11
+%VectorPrimitiveFieldSwizzlesTest_DefaultConstructor = OpFunction %void None %13
      %self_0 = OpFunctionParameter %_ptr_Function_VectorPrimitiveFieldSwizzlesTest
          %25 = OpLabel
          %26 = OpFunctionCall %void %VectorPrimitiveFieldSwizzlesTest_PreConstructor %self_0
                OpReturn
                OpFunctionEnd
-       %Main = OpFunction %void None %11
+       %Main = OpFunction %void None %13
      %self_1 = OpFunctionParameter %_ptr_Function_VectorPrimitiveFieldSwizzlesTest
          %31 = OpLabel
     %vector0 = OpVariable %_ptr_Function_TestVectorPrimitive Function
@@ -58,7 +58,7 @@
                OpStore %38 %36
                OpReturn
                OpFunctionEnd
-%VectorPrimitiveFieldSwizzlesTest_Main_EntryPoint = OpFunction %void None %13
+%VectorPrimitiveFieldSwizzlesTest_Main_EntryPoint = OpFunction %void None %15
          %43 = OpLabel
      %self_2 = OpVariable %_ptr_Function_VectorPrimitiveFieldSwizzlesTest Function
          %45 = OpFunctionCall %void %VectorPrimitiveFieldSwizzlesTest_DefaultConstructor %self_2

--- a/CSShadersTests/Tests/PrimitiveIntrinsics/Vector/VectorPrimitiveImplicitExplicitThisTests.expected.spvtxt
+++ b/CSShadersTests/Tests/PrimitiveIntrinsics/Vector/VectorPrimitiveImplicitExplicitThisTests.expected.spvtxt
@@ -36,57 +36,57 @@
                OpName %self_6 "self"
        %uint = OpTypeInt 32 0
       %float = OpTypeFloat 32
+    %float_0 = OpConstant %float 0
 %TestVectorPrimitive = OpTypeVector %float 2
 %_ptr_Function_TestVectorPrimitive = OpTypePointer Function %TestVectorPrimitive
-          %7 = OpTypeFunction %float %_ptr_Function_TestVectorPrimitive
-          %9 = OpTypeFunction %TestVectorPrimitive %_ptr_Function_TestVectorPrimitive
+          %8 = OpTypeFunction %float %_ptr_Function_TestVectorPrimitive
+         %10 = OpTypeFunction %TestVectorPrimitive %_ptr_Function_TestVectorPrimitive
 %VectorPrimitiveImplicitExplicitThisTests = OpTypeStruct
        %void = OpTypeVoid
 %_ptr_Function_VectorPrimitiveImplicitExplicitThisTests = OpTypePointer Function %VectorPrimitiveImplicitExplicitThisTests
-         %15 = OpTypeFunction %void %_ptr_Function_VectorPrimitiveImplicitExplicitThisTests
+         %16 = OpTypeFunction %void %_ptr_Function_VectorPrimitiveImplicitExplicitThisTests
 %_ptr_Function_float = OpTypePointer Function %float
-         %17 = OpTypeFunction %void
-    %float_0 = OpConstant %float 0
-%FieldThisExplicit = OpFunction %float None %7
+         %18 = OpTypeFunction %void
+%FieldThisExplicit = OpFunction %float None %8
        %self = OpFunctionParameter %_ptr_Function_TestVectorPrimitive
          %23 = OpLabel
          %24 = OpLoad %TestVectorPrimitive %self
          %25 = OpCompositeExtract %float %24 0
                OpReturnValue %25
                OpFunctionEnd
-%FieldThisImplicit = OpFunction %float None %7
+%FieldThisImplicit = OpFunction %float None %8
      %self_0 = OpFunctionParameter %_ptr_Function_TestVectorPrimitive
          %30 = OpLabel
          %31 = OpLoad %TestVectorPrimitive %self_0
          %32 = OpCompositeExtract %float %31 0
                OpReturnValue %32
                OpFunctionEnd
-%PropertyThisExplicit = OpFunction %TestVectorPrimitive None %9
+%PropertyThisExplicit = OpFunction %TestVectorPrimitive None %10
      %self_1 = OpFunctionParameter %_ptr_Function_TestVectorPrimitive
          %37 = OpLabel
          %38 = OpLoad %TestVectorPrimitive %self_1
          %39 = OpVectorShuffle %TestVectorPrimitive %38 %38 0 1
                OpReturnValue %39
                OpFunctionEnd
-%PropertyThisImplicit = OpFunction %TestVectorPrimitive None %9
+%PropertyThisImplicit = OpFunction %TestVectorPrimitive None %10
      %self_2 = OpFunctionParameter %_ptr_Function_TestVectorPrimitive
          %44 = OpLabel
          %45 = OpLoad %TestVectorPrimitive %self_2
          %46 = OpVectorShuffle %TestVectorPrimitive %45 %45 0 1
                OpReturnValue %46
                OpFunctionEnd
-%VectorPrimitiveImplicitExplicitThisTests_PreConstructor = OpFunction %void None %15
+%VectorPrimitiveImplicitExplicitThisTests_PreConstructor = OpFunction %void None %16
      %self_3 = OpFunctionParameter %_ptr_Function_VectorPrimitiveImplicitExplicitThisTests
          %51 = OpLabel
                OpReturn
                OpFunctionEnd
-%VectorPrimitiveImplicitExplicitThisTests_DefaultConstructor = OpFunction %void None %15
+%VectorPrimitiveImplicitExplicitThisTests_DefaultConstructor = OpFunction %void None %16
      %self_4 = OpFunctionParameter %_ptr_Function_VectorPrimitiveImplicitExplicitThisTests
          %56 = OpLabel
          %57 = OpFunctionCall %void %VectorPrimitiveImplicitExplicitThisTests_PreConstructor %self_4
                OpReturn
                OpFunctionEnd
-       %Main = OpFunction %void None %15
+       %Main = OpFunction %void None %16
      %self_5 = OpFunctionParameter %_ptr_Function_VectorPrimitiveImplicitExplicitThisTests
          %62 = OpLabel
     %vector0 = OpVariable %_ptr_Function_TestVectorPrimitive Function
@@ -106,7 +106,7 @@
                OpStore %propertyThisImplicit %76
                OpReturn
                OpFunctionEnd
-%VectorPrimitiveImplicitExplicitThisTests_Main_EntryPoint = OpFunction %void None %17
+%VectorPrimitiveImplicitExplicitThisTests_Main_EntryPoint = OpFunction %void None %18
          %81 = OpLabel
      %self_6 = OpVariable %_ptr_Function_VectorPrimitiveImplicitExplicitThisTests Function
          %83 = OpFunctionCall %void %VectorPrimitiveImplicitExplicitThisTests_DefaultConstructor %self_6

--- a/CSShadersTests/Tests/PrimitiveIntrinsics/Vector/VectorPrimitivePropertySwizzles.expected.spvtxt
+++ b/CSShadersTests/Tests/PrimitiveIntrinsics/Vector/VectorPrimitivePropertySwizzles.expected.spvtxt
@@ -26,26 +26,26 @@
                OpName %self_2 "self"
        %uint = OpTypeInt 32 0
       %float = OpTypeFloat 32
+    %float_0 = OpConstant %float 0
 %TestVectorPrimitive = OpTypeVector %float 2
 %VectorPrimitivePropertySwizzlesTest = OpTypeStruct
        %void = OpTypeVoid
 %_ptr_Function_VectorPrimitivePropertySwizzlesTest = OpTypePointer Function %VectorPrimitivePropertySwizzlesTest
-         %11 = OpTypeFunction %void %_ptr_Function_VectorPrimitivePropertySwizzlesTest
+         %12 = OpTypeFunction %void %_ptr_Function_VectorPrimitivePropertySwizzlesTest
 %_ptr_Function_TestVectorPrimitive = OpTypePointer Function %TestVectorPrimitive
-         %13 = OpTypeFunction %void
-    %float_0 = OpConstant %float 0
-%VectorPrimitivePropertySwizzlesTest_PreConstructor = OpFunction %void None %11
+         %14 = OpTypeFunction %void
+%VectorPrimitivePropertySwizzlesTest_PreConstructor = OpFunction %void None %12
        %self = OpFunctionParameter %_ptr_Function_VectorPrimitivePropertySwizzlesTest
          %19 = OpLabel
                OpReturn
                OpFunctionEnd
-%VectorPrimitivePropertySwizzlesTest_DefaultConstructor = OpFunction %void None %11
+%VectorPrimitivePropertySwizzlesTest_DefaultConstructor = OpFunction %void None %12
      %self_0 = OpFunctionParameter %_ptr_Function_VectorPrimitivePropertySwizzlesTest
          %24 = OpLabel
          %25 = OpFunctionCall %void %VectorPrimitivePropertySwizzlesTest_PreConstructor %self_0
                OpReturn
                OpFunctionEnd
-       %Main = OpFunction %void None %11
+       %Main = OpFunction %void None %12
      %self_1 = OpFunctionParameter %_ptr_Function_VectorPrimitivePropertySwizzlesTest
          %30 = OpLabel
     %vector0 = OpVariable %_ptr_Function_TestVectorPrimitive Function
@@ -71,7 +71,7 @@
                OpStore %vector0 %50
                OpReturn
                OpFunctionEnd
-%VectorPrimitivePropertySwizzlesTest_Main_EntryPoint = OpFunction %void None %13
+%VectorPrimitivePropertySwizzlesTest_Main_EntryPoint = OpFunction %void None %14
          %55 = OpLabel
      %self_2 = OpVariable %_ptr_Function_VectorPrimitivePropertySwizzlesTest Function
          %57 = OpFunctionCall %void %VectorPrimitivePropertySwizzlesTest_DefaultConstructor %self_2

--- a/CSShadersTests/Tests/StageInterface/PixelInputs/Pixel.expected.spvtxt
+++ b/CSShadersTests/Tests/StageInterface/PixelInputs/Pixel.expected.spvtxt
@@ -24,6 +24,7 @@
                OpMemberName %Pixel_Inputs 1 "Value2"
                OpMemberName %Pixel_Inputs 2 "V2"
                OpMemberName %Pixel_Inputs 3 "TestStruct"
+               OpName %In "In"
                OpName %TestStruct_PreConstructor "TestStruct_PreConstructor"
                OpName %self "self"
                OpName %TestStruct_DefaultConstructor "TestStruct_DefaultConstructor"
@@ -39,50 +40,49 @@
                OpName %self_4 "self"
                OpName %Pixel_Main_EntryPoint "Pixel_Main_EntryPoint"
                OpName %self_5 "self"
-               OpName %In "In"
                OpName %Pixel_Main_EntryPoint "Pixel_Main_EntryPoint"
                OpName %self_5 "self"
                OpDecorate %Pixel_Inputs Block
                OpDecorate %In Location 0
        %uint = OpTypeInt 32 0
       %float = OpTypeFloat 32
-%TestVectorPrimitive = OpTypeVector %float 2
- %TestStruct = OpTypeStruct %TestVectorPrimitive %float
-       %void = OpTypeVoid
-%_ptr_Function_TestStruct = OpTypePointer Function %TestStruct
-         %11 = OpTypeFunction %void %_ptr_Function_TestStruct
-%_ptr_Function_float = OpTypePointer Function %float
-      %Pixel = OpTypeStruct %float %float %TestVectorPrimitive %TestStruct
-%_ptr_Function_Pixel = OpTypePointer Function %Pixel
-         %15 = OpTypeFunction %void %_ptr_Function_Pixel
-%_ptr_Input_float = OpTypePointer Input %float
-%Pixel_Inputs = OpTypeStruct %float %float %TestVectorPrimitive %TestStruct
-%_ptr_Input_Pixel_Inputs = OpTypePointer Input %Pixel_Inputs
-%_ptr_Input_TestVectorPrimitive = OpTypePointer Input %TestVectorPrimitive
-%_ptr_Function_TestVectorPrimitive = OpTypePointer Function %TestVectorPrimitive
-%_ptr_Input_TestStruct = OpTypePointer Input %TestStruct
-         %23 = OpTypeFunction %void
     %float_0 = OpConstant %float 0
      %uint_1 = OpConstant %uint 1
     %float_1 = OpConstant %float 1
      %uint_0 = OpConstant %uint 0
      %uint_3 = OpConstant %uint 3
      %uint_2 = OpConstant %uint 2
+%TestVectorPrimitive = OpTypeVector %float 2
+ %TestStruct = OpTypeStruct %TestVectorPrimitive %float
+       %void = OpTypeVoid
+%_ptr_Function_TestStruct = OpTypePointer Function %TestStruct
+         %17 = OpTypeFunction %void %_ptr_Function_TestStruct
+%_ptr_Function_float = OpTypePointer Function %float
+      %Pixel = OpTypeStruct %float %float %TestVectorPrimitive %TestStruct
+%_ptr_Function_Pixel = OpTypePointer Function %Pixel
+         %21 = OpTypeFunction %void %_ptr_Function_Pixel
+%_ptr_Input_float = OpTypePointer Input %float
+%Pixel_Inputs = OpTypeStruct %float %float %TestVectorPrimitive %TestStruct
+%_ptr_Input_Pixel_Inputs = OpTypePointer Input %Pixel_Inputs
+%_ptr_Input_TestVectorPrimitive = OpTypePointer Input %TestVectorPrimitive
+%_ptr_Function_TestVectorPrimitive = OpTypePointer Function %TestVectorPrimitive
+%_ptr_Input_TestStruct = OpTypePointer Input %TestStruct
+         %29 = OpTypeFunction %void
          %In = OpVariable %_ptr_Input_Pixel_Inputs Input
-%TestStruct_PreConstructor = OpFunction %void None %11
+%TestStruct_PreConstructor = OpFunction %void None %17
        %self = OpFunctionParameter %_ptr_Function_TestStruct
          %35 = OpLabel
          %36 = OpAccessChain %_ptr_Function_float %self %uint_1
                OpStore %36 %float_0
                OpReturn
                OpFunctionEnd
-%TestStruct_DefaultConstructor = OpFunction %void None %11
+%TestStruct_DefaultConstructor = OpFunction %void None %17
      %self_0 = OpFunctionParameter %_ptr_Function_TestStruct
          %42 = OpLabel
          %43 = OpFunctionCall %void %TestStruct_PreConstructor %self_0
                OpReturn
                OpFunctionEnd
-%Pixel_PreConstructor = OpFunction %void None %15
+%Pixel_PreConstructor = OpFunction %void None %21
      %self_1 = OpFunctionParameter %_ptr_Function_Pixel
          %48 = OpLabel
 %tempTestStruct = OpVariable %_ptr_Function_TestStruct Function
@@ -96,18 +96,18 @@
                OpStore %56 %55
                OpReturn
                OpFunctionEnd
-%Pixel_DefaultConstructor = OpFunction %void None %15
+%Pixel_DefaultConstructor = OpFunction %void None %21
      %self_2 = OpFunctionParameter %_ptr_Function_Pixel
          %62 = OpLabel
          %63 = OpFunctionCall %void %Pixel_PreConstructor %self_2
                OpReturn
                OpFunctionEnd
-       %Main = OpFunction %void None %15
+       %Main = OpFunction %void None %21
      %self_3 = OpFunctionParameter %_ptr_Function_Pixel
          %68 = OpLabel
                OpReturn
                OpFunctionEnd
-%Pixel_CopyInputs = OpFunction %void None %15
+%Pixel_CopyInputs = OpFunction %void None %21
      %self_4 = OpFunctionParameter %_ptr_Function_Pixel
          %73 = OpLabel
          %74 = OpAccessChain %_ptr_Input_float %In %uint_0
@@ -128,7 +128,7 @@
                OpStore %87 %88
                OpReturn
                OpFunctionEnd
-%Pixel_Main_EntryPoint = OpFunction %void None %23
+%Pixel_Main_EntryPoint = OpFunction %void None %29
          %93 = OpLabel
      %self_5 = OpVariable %_ptr_Function_Pixel Function
          %95 = OpFunctionCall %void %Pixel_DefaultConstructor %self_5

--- a/CSShadersTests/Tests/StageInterface/PixelOutputs/Pixel.expected.spvtxt
+++ b/CSShadersTests/Tests/StageInterface/PixelOutputs/Pixel.expected.spvtxt
@@ -19,6 +19,10 @@
                OpMemberName %Pixel 1 "Value2"
                OpMemberName %Pixel 2 "V2"
                OpMemberName %Pixel 3 "TestStruct"
+               OpName %Value "Value"
+               OpName %Value2 "Value2"
+               OpName %V2 "V2"
+               OpName %TestStruct_0 "TestStruct"
                OpName %TestStruct_PreConstructor "TestStruct_PreConstructor"
                OpName %self "self"
                OpName %TestStruct_DefaultConstructor "TestStruct_DefaultConstructor"
@@ -34,10 +38,6 @@
                OpName %self_4 "self"
                OpName %Pixel_Main_EntryPoint "Pixel_Main_EntryPoint"
                OpName %self_5 "self"
-               OpName %Value "Value"
-               OpName %Value2 "Value2"
-               OpName %V2 "V2"
-               OpName %TestStruct_0 "TestStruct"
                OpName %Pixel_Main_EntryPoint "Pixel_Main_EntryPoint"
                OpName %self_5 "self"
                OpDecorate %Value Location 0
@@ -46,44 +46,44 @@
                OpDecorate %TestStruct_0 Location 3
        %uint = OpTypeInt 32 0
       %float = OpTypeFloat 32
-%TestVectorPrimitive = OpTypeVector %float 2
- %TestStruct = OpTypeStruct %TestVectorPrimitive %float
-       %void = OpTypeVoid
-%_ptr_Function_TestStruct = OpTypePointer Function %TestStruct
-         %11 = OpTypeFunction %void %_ptr_Function_TestStruct
-%_ptr_Function_float = OpTypePointer Function %float
-      %Pixel = OpTypeStruct %float %float %TestVectorPrimitive %TestStruct
-%_ptr_Function_Pixel = OpTypePointer Function %Pixel
-         %15 = OpTypeFunction %void %_ptr_Function_Pixel
-%_ptr_Output_float = OpTypePointer Output %float
-%_ptr_Function_TestVectorPrimitive = OpTypePointer Function %TestVectorPrimitive
-%_ptr_Output_TestVectorPrimitive = OpTypePointer Output %TestVectorPrimitive
-%_ptr_Output_TestStruct = OpTypePointer Output %TestStruct
-         %20 = OpTypeFunction %void
     %float_0 = OpConstant %float 0
      %uint_1 = OpConstant %uint 1
     %float_1 = OpConstant %float 1
      %uint_0 = OpConstant %uint 0
      %uint_3 = OpConstant %uint 3
      %uint_2 = OpConstant %uint 2
+%TestVectorPrimitive = OpTypeVector %float 2
+ %TestStruct = OpTypeStruct %TestVectorPrimitive %float
+       %void = OpTypeVoid
+%_ptr_Function_TestStruct = OpTypePointer Function %TestStruct
+         %17 = OpTypeFunction %void %_ptr_Function_TestStruct
+%_ptr_Function_float = OpTypePointer Function %float
+      %Pixel = OpTypeStruct %float %float %TestVectorPrimitive %TestStruct
+%_ptr_Function_Pixel = OpTypePointer Function %Pixel
+         %21 = OpTypeFunction %void %_ptr_Function_Pixel
+%_ptr_Output_float = OpTypePointer Output %float
+%_ptr_Function_TestVectorPrimitive = OpTypePointer Function %TestVectorPrimitive
+%_ptr_Output_TestVectorPrimitive = OpTypePointer Output %TestVectorPrimitive
+%_ptr_Output_TestStruct = OpTypePointer Output %TestStruct
+         %26 = OpTypeFunction %void
       %Value = OpVariable %_ptr_Output_float Output
      %Value2 = OpVariable %_ptr_Output_float Output
          %V2 = OpVariable %_ptr_Output_TestVectorPrimitive Output
 %TestStruct_0 = OpVariable %_ptr_Output_TestStruct Output
-%TestStruct_PreConstructor = OpFunction %void None %11
+%TestStruct_PreConstructor = OpFunction %void None %17
        %self = OpFunctionParameter %_ptr_Function_TestStruct
          %35 = OpLabel
          %36 = OpAccessChain %_ptr_Function_float %self %uint_1
                OpStore %36 %float_0
                OpReturn
                OpFunctionEnd
-%TestStruct_DefaultConstructor = OpFunction %void None %11
+%TestStruct_DefaultConstructor = OpFunction %void None %17
      %self_0 = OpFunctionParameter %_ptr_Function_TestStruct
          %42 = OpLabel
          %43 = OpFunctionCall %void %TestStruct_PreConstructor %self_0
                OpReturn
                OpFunctionEnd
-%Pixel_PreConstructor = OpFunction %void None %15
+%Pixel_PreConstructor = OpFunction %void None %21
      %self_1 = OpFunctionParameter %_ptr_Function_Pixel
          %48 = OpLabel
 %tempTestStruct = OpVariable %_ptr_Function_TestStruct Function
@@ -97,18 +97,18 @@
                OpStore %56 %55
                OpReturn
                OpFunctionEnd
-%Pixel_DefaultConstructor = OpFunction %void None %15
+%Pixel_DefaultConstructor = OpFunction %void None %21
      %self_2 = OpFunctionParameter %_ptr_Function_Pixel
          %62 = OpLabel
          %63 = OpFunctionCall %void %Pixel_PreConstructor %self_2
                OpReturn
                OpFunctionEnd
-       %Main = OpFunction %void None %15
+       %Main = OpFunction %void None %21
      %self_3 = OpFunctionParameter %_ptr_Function_Pixel
          %68 = OpLabel
                OpReturn
                OpFunctionEnd
-%Pixel_CopyOutputs = OpFunction %void None %15
+%Pixel_CopyOutputs = OpFunction %void None %21
      %self_4 = OpFunctionParameter %_ptr_Function_Pixel
          %73 = OpLabel
          %74 = OpAccessChain %_ptr_Function_float %self_4 %uint_0
@@ -125,7 +125,7 @@
                OpStore %TestStruct_0 %84
                OpReturn
                OpFunctionEnd
-%Pixel_Main_EntryPoint = OpFunction %void None %20
+%Pixel_Main_EntryPoint = OpFunction %void None %26
          %89 = OpLabel
      %self_5 = OpVariable %_ptr_Function_Pixel Function
          %91 = OpFunctionCall %void %Pixel_DefaultConstructor %self_5

--- a/CSShadersTests/Tests/StageInterface/PixelUniforms/Pixel.expected.spvtxt
+++ b/CSShadersTests/Tests/StageInterface/PixelUniforms/Pixel.expected.spvtxt
@@ -24,6 +24,7 @@
                OpMemberName %Pixel_SharedMaterialBuffer 1 "Value2"
                OpMemberName %Pixel_SharedMaterialBuffer 2 "V2"
                OpMemberName %Pixel_SharedMaterialBuffer 3 "TestStruct"
+               OpName %Pixel_SharedMaterialBuffer_Instance "Pixel_SharedMaterialBuffer_Instance"
                OpName %TestStruct_PreConstructor "TestStruct_PreConstructor"
                OpName %self "self"
                OpName %TestStruct_DefaultConstructor "TestStruct_DefaultConstructor"
@@ -39,7 +40,6 @@
                OpName %self_4 "self"
                OpName %Pixel_Main_EntryPoint "Pixel_Main_EntryPoint"
                OpName %self_5 "self"
-               OpName %Pixel_SharedMaterialBuffer_Instance "Pixel_SharedMaterialBuffer_Instance"
                OpName %Pixel_Main_EntryPoint "Pixel_Main_EntryPoint"
                OpName %self_5 "self"
                OpDecorate %Pixel_SharedMaterialBuffer DescriptorSet 0
@@ -53,43 +53,43 @@
                OpMemberDecorate %Pixel_SharedMaterialBuffer 3 Offset 16
        %uint = OpTypeInt 32 0
       %float = OpTypeFloat 32
-%TestVectorPrimitive = OpTypeVector %float 2
- %TestStruct = OpTypeStruct %TestVectorPrimitive %float
-       %void = OpTypeVoid
-%_ptr_Function_TestStruct = OpTypePointer Function %TestStruct
-         %11 = OpTypeFunction %void %_ptr_Function_TestStruct
-%_ptr_Function_float = OpTypePointer Function %float
-      %Pixel = OpTypeStruct %float %float %TestVectorPrimitive %TestStruct
-%_ptr_Function_Pixel = OpTypePointer Function %Pixel
-         %15 = OpTypeFunction %void %_ptr_Function_Pixel
-%_ptr_Uniform_float = OpTypePointer Uniform %float
-%Pixel_SharedMaterialBuffer = OpTypeStruct %float %float %TestVectorPrimitive %TestStruct
-%_ptr_Uniform_Pixel_SharedMaterialBuffer = OpTypePointer Uniform %Pixel_SharedMaterialBuffer
-%_ptr_Uniform_TestVectorPrimitive = OpTypePointer Uniform %TestVectorPrimitive
-%_ptr_Function_TestVectorPrimitive = OpTypePointer Function %TestVectorPrimitive
-%_ptr_Uniform_TestStruct = OpTypePointer Uniform %TestStruct
-         %23 = OpTypeFunction %void
     %float_0 = OpConstant %float 0
      %uint_1 = OpConstant %uint 1
     %float_1 = OpConstant %float 1
      %uint_0 = OpConstant %uint 0
      %uint_3 = OpConstant %uint 3
      %uint_2 = OpConstant %uint 2
+%TestVectorPrimitive = OpTypeVector %float 2
+ %TestStruct = OpTypeStruct %TestVectorPrimitive %float
+       %void = OpTypeVoid
+%_ptr_Function_TestStruct = OpTypePointer Function %TestStruct
+         %17 = OpTypeFunction %void %_ptr_Function_TestStruct
+%_ptr_Function_float = OpTypePointer Function %float
+      %Pixel = OpTypeStruct %float %float %TestVectorPrimitive %TestStruct
+%_ptr_Function_Pixel = OpTypePointer Function %Pixel
+         %21 = OpTypeFunction %void %_ptr_Function_Pixel
+%_ptr_Uniform_float = OpTypePointer Uniform %float
+%Pixel_SharedMaterialBuffer = OpTypeStruct %float %float %TestVectorPrimitive %TestStruct
+%_ptr_Uniform_Pixel_SharedMaterialBuffer = OpTypePointer Uniform %Pixel_SharedMaterialBuffer
+%_ptr_Uniform_TestVectorPrimitive = OpTypePointer Uniform %TestVectorPrimitive
+%_ptr_Function_TestVectorPrimitive = OpTypePointer Function %TestVectorPrimitive
+%_ptr_Uniform_TestStruct = OpTypePointer Uniform %TestStruct
+         %29 = OpTypeFunction %void
 %Pixel_SharedMaterialBuffer_Instance = OpVariable %_ptr_Uniform_Pixel_SharedMaterialBuffer Uniform
-%TestStruct_PreConstructor = OpFunction %void None %11
+%TestStruct_PreConstructor = OpFunction %void None %17
        %self = OpFunctionParameter %_ptr_Function_TestStruct
          %35 = OpLabel
          %36 = OpAccessChain %_ptr_Function_float %self %uint_1
                OpStore %36 %float_0
                OpReturn
                OpFunctionEnd
-%TestStruct_DefaultConstructor = OpFunction %void None %11
+%TestStruct_DefaultConstructor = OpFunction %void None %17
      %self_0 = OpFunctionParameter %_ptr_Function_TestStruct
          %42 = OpLabel
          %43 = OpFunctionCall %void %TestStruct_PreConstructor %self_0
                OpReturn
                OpFunctionEnd
-%Pixel_PreConstructor = OpFunction %void None %15
+%Pixel_PreConstructor = OpFunction %void None %21
      %self_1 = OpFunctionParameter %_ptr_Function_Pixel
          %48 = OpLabel
 %tempTestStruct = OpVariable %_ptr_Function_TestStruct Function
@@ -103,18 +103,18 @@
                OpStore %56 %55
                OpReturn
                OpFunctionEnd
-%Pixel_DefaultConstructor = OpFunction %void None %15
+%Pixel_DefaultConstructor = OpFunction %void None %21
      %self_2 = OpFunctionParameter %_ptr_Function_Pixel
          %62 = OpLabel
          %63 = OpFunctionCall %void %Pixel_PreConstructor %self_2
                OpReturn
                OpFunctionEnd
-       %Main = OpFunction %void None %15
+       %Main = OpFunction %void None %21
      %self_3 = OpFunctionParameter %_ptr_Function_Pixel
          %68 = OpLabel
                OpReturn
                OpFunctionEnd
-%Pixel_CopyInputs = OpFunction %void None %15
+%Pixel_CopyInputs = OpFunction %void None %21
      %self_4 = OpFunctionParameter %_ptr_Function_Pixel
          %73 = OpLabel
          %74 = OpAccessChain %_ptr_Uniform_float %Pixel_SharedMaterialBuffer_Instance %uint_0
@@ -135,7 +135,7 @@
                OpStore %87 %88
                OpReturn
                OpFunctionEnd
-%Pixel_Main_EntryPoint = OpFunction %void None %23
+%Pixel_Main_EntryPoint = OpFunction %void None %29
          %93 = OpLabel
      %self_5 = OpVariable %_ptr_Function_Pixel Function
          %95 = OpFunctionCall %void %Pixel_DefaultConstructor %self_5

--- a/CSShadersTests/Tests/StageInterface/UniformBuffers/Layouts/UniformBufferFloat2x2Layouts.expected.spvtxt
+++ b/CSShadersTests/Tests/StageInterface/UniformBuffers/Layouts/UniformBufferFloat2x2Layouts.expected.spvtxt
@@ -35,6 +35,9 @@
                OpMemberName %Float2x2Buffer2_0 0 "Value0"
                OpMemberName %Float2x2Buffer2_0 1 "Value1"
                OpMemberName %Float2x2Buffer2_0 2 "Float2x2"
+               OpName %Float2x2Buffer0_Instance "Float2x2Buffer0_Instance"
+               OpName %Float2x2Buffer1_Instance "Float2x2Buffer1_Instance"
+               OpName %Float2x2Buffer2_Instance "Float2x2Buffer2_Instance"
                OpName %Float2x2Buffer0_PreConstructor "Float2x2Buffer0_PreConstructor"
                OpName %self "self"
                OpName %Float2x2Buffer0_DefaultConstructor "Float2x2Buffer0_DefaultConstructor"
@@ -60,9 +63,6 @@
                OpName %self_8 "self"
                OpName %UniformBufferFloat2x2Layouts_Main_EntryPoint "UniformBufferFloat2x2Layouts_Main_EntryPoint"
                OpName %self_9 "self"
-               OpName %Float2x2Buffer0_Instance "Float2x2Buffer0_Instance"
-               OpName %Float2x2Buffer1_Instance "Float2x2Buffer1_Instance"
-               OpName %Float2x2Buffer2_Instance "Float2x2Buffer2_Instance"
                OpName %UniformBufferFloat2x2Layouts_Main_EntryPoint "UniformBufferFloat2x2Layouts_Main_EntryPoint"
                OpName %self_9 "self"
                OpDecorate %Float2x2Buffer0_0 DescriptorSet 0
@@ -91,22 +91,26 @@
                OpMemberDecorate %Float2x2Buffer2_0 2 ColMajor
        %uint = OpTypeInt 32 0
       %float = OpTypeFloat 32
+    %float_0 = OpConstant %float 0
+     %uint_0 = OpConstant %uint 0
+     %uint_1 = OpConstant %uint 1
+     %uint_2 = OpConstant %uint 2
 %TestVector2 = OpTypeVector %float 2
 %TestFloat2x2 = OpTypeMatrix %TestVector2 2
 %Float2x2Buffer0 = OpTypeStruct %TestFloat2x2 %TestFloat2x2
        %void = OpTypeVoid
 %_ptr_Function_Float2x2Buffer0 = OpTypePointer Function %Float2x2Buffer0
-         %13 = OpTypeFunction %void %_ptr_Function_Float2x2Buffer0
+         %17 = OpTypeFunction %void %_ptr_Function_Float2x2Buffer0
 %Float2x2Buffer1 = OpTypeStruct %float %TestFloat2x2
 %_ptr_Function_Float2x2Buffer1 = OpTypePointer Function %Float2x2Buffer1
-         %17 = OpTypeFunction %void %_ptr_Function_Float2x2Buffer1
+         %21 = OpTypeFunction %void %_ptr_Function_Float2x2Buffer1
 %_ptr_Function_float = OpTypePointer Function %float
 %Float2x2Buffer2 = OpTypeStruct %float %float %TestFloat2x2
 %_ptr_Function_Float2x2Buffer2 = OpTypePointer Function %Float2x2Buffer2
-         %21 = OpTypeFunction %void %_ptr_Function_Float2x2Buffer2
+         %25 = OpTypeFunction %void %_ptr_Function_Float2x2Buffer2
 %UniformBufferFloat2x2Layouts = OpTypeStruct %Float2x2Buffer0 %Float2x2Buffer1 %Float2x2Buffer2
 %_ptr_Function_UniformBufferFloat2x2Layouts = OpTypePointer Function %UniformBufferFloat2x2Layouts
-         %25 = OpTypeFunction %void %_ptr_Function_UniformBufferFloat2x2Layouts
+         %29 = OpTypeFunction %void %_ptr_Function_UniformBufferFloat2x2Layouts
 %_ptr_Uniform_TestFloat2x2 = OpTypePointer Uniform %TestFloat2x2
 %Float2x2Buffer0_0 = OpTypeStruct %TestFloat2x2 %TestFloat2x2
 %_ptr_Uniform_Float2x2Buffer0_0 = OpTypePointer Uniform %Float2x2Buffer0_0
@@ -116,39 +120,35 @@
 %_ptr_Uniform_Float2x2Buffer1_0 = OpTypePointer Uniform %Float2x2Buffer1_0
 %Float2x2Buffer2_0 = OpTypeStruct %float %float %TestFloat2x2
 %_ptr_Uniform_Float2x2Buffer2_0 = OpTypePointer Uniform %Float2x2Buffer2_0
-         %38 = OpTypeFunction %void
-    %float_0 = OpConstant %float 0
-     %uint_0 = OpConstant %uint 0
-     %uint_1 = OpConstant %uint 1
-     %uint_2 = OpConstant %uint 2
+         %42 = OpTypeFunction %void
 %Float2x2Buffer0_Instance = OpVariable %_ptr_Uniform_Float2x2Buffer0_0 Uniform
 %Float2x2Buffer1_Instance = OpVariable %_ptr_Uniform_Float2x2Buffer1_0 Uniform
 %Float2x2Buffer2_Instance = OpVariable %_ptr_Uniform_Float2x2Buffer2_0 Uniform
-%Float2x2Buffer0_PreConstructor = OpFunction %void None %13
+%Float2x2Buffer0_PreConstructor = OpFunction %void None %17
        %self = OpFunctionParameter %_ptr_Function_Float2x2Buffer0
          %50 = OpLabel
                OpReturn
                OpFunctionEnd
-%Float2x2Buffer0_DefaultConstructor = OpFunction %void None %13
+%Float2x2Buffer0_DefaultConstructor = OpFunction %void None %17
      %self_0 = OpFunctionParameter %_ptr_Function_Float2x2Buffer0
          %55 = OpLabel
          %56 = OpFunctionCall %void %Float2x2Buffer0_PreConstructor %self_0
                OpReturn
                OpFunctionEnd
-%Float2x2Buffer1_PreConstructor = OpFunction %void None %17
+%Float2x2Buffer1_PreConstructor = OpFunction %void None %21
      %self_1 = OpFunctionParameter %_ptr_Function_Float2x2Buffer1
          %61 = OpLabel
          %62 = OpAccessChain %_ptr_Function_float %self_1 %uint_0
                OpStore %62 %float_0
                OpReturn
                OpFunctionEnd
-%Float2x2Buffer1_DefaultConstructor = OpFunction %void None %17
+%Float2x2Buffer1_DefaultConstructor = OpFunction %void None %21
      %self_2 = OpFunctionParameter %_ptr_Function_Float2x2Buffer1
          %68 = OpLabel
          %69 = OpFunctionCall %void %Float2x2Buffer1_PreConstructor %self_2
                OpReturn
                OpFunctionEnd
-%Float2x2Buffer2_PreConstructor = OpFunction %void None %21
+%Float2x2Buffer2_PreConstructor = OpFunction %void None %25
      %self_3 = OpFunctionParameter %_ptr_Function_Float2x2Buffer2
          %74 = OpLabel
          %75 = OpAccessChain %_ptr_Function_float %self_3 %uint_0
@@ -157,13 +157,13 @@
                OpStore %77 %float_0
                OpReturn
                OpFunctionEnd
-%Float2x2Buffer2_DefaultConstructor = OpFunction %void None %21
+%Float2x2Buffer2_DefaultConstructor = OpFunction %void None %25
      %self_4 = OpFunctionParameter %_ptr_Function_Float2x2Buffer2
          %83 = OpLabel
          %84 = OpFunctionCall %void %Float2x2Buffer2_PreConstructor %self_4
                OpReturn
                OpFunctionEnd
-%UniformBufferFloat2x2Layouts_PreConstructor = OpFunction %void None %25
+%UniformBufferFloat2x2Layouts_PreConstructor = OpFunction %void None %29
      %self_5 = OpFunctionParameter %_ptr_Function_UniformBufferFloat2x2Layouts
          %89 = OpLabel
 %tempFloat2x2Buffer0 = OpVariable %_ptr_Function_Float2x2Buffer0 Function
@@ -183,18 +183,18 @@
                OpStore %103 %102
                OpReturn
                OpFunctionEnd
-%UniformBufferFloat2x2Layouts_DefaultConstructor = OpFunction %void None %25
+%UniformBufferFloat2x2Layouts_DefaultConstructor = OpFunction %void None %29
      %self_6 = OpFunctionParameter %_ptr_Function_UniformBufferFloat2x2Layouts
         %109 = OpLabel
         %110 = OpFunctionCall %void %UniformBufferFloat2x2Layouts_PreConstructor %self_6
                OpReturn
                OpFunctionEnd
-       %Main = OpFunction %void None %25
+       %Main = OpFunction %void None %29
      %self_7 = OpFunctionParameter %_ptr_Function_UniformBufferFloat2x2Layouts
         %115 = OpLabel
                OpReturn
                OpFunctionEnd
-%UniformBufferFloat2x2Layouts_CopyInputs = OpFunction %void None %25
+%UniformBufferFloat2x2Layouts_CopyInputs = OpFunction %void None %29
      %self_8 = OpFunctionParameter %_ptr_Function_UniformBufferFloat2x2Layouts
         %120 = OpLabel
         %121 = OpAccessChain %_ptr_Function_Float2x2Buffer0 %self_8 %uint_0
@@ -230,7 +230,7 @@
                OpStore %149 %150
                OpReturn
                OpFunctionEnd
-%UniformBufferFloat2x2Layouts_Main_EntryPoint = OpFunction %void None %38
+%UniformBufferFloat2x2Layouts_Main_EntryPoint = OpFunction %void None %42
         %155 = OpLabel
      %self_9 = OpVariable %_ptr_Function_UniformBufferFloat2x2Layouts Function
         %157 = OpFunctionCall %void %UniformBufferFloat2x2Layouts_DefaultConstructor %self_9

--- a/CSShadersTests/Tests/StageInterface/UniformBuffers/Layouts/UniformBufferFloat3x3Layouts.expected.spvtxt
+++ b/CSShadersTests/Tests/StageInterface/UniformBuffers/Layouts/UniformBufferFloat3x3Layouts.expected.spvtxt
@@ -26,6 +26,8 @@
                OpName %Float3x3Buffer1_0 "Float3x3Buffer1_0"
                OpMemberName %Float3x3Buffer1_0 0 "Value0"
                OpMemberName %Float3x3Buffer1_0 1 "Float3x3"
+               OpName %Float3x3Buffer0_Instance "Float3x3Buffer0_Instance"
+               OpName %Float3x3Buffer1_Instance "Float3x3Buffer1_Instance"
                OpName %Float3x3Buffer0_PreConstructor "Float3x3Buffer0_PreConstructor"
                OpName %self "self"
                OpName %Float3x3Buffer0_DefaultConstructor "Float3x3Buffer0_DefaultConstructor"
@@ -46,8 +48,6 @@
                OpName %self_6 "self"
                OpName %UniformBufferFloat3x3Layouts_Main_EntryPoint "UniformBufferFloat3x3Layouts_Main_EntryPoint"
                OpName %self_7 "self"
-               OpName %Float3x3Buffer0_Instance "Float3x3Buffer0_Instance"
-               OpName %Float3x3Buffer1_Instance "Float3x3Buffer1_Instance"
                OpName %UniformBufferFloat3x3Layouts_Main_EntryPoint "UniformBufferFloat3x3Layouts_Main_EntryPoint"
                OpName %self_7 "self"
                OpDecorate %Float3x3Buffer0_0 DescriptorSet 0
@@ -68,19 +68,22 @@
                OpMemberDecorate %Float3x3Buffer1_0 1 ColMajor
        %uint = OpTypeInt 32 0
       %float = OpTypeFloat 32
+    %float_0 = OpConstant %float 0
+     %uint_0 = OpConstant %uint 0
+     %uint_1 = OpConstant %uint 1
 %TestVector3 = OpTypeVector %float 3
 %TestFloat3x3 = OpTypeMatrix %TestVector3 3
 %Float3x3Buffer0 = OpTypeStruct %TestFloat3x3 %TestFloat3x3
        %void = OpTypeVoid
 %_ptr_Function_Float3x3Buffer0 = OpTypePointer Function %Float3x3Buffer0
-         %13 = OpTypeFunction %void %_ptr_Function_Float3x3Buffer0
+         %16 = OpTypeFunction %void %_ptr_Function_Float3x3Buffer0
 %Float3x3Buffer1 = OpTypeStruct %float %TestFloat3x3
 %_ptr_Function_Float3x3Buffer1 = OpTypePointer Function %Float3x3Buffer1
-         %17 = OpTypeFunction %void %_ptr_Function_Float3x3Buffer1
+         %20 = OpTypeFunction %void %_ptr_Function_Float3x3Buffer1
 %_ptr_Function_float = OpTypePointer Function %float
 %UniformBufferFloat3x3Layouts = OpTypeStruct %Float3x3Buffer0 %Float3x3Buffer1
 %_ptr_Function_UniformBufferFloat3x3Layouts = OpTypePointer Function %UniformBufferFloat3x3Layouts
-         %21 = OpTypeFunction %void %_ptr_Function_UniformBufferFloat3x3Layouts
+         %24 = OpTypeFunction %void %_ptr_Function_UniformBufferFloat3x3Layouts
 %_ptr_Uniform_TestFloat3x3 = OpTypePointer Uniform %TestFloat3x3
 %Float3x3Buffer0_0 = OpTypeStruct %TestFloat3x3 %TestFloat3x3
 %_ptr_Uniform_Float3x3Buffer0_0 = OpTypePointer Uniform %Float3x3Buffer0_0
@@ -88,37 +91,34 @@
 %_ptr_Uniform_float = OpTypePointer Uniform %float
 %Float3x3Buffer1_0 = OpTypeStruct %float %TestFloat3x3
 %_ptr_Uniform_Float3x3Buffer1_0 = OpTypePointer Uniform %Float3x3Buffer1_0
-         %31 = OpTypeFunction %void
-    %float_0 = OpConstant %float 0
-     %uint_0 = OpConstant %uint 0
-     %uint_1 = OpConstant %uint 1
+         %34 = OpTypeFunction %void
 %Float3x3Buffer0_Instance = OpVariable %_ptr_Uniform_Float3x3Buffer0_0 Uniform
 %Float3x3Buffer1_Instance = OpVariable %_ptr_Uniform_Float3x3Buffer1_0 Uniform
-%Float3x3Buffer0_PreConstructor = OpFunction %void None %13
+%Float3x3Buffer0_PreConstructor = OpFunction %void None %16
        %self = OpFunctionParameter %_ptr_Function_Float3x3Buffer0
          %41 = OpLabel
                OpReturn
                OpFunctionEnd
-%Float3x3Buffer0_DefaultConstructor = OpFunction %void None %13
+%Float3x3Buffer0_DefaultConstructor = OpFunction %void None %16
      %self_0 = OpFunctionParameter %_ptr_Function_Float3x3Buffer0
          %46 = OpLabel
          %47 = OpFunctionCall %void %Float3x3Buffer0_PreConstructor %self_0
                OpReturn
                OpFunctionEnd
-%Float3x3Buffer1_PreConstructor = OpFunction %void None %17
+%Float3x3Buffer1_PreConstructor = OpFunction %void None %20
      %self_1 = OpFunctionParameter %_ptr_Function_Float3x3Buffer1
          %52 = OpLabel
          %53 = OpAccessChain %_ptr_Function_float %self_1 %uint_0
                OpStore %53 %float_0
                OpReturn
                OpFunctionEnd
-%Float3x3Buffer1_DefaultConstructor = OpFunction %void None %17
+%Float3x3Buffer1_DefaultConstructor = OpFunction %void None %20
      %self_2 = OpFunctionParameter %_ptr_Function_Float3x3Buffer1
          %59 = OpLabel
          %60 = OpFunctionCall %void %Float3x3Buffer1_PreConstructor %self_2
                OpReturn
                OpFunctionEnd
-%UniformBufferFloat3x3Layouts_PreConstructor = OpFunction %void None %21
+%UniformBufferFloat3x3Layouts_PreConstructor = OpFunction %void None %24
      %self_3 = OpFunctionParameter %_ptr_Function_UniformBufferFloat3x3Layouts
          %65 = OpLabel
 %tempFloat3x3Buffer0 = OpVariable %_ptr_Function_Float3x3Buffer0 Function
@@ -133,18 +133,18 @@
                OpStore %74 %73
                OpReturn
                OpFunctionEnd
-%UniformBufferFloat3x3Layouts_DefaultConstructor = OpFunction %void None %21
+%UniformBufferFloat3x3Layouts_DefaultConstructor = OpFunction %void None %24
      %self_4 = OpFunctionParameter %_ptr_Function_UniformBufferFloat3x3Layouts
          %80 = OpLabel
          %81 = OpFunctionCall %void %UniformBufferFloat3x3Layouts_PreConstructor %self_4
                OpReturn
                OpFunctionEnd
-       %Main = OpFunction %void None %21
+       %Main = OpFunction %void None %24
      %self_5 = OpFunctionParameter %_ptr_Function_UniformBufferFloat3x3Layouts
          %86 = OpLabel
                OpReturn
                OpFunctionEnd
-%UniformBufferFloat3x3Layouts_CopyInputs = OpFunction %void None %21
+%UniformBufferFloat3x3Layouts_CopyInputs = OpFunction %void None %24
      %self_6 = OpFunctionParameter %_ptr_Function_UniformBufferFloat3x3Layouts
          %91 = OpLabel
          %92 = OpAccessChain %_ptr_Function_Float3x3Buffer0 %self_6 %uint_0
@@ -167,7 +167,7 @@
                OpStore %107 %108
                OpReturn
                OpFunctionEnd
-%UniformBufferFloat3x3Layouts_Main_EntryPoint = OpFunction %void None %31
+%UniformBufferFloat3x3Layouts_Main_EntryPoint = OpFunction %void None %34
         %113 = OpLabel
      %self_7 = OpVariable %_ptr_Function_UniformBufferFloat3x3Layouts Function
         %115 = OpFunctionCall %void %UniformBufferFloat3x3Layouts_DefaultConstructor %self_7

--- a/CSShadersTests/Tests/StageInterface/UniformBuffers/Layouts/UniformBufferFloat4x4.expected.spvtxt
+++ b/CSShadersTests/Tests/StageInterface/UniformBuffers/Layouts/UniformBufferFloat4x4.expected.spvtxt
@@ -26,6 +26,8 @@
                OpName %Float4x4Buffer1_0 "Float4x4Buffer1_0"
                OpMemberName %Float4x4Buffer1_0 0 "Value0"
                OpMemberName %Float4x4Buffer1_0 1 "Float4x4"
+               OpName %Float4x4Buffer0_Instance "Float4x4Buffer0_Instance"
+               OpName %Float4x4Buffer1_Instance "Float4x4Buffer1_Instance"
                OpName %Float4x4Buffer0_PreConstructor "Float4x4Buffer0_PreConstructor"
                OpName %self "self"
                OpName %Float4x4Buffer0_DefaultConstructor "Float4x4Buffer0_DefaultConstructor"
@@ -46,8 +48,6 @@
                OpName %self_6 "self"
                OpName %UniformBufferFloat4x4Layouts_Main_EntryPoint "UniformBufferFloat4x4Layouts_Main_EntryPoint"
                OpName %self_7 "self"
-               OpName %Float4x4Buffer0_Instance "Float4x4Buffer0_Instance"
-               OpName %Float4x4Buffer1_Instance "Float4x4Buffer1_Instance"
                OpName %UniformBufferFloat4x4Layouts_Main_EntryPoint "UniformBufferFloat4x4Layouts_Main_EntryPoint"
                OpName %self_7 "self"
                OpDecorate %Float4x4Buffer0_0 DescriptorSet 0
@@ -68,19 +68,22 @@
                OpMemberDecorate %Float4x4Buffer1_0 1 ColMajor
        %uint = OpTypeInt 32 0
       %float = OpTypeFloat 32
+    %float_0 = OpConstant %float 0
+     %uint_0 = OpConstant %uint 0
+     %uint_1 = OpConstant %uint 1
 %TestVector4 = OpTypeVector %float 4
 %TestFloat4x4 = OpTypeMatrix %TestVector4 4
 %Float4x4Buffer0 = OpTypeStruct %TestFloat4x4 %TestFloat4x4
        %void = OpTypeVoid
 %_ptr_Function_Float4x4Buffer0 = OpTypePointer Function %Float4x4Buffer0
-         %13 = OpTypeFunction %void %_ptr_Function_Float4x4Buffer0
+         %16 = OpTypeFunction %void %_ptr_Function_Float4x4Buffer0
 %Float4x4Buffer1 = OpTypeStruct %float %TestFloat4x4
 %_ptr_Function_Float4x4Buffer1 = OpTypePointer Function %Float4x4Buffer1
-         %17 = OpTypeFunction %void %_ptr_Function_Float4x4Buffer1
+         %20 = OpTypeFunction %void %_ptr_Function_Float4x4Buffer1
 %_ptr_Function_float = OpTypePointer Function %float
 %UniformBufferFloat4x4Layouts = OpTypeStruct %Float4x4Buffer0 %Float4x4Buffer1
 %_ptr_Function_UniformBufferFloat4x4Layouts = OpTypePointer Function %UniformBufferFloat4x4Layouts
-         %21 = OpTypeFunction %void %_ptr_Function_UniformBufferFloat4x4Layouts
+         %24 = OpTypeFunction %void %_ptr_Function_UniformBufferFloat4x4Layouts
 %_ptr_Uniform_TestFloat4x4 = OpTypePointer Uniform %TestFloat4x4
 %Float4x4Buffer0_0 = OpTypeStruct %TestFloat4x4 %TestFloat4x4
 %_ptr_Uniform_Float4x4Buffer0_0 = OpTypePointer Uniform %Float4x4Buffer0_0
@@ -88,37 +91,34 @@
 %_ptr_Uniform_float = OpTypePointer Uniform %float
 %Float4x4Buffer1_0 = OpTypeStruct %float %TestFloat4x4
 %_ptr_Uniform_Float4x4Buffer1_0 = OpTypePointer Uniform %Float4x4Buffer1_0
-         %31 = OpTypeFunction %void
-    %float_0 = OpConstant %float 0
-     %uint_0 = OpConstant %uint 0
-     %uint_1 = OpConstant %uint 1
+         %34 = OpTypeFunction %void
 %Float4x4Buffer0_Instance = OpVariable %_ptr_Uniform_Float4x4Buffer0_0 Uniform
 %Float4x4Buffer1_Instance = OpVariable %_ptr_Uniform_Float4x4Buffer1_0 Uniform
-%Float4x4Buffer0_PreConstructor = OpFunction %void None %13
+%Float4x4Buffer0_PreConstructor = OpFunction %void None %16
        %self = OpFunctionParameter %_ptr_Function_Float4x4Buffer0
          %41 = OpLabel
                OpReturn
                OpFunctionEnd
-%Float4x4Buffer0_DefaultConstructor = OpFunction %void None %13
+%Float4x4Buffer0_DefaultConstructor = OpFunction %void None %16
      %self_0 = OpFunctionParameter %_ptr_Function_Float4x4Buffer0
          %46 = OpLabel
          %47 = OpFunctionCall %void %Float4x4Buffer0_PreConstructor %self_0
                OpReturn
                OpFunctionEnd
-%Float4x4Buffer1_PreConstructor = OpFunction %void None %17
+%Float4x4Buffer1_PreConstructor = OpFunction %void None %20
      %self_1 = OpFunctionParameter %_ptr_Function_Float4x4Buffer1
          %52 = OpLabel
          %53 = OpAccessChain %_ptr_Function_float %self_1 %uint_0
                OpStore %53 %float_0
                OpReturn
                OpFunctionEnd
-%Float4x4Buffer1_DefaultConstructor = OpFunction %void None %17
+%Float4x4Buffer1_DefaultConstructor = OpFunction %void None %20
      %self_2 = OpFunctionParameter %_ptr_Function_Float4x4Buffer1
          %59 = OpLabel
          %60 = OpFunctionCall %void %Float4x4Buffer1_PreConstructor %self_2
                OpReturn
                OpFunctionEnd
-%UniformBufferFloat4x4Layouts_PreConstructor = OpFunction %void None %21
+%UniformBufferFloat4x4Layouts_PreConstructor = OpFunction %void None %24
      %self_3 = OpFunctionParameter %_ptr_Function_UniformBufferFloat4x4Layouts
          %65 = OpLabel
 %tempFloat4x4Buffer0 = OpVariable %_ptr_Function_Float4x4Buffer0 Function
@@ -133,18 +133,18 @@
                OpStore %74 %73
                OpReturn
                OpFunctionEnd
-%UniformBufferFloat4x4Layouts_DefaultConstructor = OpFunction %void None %21
+%UniformBufferFloat4x4Layouts_DefaultConstructor = OpFunction %void None %24
      %self_4 = OpFunctionParameter %_ptr_Function_UniformBufferFloat4x4Layouts
          %80 = OpLabel
          %81 = OpFunctionCall %void %UniformBufferFloat4x4Layouts_PreConstructor %self_4
                OpReturn
                OpFunctionEnd
-       %Main = OpFunction %void None %21
+       %Main = OpFunction %void None %24
      %self_5 = OpFunctionParameter %_ptr_Function_UniformBufferFloat4x4Layouts
          %86 = OpLabel
                OpReturn
                OpFunctionEnd
-%UniformBufferFloat4x4Layouts_CopyInputs = OpFunction %void None %21
+%UniformBufferFloat4x4Layouts_CopyInputs = OpFunction %void None %24
      %self_6 = OpFunctionParameter %_ptr_Function_UniformBufferFloat4x4Layouts
          %91 = OpLabel
          %92 = OpAccessChain %_ptr_Function_Float4x4Buffer0 %self_6 %uint_0
@@ -167,7 +167,7 @@
                OpStore %107 %108
                OpReturn
                OpFunctionEnd
-%UniformBufferFloat4x4Layouts_Main_EntryPoint = OpFunction %void None %31
+%UniformBufferFloat4x4Layouts_Main_EntryPoint = OpFunction %void None %34
         %113 = OpLabel
      %self_7 = OpVariable %_ptr_Function_UniformBufferFloat4x4Layouts Function
         %115 = OpFunctionCall %void %UniformBufferFloat4x4Layouts_DefaultConstructor %self_7

--- a/CSShadersTests/Tests/StageInterface/UniformBuffers/Layouts/UniformBufferFloatLayouts.expected.spvtxt
+++ b/CSShadersTests/Tests/StageInterface/UniformBuffers/Layouts/UniformBufferFloatLayouts.expected.spvtxt
@@ -23,6 +23,7 @@
                OpMemberName %FloatBuffer_0 2 "Value3"
                OpMemberName %FloatBuffer_0 3 "Value4"
                OpMemberName %FloatBuffer_0 4 "Value5"
+               OpName %FloatBuffer_Instance "FloatBuffer_Instance"
                OpName %FloatBuffer_PreConstructor "FloatBuffer_PreConstructor"
                OpName %self "self"
                OpName %FloatBuffer_DefaultConstructor "FloatBuffer_DefaultConstructor"
@@ -38,7 +39,6 @@
                OpName %self_4 "self"
                OpName %UniformBufferLayouts1_Main_EntryPoint "UniformBufferLayouts1_Main_EntryPoint"
                OpName %self_5 "self"
-               OpName %FloatBuffer_Instance "FloatBuffer_Instance"
                OpName %UniformBufferLayouts1_Main_EntryPoint "UniformBufferLayouts1_Main_EntryPoint"
                OpName %self_5 "self"
                OpDecorate %FloatBuffer_0 DescriptorSet 0
@@ -51,26 +51,26 @@
                OpMemberDecorate %FloatBuffer_0 4 Offset 16
        %uint = OpTypeInt 32 0
       %float = OpTypeFloat 32
-%FloatBuffer = OpTypeStruct %float %float %float %float %float
-       %void = OpTypeVoid
-%_ptr_Function_FloatBuffer = OpTypePointer Function %FloatBuffer
-          %9 = OpTypeFunction %void %_ptr_Function_FloatBuffer
-%_ptr_Function_float = OpTypePointer Function %float
-%UniformBufferLayouts1 = OpTypeStruct %FloatBuffer
-%_ptr_Function_UniformBufferLayouts1 = OpTypePointer Function %UniformBufferLayouts1
-         %13 = OpTypeFunction %void %_ptr_Function_UniformBufferLayouts1
-%_ptr_Uniform_float = OpTypePointer Uniform %float
-%FloatBuffer_0 = OpTypeStruct %float %float %float %float %float
-%_ptr_Uniform_FloatBuffer_0 = OpTypePointer Uniform %FloatBuffer_0
-         %19 = OpTypeFunction %void
     %float_1 = OpConstant %float 1
      %uint_0 = OpConstant %uint 0
      %uint_1 = OpConstant %uint 1
      %uint_2 = OpConstant %uint 2
      %uint_3 = OpConstant %uint 3
      %uint_4 = OpConstant %uint 4
+%FloatBuffer = OpTypeStruct %float %float %float %float %float
+       %void = OpTypeVoid
+%_ptr_Function_FloatBuffer = OpTypePointer Function %FloatBuffer
+         %15 = OpTypeFunction %void %_ptr_Function_FloatBuffer
+%_ptr_Function_float = OpTypePointer Function %float
+%UniformBufferLayouts1 = OpTypeStruct %FloatBuffer
+%_ptr_Function_UniformBufferLayouts1 = OpTypePointer Function %UniformBufferLayouts1
+         %19 = OpTypeFunction %void %_ptr_Function_UniformBufferLayouts1
+%_ptr_Uniform_float = OpTypePointer Uniform %float
+%FloatBuffer_0 = OpTypeStruct %float %float %float %float %float
+%_ptr_Uniform_FloatBuffer_0 = OpTypePointer Uniform %FloatBuffer_0
+         %25 = OpTypeFunction %void
 %FloatBuffer_Instance = OpVariable %_ptr_Uniform_FloatBuffer_0 Uniform
-%FloatBuffer_PreConstructor = OpFunction %void None %9
+%FloatBuffer_PreConstructor = OpFunction %void None %15
        %self = OpFunctionParameter %_ptr_Function_FloatBuffer
          %31 = OpLabel
          %32 = OpAccessChain %_ptr_Function_float %self %uint_0
@@ -85,13 +85,13 @@
                OpStore %40 %float_1
                OpReturn
                OpFunctionEnd
-%FloatBuffer_DefaultConstructor = OpFunction %void None %9
+%FloatBuffer_DefaultConstructor = OpFunction %void None %15
      %self_0 = OpFunctionParameter %_ptr_Function_FloatBuffer
          %46 = OpLabel
          %47 = OpFunctionCall %void %FloatBuffer_PreConstructor %self_0
                OpReturn
                OpFunctionEnd
-%UniformBufferLayouts1_PreConstructor = OpFunction %void None %13
+%UniformBufferLayouts1_PreConstructor = OpFunction %void None %19
      %self_1 = OpFunctionParameter %_ptr_Function_UniformBufferLayouts1
          %52 = OpLabel
 %tempFloatBuffer = OpVariable %_ptr_Function_FloatBuffer Function
@@ -101,18 +101,18 @@
                OpStore %56 %55
                OpReturn
                OpFunctionEnd
-%UniformBufferLayouts1_DefaultConstructor = OpFunction %void None %13
+%UniformBufferLayouts1_DefaultConstructor = OpFunction %void None %19
      %self_2 = OpFunctionParameter %_ptr_Function_UniformBufferLayouts1
          %62 = OpLabel
          %63 = OpFunctionCall %void %UniformBufferLayouts1_PreConstructor %self_2
                OpReturn
                OpFunctionEnd
-       %Main = OpFunction %void None %13
+       %Main = OpFunction %void None %19
      %self_3 = OpFunctionParameter %_ptr_Function_UniformBufferLayouts1
          %68 = OpLabel
                OpReturn
                OpFunctionEnd
-%UniformBufferLayouts1_CopyInputs = OpFunction %void None %13
+%UniformBufferLayouts1_CopyInputs = OpFunction %void None %19
      %self_4 = OpFunctionParameter %_ptr_Function_UniformBufferLayouts1
          %73 = OpLabel
          %74 = OpAccessChain %_ptr_Function_FloatBuffer %self_4 %uint_0
@@ -138,7 +138,7 @@
                OpStore %92 %93
                OpReturn
                OpFunctionEnd
-%UniformBufferLayouts1_Main_EntryPoint = OpFunction %void None %19
+%UniformBufferLayouts1_Main_EntryPoint = OpFunction %void None %25
          %98 = OpLabel
      %self_5 = OpVariable %_ptr_Function_UniformBufferLayouts1 Function
         %100 = OpFunctionCall %void %UniformBufferLayouts1_DefaultConstructor %self_5

--- a/CSShadersTests/Tests/StageInterface/UniformBuffers/Layouts/UniformBufferVec2Layouts.expected.spvtxt
+++ b/CSShadersTests/Tests/StageInterface/UniformBuffers/Layouts/UniformBufferVec2Layouts.expected.spvtxt
@@ -51,6 +51,10 @@
                OpMemberName %Vec2Buffer3_0 1 "Value1"
                OpMemberName %Vec2Buffer3_0 2 "Value2"
                OpMemberName %Vec2Buffer3_0 3 "Vec2"
+               OpName %Vec2Buffer0_Instance "Vec2Buffer0_Instance"
+               OpName %Vec2Buffer1_Instance "Vec2Buffer1_Instance"
+               OpName %Vec2Buffer2_Instance "Vec2Buffer2_Instance"
+               OpName %Vec2Buffer3_Instance "Vec2Buffer3_Instance"
                OpName %Vec2Buffer0_PreConstructor "Vec2Buffer0_PreConstructor"
                OpName %self "self"
                OpName %Vec2Buffer0_DefaultConstructor "Vec2Buffer0_DefaultConstructor"
@@ -81,10 +85,6 @@
                OpName %self_10 "self"
                OpName %UniformBufferVec2Layouts_Main_EntryPoint "UniformBufferVec2Layouts_Main_EntryPoint"
                OpName %self_11 "self"
-               OpName %Vec2Buffer0_Instance "Vec2Buffer0_Instance"
-               OpName %Vec2Buffer1_Instance "Vec2Buffer1_Instance"
-               OpName %Vec2Buffer2_Instance "Vec2Buffer2_Instance"
-               OpName %Vec2Buffer3_Instance "Vec2Buffer3_Instance"
                OpName %UniformBufferVec2Layouts_Main_EntryPoint "UniformBufferVec2Layouts_Main_EntryPoint"
                OpName %self_11 "self"
                OpDecorate %Vec2Buffer0_0 DescriptorSet 0
@@ -115,24 +115,29 @@
                OpMemberDecorate %Vec2Buffer3_0 3 Offset 16
        %uint = OpTypeInt 32 0
       %float = OpTypeFloat 32
+    %float_0 = OpConstant %float 0
+     %uint_0 = OpConstant %uint 0
+     %uint_1 = OpConstant %uint 1
+     %uint_2 = OpConstant %uint 2
+     %uint_3 = OpConstant %uint 3
 %TestVector2 = OpTypeVector %float 2
 %Vec2Buffer0 = OpTypeStruct %TestVector2 %TestVector2 %TestVector2
        %void = OpTypeVoid
 %_ptr_Function_Vec2Buffer0 = OpTypePointer Function %Vec2Buffer0
-         %11 = OpTypeFunction %void %_ptr_Function_Vec2Buffer0
+         %16 = OpTypeFunction %void %_ptr_Function_Vec2Buffer0
 %Vec2Buffer1 = OpTypeStruct %float %TestVector2 %TestVector2
 %_ptr_Function_Vec2Buffer1 = OpTypePointer Function %Vec2Buffer1
-         %15 = OpTypeFunction %void %_ptr_Function_Vec2Buffer1
+         %20 = OpTypeFunction %void %_ptr_Function_Vec2Buffer1
 %_ptr_Function_float = OpTypePointer Function %float
 %Vec2Buffer2 = OpTypeStruct %float %float %TestVector2 %TestVector2
 %_ptr_Function_Vec2Buffer2 = OpTypePointer Function %Vec2Buffer2
-         %19 = OpTypeFunction %void %_ptr_Function_Vec2Buffer2
+         %24 = OpTypeFunction %void %_ptr_Function_Vec2Buffer2
 %Vec2Buffer3 = OpTypeStruct %float %float %float %TestVector2
 %_ptr_Function_Vec2Buffer3 = OpTypePointer Function %Vec2Buffer3
-         %23 = OpTypeFunction %void %_ptr_Function_Vec2Buffer3
+         %28 = OpTypeFunction %void %_ptr_Function_Vec2Buffer3
 %UniformBufferVec2Layouts = OpTypeStruct %Vec2Buffer0 %Vec2Buffer1 %Vec2Buffer2 %Vec2Buffer3
 %_ptr_Function_UniformBufferVec2Layouts = OpTypePointer Function %UniformBufferVec2Layouts
-         %27 = OpTypeFunction %void %_ptr_Function_UniformBufferVec2Layouts
+         %32 = OpTypeFunction %void %_ptr_Function_UniformBufferVec2Layouts
 %_ptr_Uniform_TestVector2 = OpTypePointer Uniform %TestVector2
 %Vec2Buffer0_0 = OpTypeStruct %TestVector2 %TestVector2 %TestVector2
 %_ptr_Uniform_Vec2Buffer0_0 = OpTypePointer Uniform %Vec2Buffer0_0
@@ -144,41 +149,36 @@
 %_ptr_Uniform_Vec2Buffer2_0 = OpTypePointer Uniform %Vec2Buffer2_0
 %Vec2Buffer3_0 = OpTypeStruct %float %float %float %TestVector2
 %_ptr_Uniform_Vec2Buffer3_0 = OpTypePointer Uniform %Vec2Buffer3_0
-         %43 = OpTypeFunction %void
-    %float_0 = OpConstant %float 0
-     %uint_0 = OpConstant %uint 0
-     %uint_1 = OpConstant %uint 1
-     %uint_2 = OpConstant %uint 2
-     %uint_3 = OpConstant %uint 3
+         %48 = OpTypeFunction %void
 %Vec2Buffer0_Instance = OpVariable %_ptr_Uniform_Vec2Buffer0_0 Uniform
 %Vec2Buffer1_Instance = OpVariable %_ptr_Uniform_Vec2Buffer1_0 Uniform
 %Vec2Buffer2_Instance = OpVariable %_ptr_Uniform_Vec2Buffer2_0 Uniform
 %Vec2Buffer3_Instance = OpVariable %_ptr_Uniform_Vec2Buffer3_0 Uniform
-%Vec2Buffer0_PreConstructor = OpFunction %void None %11
+%Vec2Buffer0_PreConstructor = OpFunction %void None %16
        %self = OpFunctionParameter %_ptr_Function_Vec2Buffer0
          %57 = OpLabel
                OpReturn
                OpFunctionEnd
-%Vec2Buffer0_DefaultConstructor = OpFunction %void None %11
+%Vec2Buffer0_DefaultConstructor = OpFunction %void None %16
      %self_0 = OpFunctionParameter %_ptr_Function_Vec2Buffer0
          %62 = OpLabel
          %63 = OpFunctionCall %void %Vec2Buffer0_PreConstructor %self_0
                OpReturn
                OpFunctionEnd
-%Vec2Buffer1_PreConstructor = OpFunction %void None %15
+%Vec2Buffer1_PreConstructor = OpFunction %void None %20
      %self_1 = OpFunctionParameter %_ptr_Function_Vec2Buffer1
          %68 = OpLabel
          %69 = OpAccessChain %_ptr_Function_float %self_1 %uint_0
                OpStore %69 %float_0
                OpReturn
                OpFunctionEnd
-%Vec2Buffer1_DefaultConstructor = OpFunction %void None %15
+%Vec2Buffer1_DefaultConstructor = OpFunction %void None %20
      %self_2 = OpFunctionParameter %_ptr_Function_Vec2Buffer1
          %75 = OpLabel
          %76 = OpFunctionCall %void %Vec2Buffer1_PreConstructor %self_2
                OpReturn
                OpFunctionEnd
-%Vec2Buffer2_PreConstructor = OpFunction %void None %19
+%Vec2Buffer2_PreConstructor = OpFunction %void None %24
      %self_3 = OpFunctionParameter %_ptr_Function_Vec2Buffer2
          %81 = OpLabel
          %82 = OpAccessChain %_ptr_Function_float %self_3 %uint_0
@@ -187,13 +187,13 @@
                OpStore %84 %float_0
                OpReturn
                OpFunctionEnd
-%Vec2Buffer2_DefaultConstructor = OpFunction %void None %19
+%Vec2Buffer2_DefaultConstructor = OpFunction %void None %24
      %self_4 = OpFunctionParameter %_ptr_Function_Vec2Buffer2
          %90 = OpLabel
          %91 = OpFunctionCall %void %Vec2Buffer2_PreConstructor %self_4
                OpReturn
                OpFunctionEnd
-%Vec2Buffer3_PreConstructor = OpFunction %void None %23
+%Vec2Buffer3_PreConstructor = OpFunction %void None %28
      %self_5 = OpFunctionParameter %_ptr_Function_Vec2Buffer3
          %96 = OpLabel
          %97 = OpAccessChain %_ptr_Function_float %self_5 %uint_0
@@ -204,13 +204,13 @@
                OpStore %101 %float_0
                OpReturn
                OpFunctionEnd
-%Vec2Buffer3_DefaultConstructor = OpFunction %void None %23
+%Vec2Buffer3_DefaultConstructor = OpFunction %void None %28
      %self_6 = OpFunctionParameter %_ptr_Function_Vec2Buffer3
         %107 = OpLabel
         %108 = OpFunctionCall %void %Vec2Buffer3_PreConstructor %self_6
                OpReturn
                OpFunctionEnd
-%UniformBufferVec2Layouts_PreConstructor = OpFunction %void None %27
+%UniformBufferVec2Layouts_PreConstructor = OpFunction %void None %32
      %self_7 = OpFunctionParameter %_ptr_Function_UniformBufferVec2Layouts
         %113 = OpLabel
 %tempVec2Buffer0 = OpVariable %_ptr_Function_Vec2Buffer0 Function
@@ -235,18 +235,18 @@
                OpStore %132 %131
                OpReturn
                OpFunctionEnd
-%UniformBufferVec2Layouts_DefaultConstructor = OpFunction %void None %27
+%UniformBufferVec2Layouts_DefaultConstructor = OpFunction %void None %32
      %self_8 = OpFunctionParameter %_ptr_Function_UniformBufferVec2Layouts
         %138 = OpLabel
         %139 = OpFunctionCall %void %UniformBufferVec2Layouts_PreConstructor %self_8
                OpReturn
                OpFunctionEnd
-       %Main = OpFunction %void None %27
+       %Main = OpFunction %void None %32
      %self_9 = OpFunctionParameter %_ptr_Function_UniformBufferVec2Layouts
         %144 = OpLabel
                OpReturn
                OpFunctionEnd
-%UniformBufferVec2Layouts_CopyInputs = OpFunction %void None %27
+%UniformBufferVec2Layouts_CopyInputs = OpFunction %void None %32
     %self_10 = OpFunctionParameter %_ptr_Function_UniformBufferVec2Layouts
         %149 = OpLabel
         %150 = OpAccessChain %_ptr_Function_Vec2Buffer0 %self_10 %uint_0
@@ -311,7 +311,7 @@
                OpStore %207 %208
                OpReturn
                OpFunctionEnd
-%UniformBufferVec2Layouts_Main_EntryPoint = OpFunction %void None %43
+%UniformBufferVec2Layouts_Main_EntryPoint = OpFunction %void None %48
         %213 = OpLabel
     %self_11 = OpVariable %_ptr_Function_UniformBufferVec2Layouts Function
         %215 = OpFunctionCall %void %UniformBufferVec2Layouts_DefaultConstructor %self_11

--- a/CSShadersTests/Tests/StageInterface/UniformBuffers/Layouts/UniformBufferVec3Layouts.expected.spvtxt
+++ b/CSShadersTests/Tests/StageInterface/UniformBuffers/Layouts/UniformBufferVec3Layouts.expected.spvtxt
@@ -54,6 +54,11 @@
                OpMemberName %Vec3Buffer4_0 1 "Value1"
                OpMemberName %Vec3Buffer4_0 2 "Value2"
                OpMemberName %Vec3Buffer4_0 3 "TestVector3"
+               OpName %Vec3Buffer0_Instance "Vec3Buffer0_Instance"
+               OpName %Vec3Buffer1_Instance "Vec3Buffer1_Instance"
+               OpName %Vec3Buffer2_Instance "Vec3Buffer2_Instance"
+               OpName %Vec3Buffer3_Instance "Vec3Buffer3_Instance"
+               OpName %Vec3Buffer4_Instance "Vec3Buffer4_Instance"
                OpName %Vec3Buffer0_PreConstructor "Vec3Buffer0_PreConstructor"
                OpName %self "self"
                OpName %Vec3Buffer0_DefaultConstructor "Vec3Buffer0_DefaultConstructor"
@@ -89,11 +94,6 @@
                OpName %self_12 "self"
                OpName %UniformBufferVec3Layouts_Main_EntryPoint "UniformBufferVec3Layouts_Main_EntryPoint"
                OpName %self_13 "self"
-               OpName %Vec3Buffer0_Instance "Vec3Buffer0_Instance"
-               OpName %Vec3Buffer1_Instance "Vec3Buffer1_Instance"
-               OpName %Vec3Buffer2_Instance "Vec3Buffer2_Instance"
-               OpName %Vec3Buffer3_Instance "Vec3Buffer3_Instance"
-               OpName %Vec3Buffer4_Instance "Vec3Buffer4_Instance"
                OpName %UniformBufferVec3Layouts_Main_EntryPoint "UniformBufferVec3Layouts_Main_EntryPoint"
                OpName %self_13 "self"
                OpDecorate %Vec3Buffer0_0 DescriptorSet 0
@@ -127,27 +127,33 @@
                OpMemberDecorate %Vec3Buffer4_0 3 Offset 16
        %uint = OpTypeInt 32 0
       %float = OpTypeFloat 32
+    %float_0 = OpConstant %float 0
+     %uint_1 = OpConstant %uint 1
+     %uint_0 = OpConstant %uint 0
+     %uint_2 = OpConstant %uint 2
+     %uint_3 = OpConstant %uint 3
+     %uint_4 = OpConstant %uint 4
 %TestVector3 = OpTypeVector %float 3
 %Vec3Buffer0 = OpTypeStruct %TestVector3 %TestVector3
        %void = OpTypeVoid
 %_ptr_Function_Vec3Buffer0 = OpTypePointer Function %Vec3Buffer0
-         %11 = OpTypeFunction %void %_ptr_Function_Vec3Buffer0
+         %17 = OpTypeFunction %void %_ptr_Function_Vec3Buffer0
 %Vec3Buffer1 = OpTypeStruct %TestVector3 %float %TestVector3
 %_ptr_Function_Vec3Buffer1 = OpTypePointer Function %Vec3Buffer1
-         %15 = OpTypeFunction %void %_ptr_Function_Vec3Buffer1
+         %21 = OpTypeFunction %void %_ptr_Function_Vec3Buffer1
 %_ptr_Function_float = OpTypePointer Function %float
 %Vec3Buffer2 = OpTypeStruct %float %TestVector3
 %_ptr_Function_Vec3Buffer2 = OpTypePointer Function %Vec3Buffer2
-         %19 = OpTypeFunction %void %_ptr_Function_Vec3Buffer2
+         %25 = OpTypeFunction %void %_ptr_Function_Vec3Buffer2
 %Vec3Buffer3 = OpTypeStruct %float %float %TestVector3
 %_ptr_Function_Vec3Buffer3 = OpTypePointer Function %Vec3Buffer3
-         %23 = OpTypeFunction %void %_ptr_Function_Vec3Buffer3
+         %29 = OpTypeFunction %void %_ptr_Function_Vec3Buffer3
 %Vec3Buffer4 = OpTypeStruct %float %float %float %TestVector3
 %_ptr_Function_Vec3Buffer4 = OpTypePointer Function %Vec3Buffer4
-         %27 = OpTypeFunction %void %_ptr_Function_Vec3Buffer4
+         %33 = OpTypeFunction %void %_ptr_Function_Vec3Buffer4
 %UniformBufferVec3Layouts = OpTypeStruct %Vec3Buffer0 %Vec3Buffer1 %Vec3Buffer2 %Vec3Buffer3 %Vec3Buffer4
 %_ptr_Function_UniformBufferVec3Layouts = OpTypePointer Function %UniformBufferVec3Layouts
-         %31 = OpTypeFunction %void %_ptr_Function_UniformBufferVec3Layouts
+         %37 = OpTypeFunction %void %_ptr_Function_UniformBufferVec3Layouts
 %_ptr_Uniform_TestVector3 = OpTypePointer Uniform %TestVector3
 %Vec3Buffer0_0 = OpTypeStruct %TestVector3 %TestVector3
 %_ptr_Uniform_Vec3Buffer0_0 = OpTypePointer Uniform %Vec3Buffer0_0
@@ -161,56 +167,50 @@
 %_ptr_Uniform_Vec3Buffer3_0 = OpTypePointer Uniform %Vec3Buffer3_0
 %Vec3Buffer4_0 = OpTypeStruct %float %float %float %TestVector3
 %_ptr_Uniform_Vec3Buffer4_0 = OpTypePointer Uniform %Vec3Buffer4_0
-         %50 = OpTypeFunction %void
-    %float_0 = OpConstant %float 0
-     %uint_1 = OpConstant %uint 1
-     %uint_0 = OpConstant %uint 0
-     %uint_2 = OpConstant %uint 2
-     %uint_3 = OpConstant %uint 3
-     %uint_4 = OpConstant %uint 4
+         %56 = OpTypeFunction %void
 %Vec3Buffer0_Instance = OpVariable %_ptr_Uniform_Vec3Buffer0_0 Uniform
 %Vec3Buffer1_Instance = OpVariable %_ptr_Uniform_Vec3Buffer1_0 Uniform
 %Vec3Buffer2_Instance = OpVariable %_ptr_Uniform_Vec3Buffer2_0 Uniform
 %Vec3Buffer3_Instance = OpVariable %_ptr_Uniform_Vec3Buffer3_0 Uniform
 %Vec3Buffer4_Instance = OpVariable %_ptr_Uniform_Vec3Buffer4_0 Uniform
-%Vec3Buffer0_PreConstructor = OpFunction %void None %11
+%Vec3Buffer0_PreConstructor = OpFunction %void None %17
        %self = OpFunctionParameter %_ptr_Function_Vec3Buffer0
          %66 = OpLabel
                OpReturn
                OpFunctionEnd
-%Vec3Buffer0_DefaultConstructor = OpFunction %void None %11
+%Vec3Buffer0_DefaultConstructor = OpFunction %void None %17
      %self_0 = OpFunctionParameter %_ptr_Function_Vec3Buffer0
          %71 = OpLabel
          %72 = OpFunctionCall %void %Vec3Buffer0_PreConstructor %self_0
                OpReturn
                OpFunctionEnd
-%Vec3Buffer1_PreConstructor = OpFunction %void None %15
+%Vec3Buffer1_PreConstructor = OpFunction %void None %21
      %self_1 = OpFunctionParameter %_ptr_Function_Vec3Buffer1
          %77 = OpLabel
          %78 = OpAccessChain %_ptr_Function_float %self_1 %uint_1
                OpStore %78 %float_0
                OpReturn
                OpFunctionEnd
-%Vec3Buffer1_DefaultConstructor = OpFunction %void None %15
+%Vec3Buffer1_DefaultConstructor = OpFunction %void None %21
      %self_2 = OpFunctionParameter %_ptr_Function_Vec3Buffer1
          %84 = OpLabel
          %85 = OpFunctionCall %void %Vec3Buffer1_PreConstructor %self_2
                OpReturn
                OpFunctionEnd
-%Vec3Buffer2_PreConstructor = OpFunction %void None %19
+%Vec3Buffer2_PreConstructor = OpFunction %void None %25
      %self_3 = OpFunctionParameter %_ptr_Function_Vec3Buffer2
          %90 = OpLabel
          %91 = OpAccessChain %_ptr_Function_float %self_3 %uint_0
                OpStore %91 %float_0
                OpReturn
                OpFunctionEnd
-%Vec3Buffer2_DefaultConstructor = OpFunction %void None %19
+%Vec3Buffer2_DefaultConstructor = OpFunction %void None %25
      %self_4 = OpFunctionParameter %_ptr_Function_Vec3Buffer2
          %97 = OpLabel
          %98 = OpFunctionCall %void %Vec3Buffer2_PreConstructor %self_4
                OpReturn
                OpFunctionEnd
-%Vec3Buffer3_PreConstructor = OpFunction %void None %23
+%Vec3Buffer3_PreConstructor = OpFunction %void None %29
      %self_5 = OpFunctionParameter %_ptr_Function_Vec3Buffer3
         %103 = OpLabel
         %104 = OpAccessChain %_ptr_Function_float %self_5 %uint_0
@@ -219,13 +219,13 @@
                OpStore %106 %float_0
                OpReturn
                OpFunctionEnd
-%Vec3Buffer3_DefaultConstructor = OpFunction %void None %23
+%Vec3Buffer3_DefaultConstructor = OpFunction %void None %29
      %self_6 = OpFunctionParameter %_ptr_Function_Vec3Buffer3
         %112 = OpLabel
         %113 = OpFunctionCall %void %Vec3Buffer3_PreConstructor %self_6
                OpReturn
                OpFunctionEnd
-%Vec3Buffer4_PreConstructor = OpFunction %void None %27
+%Vec3Buffer4_PreConstructor = OpFunction %void None %33
      %self_7 = OpFunctionParameter %_ptr_Function_Vec3Buffer4
         %118 = OpLabel
         %119 = OpAccessChain %_ptr_Function_float %self_7 %uint_0
@@ -236,13 +236,13 @@
                OpStore %123 %float_0
                OpReturn
                OpFunctionEnd
-%Vec3Buffer4_DefaultConstructor = OpFunction %void None %27
+%Vec3Buffer4_DefaultConstructor = OpFunction %void None %33
      %self_8 = OpFunctionParameter %_ptr_Function_Vec3Buffer4
         %129 = OpLabel
         %130 = OpFunctionCall %void %Vec3Buffer4_PreConstructor %self_8
                OpReturn
                OpFunctionEnd
-%UniformBufferVec3Layouts_PreConstructor = OpFunction %void None %31
+%UniformBufferVec3Layouts_PreConstructor = OpFunction %void None %37
      %self_9 = OpFunctionParameter %_ptr_Function_UniformBufferVec3Layouts
         %135 = OpLabel
 %tempVec3Buffer0 = OpVariable %_ptr_Function_Vec3Buffer0 Function
@@ -272,18 +272,18 @@
                OpStore %159 %158
                OpReturn
                OpFunctionEnd
-%UniformBufferVec3Layouts_DefaultConstructor = OpFunction %void None %31
+%UniformBufferVec3Layouts_DefaultConstructor = OpFunction %void None %37
     %self_10 = OpFunctionParameter %_ptr_Function_UniformBufferVec3Layouts
         %165 = OpLabel
         %166 = OpFunctionCall %void %UniformBufferVec3Layouts_PreConstructor %self_10
                OpReturn
                OpFunctionEnd
-       %Main = OpFunction %void None %31
+       %Main = OpFunction %void None %37
     %self_11 = OpFunctionParameter %_ptr_Function_UniformBufferVec3Layouts
         %171 = OpLabel
                OpReturn
                OpFunctionEnd
-%UniformBufferVec3Layouts_CopyInputs = OpFunction %void None %31
+%UniformBufferVec3Layouts_CopyInputs = OpFunction %void None %37
     %self_12 = OpFunctionParameter %_ptr_Function_UniformBufferVec3Layouts
         %176 = OpLabel
         %177 = OpAccessChain %_ptr_Function_Vec3Buffer0 %self_12 %uint_0
@@ -349,7 +349,7 @@
                OpStore %235 %236
                OpReturn
                OpFunctionEnd
-%UniformBufferVec3Layouts_Main_EntryPoint = OpFunction %void None %50
+%UniformBufferVec3Layouts_Main_EntryPoint = OpFunction %void None %56
         %241 = OpLabel
     %self_13 = OpVariable %_ptr_Function_UniformBufferVec3Layouts Function
         %243 = OpFunctionCall %void %UniformBufferVec3Layouts_DefaultConstructor %self_13

--- a/CSShadersTests/Tests/StageInterface/UniformBuffers/Layouts/UniformBufferVec4Layouts.expected.spvtxt
+++ b/CSShadersTests/Tests/StageInterface/UniformBuffers/Layouts/UniformBufferVec4Layouts.expected.spvtxt
@@ -45,6 +45,10 @@
                OpMemberName %Vec4Buffer3_0 1 "Value1"
                OpMemberName %Vec4Buffer3_0 2 "Value2"
                OpMemberName %Vec4Buffer3_0 3 "TestVector4"
+               OpName %Vec4Buffer0_Instance "Vec4Buffer0_Instance"
+               OpName %Vec4Buffer1_Instance "Vec4Buffer1_Instance"
+               OpName %Vec4Buffer2_Instance "Vec4Buffer2_Instance"
+               OpName %Vec4Buffer3_Instance "Vec4Buffer3_Instance"
                OpName %Vec4Buffer0_PreConstructor "Vec4Buffer0_PreConstructor"
                OpName %self "self"
                OpName %Vec4Buffer0_DefaultConstructor "Vec4Buffer0_DefaultConstructor"
@@ -75,10 +79,6 @@
                OpName %self_10 "self"
                OpName %UniformBufferVec4Layouts_Main_EntryPoint "UniformBufferVec4Layouts_Main_EntryPoint"
                OpName %self_11 "self"
-               OpName %Vec4Buffer0_Instance "Vec4Buffer0_Instance"
-               OpName %Vec4Buffer1_Instance "Vec4Buffer1_Instance"
-               OpName %Vec4Buffer2_Instance "Vec4Buffer2_Instance"
-               OpName %Vec4Buffer3_Instance "Vec4Buffer3_Instance"
                OpName %UniformBufferVec4Layouts_Main_EntryPoint "UniformBufferVec4Layouts_Main_EntryPoint"
                OpName %self_11 "self"
                OpDecorate %Vec4Buffer0_0 DescriptorSet 0
@@ -106,24 +106,29 @@
                OpMemberDecorate %Vec4Buffer3_0 3 Offset 16
        %uint = OpTypeInt 32 0
       %float = OpTypeFloat 32
+    %float_0 = OpConstant %float 0
+     %uint_0 = OpConstant %uint 0
+     %uint_1 = OpConstant %uint 1
+     %uint_2 = OpConstant %uint 2
+     %uint_3 = OpConstant %uint 3
 %TestVector4 = OpTypeVector %float 4
 %Vec4Buffer0 = OpTypeStruct %TestVector4 %TestVector4
        %void = OpTypeVoid
 %_ptr_Function_Vec4Buffer0 = OpTypePointer Function %Vec4Buffer0
-         %11 = OpTypeFunction %void %_ptr_Function_Vec4Buffer0
+         %16 = OpTypeFunction %void %_ptr_Function_Vec4Buffer0
 %Vec4Buffer1 = OpTypeStruct %float %TestVector4
 %_ptr_Function_Vec4Buffer1 = OpTypePointer Function %Vec4Buffer1
-         %15 = OpTypeFunction %void %_ptr_Function_Vec4Buffer1
+         %20 = OpTypeFunction %void %_ptr_Function_Vec4Buffer1
 %_ptr_Function_float = OpTypePointer Function %float
 %Vec4Buffer2 = OpTypeStruct %float %float %TestVector4
 %_ptr_Function_Vec4Buffer2 = OpTypePointer Function %Vec4Buffer2
-         %19 = OpTypeFunction %void %_ptr_Function_Vec4Buffer2
+         %24 = OpTypeFunction %void %_ptr_Function_Vec4Buffer2
 %Vec4Buffer3 = OpTypeStruct %float %float %float %TestVector4
 %_ptr_Function_Vec4Buffer3 = OpTypePointer Function %Vec4Buffer3
-         %23 = OpTypeFunction %void %_ptr_Function_Vec4Buffer3
+         %28 = OpTypeFunction %void %_ptr_Function_Vec4Buffer3
 %UniformBufferVec4Layouts = OpTypeStruct %Vec4Buffer0 %Vec4Buffer1 %Vec4Buffer2 %Vec4Buffer3
 %_ptr_Function_UniformBufferVec4Layouts = OpTypePointer Function %UniformBufferVec4Layouts
-         %27 = OpTypeFunction %void %_ptr_Function_UniformBufferVec4Layouts
+         %32 = OpTypeFunction %void %_ptr_Function_UniformBufferVec4Layouts
 %_ptr_Uniform_TestVector4 = OpTypePointer Uniform %TestVector4
 %Vec4Buffer0_0 = OpTypeStruct %TestVector4 %TestVector4
 %_ptr_Uniform_Vec4Buffer0_0 = OpTypePointer Uniform %Vec4Buffer0_0
@@ -135,41 +140,36 @@
 %_ptr_Uniform_Vec4Buffer2_0 = OpTypePointer Uniform %Vec4Buffer2_0
 %Vec4Buffer3_0 = OpTypeStruct %float %float %float %TestVector4
 %_ptr_Uniform_Vec4Buffer3_0 = OpTypePointer Uniform %Vec4Buffer3_0
-         %43 = OpTypeFunction %void
-    %float_0 = OpConstant %float 0
-     %uint_0 = OpConstant %uint 0
-     %uint_1 = OpConstant %uint 1
-     %uint_2 = OpConstant %uint 2
-     %uint_3 = OpConstant %uint 3
+         %48 = OpTypeFunction %void
 %Vec4Buffer0_Instance = OpVariable %_ptr_Uniform_Vec4Buffer0_0 Uniform
 %Vec4Buffer1_Instance = OpVariable %_ptr_Uniform_Vec4Buffer1_0 Uniform
 %Vec4Buffer2_Instance = OpVariable %_ptr_Uniform_Vec4Buffer2_0 Uniform
 %Vec4Buffer3_Instance = OpVariable %_ptr_Uniform_Vec4Buffer3_0 Uniform
-%Vec4Buffer0_PreConstructor = OpFunction %void None %11
+%Vec4Buffer0_PreConstructor = OpFunction %void None %16
        %self = OpFunctionParameter %_ptr_Function_Vec4Buffer0
          %57 = OpLabel
                OpReturn
                OpFunctionEnd
-%Vec4Buffer0_DefaultConstructor = OpFunction %void None %11
+%Vec4Buffer0_DefaultConstructor = OpFunction %void None %16
      %self_0 = OpFunctionParameter %_ptr_Function_Vec4Buffer0
          %62 = OpLabel
          %63 = OpFunctionCall %void %Vec4Buffer0_PreConstructor %self_0
                OpReturn
                OpFunctionEnd
-%Vec4Buffer1_PreConstructor = OpFunction %void None %15
+%Vec4Buffer1_PreConstructor = OpFunction %void None %20
      %self_1 = OpFunctionParameter %_ptr_Function_Vec4Buffer1
          %68 = OpLabel
          %69 = OpAccessChain %_ptr_Function_float %self_1 %uint_0
                OpStore %69 %float_0
                OpReturn
                OpFunctionEnd
-%Vec4Buffer1_DefaultConstructor = OpFunction %void None %15
+%Vec4Buffer1_DefaultConstructor = OpFunction %void None %20
      %self_2 = OpFunctionParameter %_ptr_Function_Vec4Buffer1
          %75 = OpLabel
          %76 = OpFunctionCall %void %Vec4Buffer1_PreConstructor %self_2
                OpReturn
                OpFunctionEnd
-%Vec4Buffer2_PreConstructor = OpFunction %void None %19
+%Vec4Buffer2_PreConstructor = OpFunction %void None %24
      %self_3 = OpFunctionParameter %_ptr_Function_Vec4Buffer2
          %81 = OpLabel
          %82 = OpAccessChain %_ptr_Function_float %self_3 %uint_0
@@ -178,13 +178,13 @@
                OpStore %84 %float_0
                OpReturn
                OpFunctionEnd
-%Vec4Buffer2_DefaultConstructor = OpFunction %void None %19
+%Vec4Buffer2_DefaultConstructor = OpFunction %void None %24
      %self_4 = OpFunctionParameter %_ptr_Function_Vec4Buffer2
          %90 = OpLabel
          %91 = OpFunctionCall %void %Vec4Buffer2_PreConstructor %self_4
                OpReturn
                OpFunctionEnd
-%Vec4Buffer3_PreConstructor = OpFunction %void None %23
+%Vec4Buffer3_PreConstructor = OpFunction %void None %28
      %self_5 = OpFunctionParameter %_ptr_Function_Vec4Buffer3
          %96 = OpLabel
          %97 = OpAccessChain %_ptr_Function_float %self_5 %uint_0
@@ -195,13 +195,13 @@
                OpStore %101 %float_0
                OpReturn
                OpFunctionEnd
-%Vec4Buffer3_DefaultConstructor = OpFunction %void None %23
+%Vec4Buffer3_DefaultConstructor = OpFunction %void None %28
      %self_6 = OpFunctionParameter %_ptr_Function_Vec4Buffer3
         %107 = OpLabel
         %108 = OpFunctionCall %void %Vec4Buffer3_PreConstructor %self_6
                OpReturn
                OpFunctionEnd
-%UniformBufferVec4Layouts_PreConstructor = OpFunction %void None %27
+%UniformBufferVec4Layouts_PreConstructor = OpFunction %void None %32
      %self_7 = OpFunctionParameter %_ptr_Function_UniformBufferVec4Layouts
         %113 = OpLabel
 %tempVec4Buffer0 = OpVariable %_ptr_Function_Vec4Buffer0 Function
@@ -226,18 +226,18 @@
                OpStore %132 %131
                OpReturn
                OpFunctionEnd
-%UniformBufferVec4Layouts_DefaultConstructor = OpFunction %void None %27
+%UniformBufferVec4Layouts_DefaultConstructor = OpFunction %void None %32
      %self_8 = OpFunctionParameter %_ptr_Function_UniformBufferVec4Layouts
         %138 = OpLabel
         %139 = OpFunctionCall %void %UniformBufferVec4Layouts_PreConstructor %self_8
                OpReturn
                OpFunctionEnd
-       %Main = OpFunction %void None %27
+       %Main = OpFunction %void None %32
      %self_9 = OpFunctionParameter %_ptr_Function_UniformBufferVec4Layouts
         %144 = OpLabel
                OpReturn
                OpFunctionEnd
-%UniformBufferVec4Layouts_CopyInputs = OpFunction %void None %27
+%UniformBufferVec4Layouts_CopyInputs = OpFunction %void None %32
     %self_10 = OpFunctionParameter %_ptr_Function_UniformBufferVec4Layouts
         %149 = OpLabel
         %150 = OpAccessChain %_ptr_Function_Vec4Buffer0 %self_10 %uint_0
@@ -290,7 +290,7 @@
                OpStore %195 %196
                OpReturn
                OpFunctionEnd
-%UniformBufferVec4Layouts_Main_EntryPoint = OpFunction %void None %43
+%UniformBufferVec4Layouts_Main_EntryPoint = OpFunction %void None %48
         %201 = OpLabel
     %self_11 = OpVariable %_ptr_Function_UniformBufferVec4Layouts Function
         %203 = OpFunctionCall %void %UniformBufferVec4Layouts_DefaultConstructor %self_11

--- a/CSShadersTests/Tests/StageInterface/UniformBuffers/UniformBuffers1.expected.spvtxt
+++ b/CSShadersTests/Tests/StageInterface/UniformBuffers/UniformBuffers1.expected.spvtxt
@@ -19,6 +19,7 @@
                OpMemberName %Buffer_0 0 "Value"
                OpMemberName %Buffer_0 1 "Value2"
                OpMemberName %Buffer_0 2 "Value3"
+               OpName %Buffer_Instance "Buffer_Instance"
                OpName %Buffer_PreConstructor "Buffer_PreConstructor"
                OpName %self "self"
                OpName %Buffer_DefaultConstructor "Buffer_DefaultConstructor"
@@ -34,7 +35,6 @@
                OpName %self_4 "self"
                OpName %UniformBuffers1_Main_EntryPoint "UniformBuffers1_Main_EntryPoint"
                OpName %self_5 "self"
-               OpName %Buffer_Instance "Buffer_Instance"
                OpName %UniformBuffers1_Main_EntryPoint "UniformBuffers1_Main_EntryPoint"
                OpName %self_5 "self"
                OpDecorate %Buffer_0 DescriptorSet 0
@@ -45,24 +45,24 @@
                OpMemberDecorate %Buffer_0 2 Offset 8
        %uint = OpTypeInt 32 0
       %float = OpTypeFloat 32
-     %Buffer = OpTypeStruct %float %float %float
-       %void = OpTypeVoid
-%_ptr_Function_Buffer = OpTypePointer Function %Buffer
-          %9 = OpTypeFunction %void %_ptr_Function_Buffer
-%_ptr_Function_float = OpTypePointer Function %float
-%UniformBuffers1 = OpTypeStruct %Buffer
-%_ptr_Function_UniformBuffers1 = OpTypePointer Function %UniformBuffers1
-         %13 = OpTypeFunction %void %_ptr_Function_UniformBuffers1
-%_ptr_Uniform_float = OpTypePointer Uniform %float
-   %Buffer_0 = OpTypeStruct %float %float %float
-%_ptr_Uniform_Buffer_0 = OpTypePointer Uniform %Buffer_0
-         %19 = OpTypeFunction %void
     %float_1 = OpConstant %float 1
      %uint_0 = OpConstant %uint 0
      %uint_1 = OpConstant %uint 1
      %uint_2 = OpConstant %uint 2
+     %Buffer = OpTypeStruct %float %float %float
+       %void = OpTypeVoid
+%_ptr_Function_Buffer = OpTypePointer Function %Buffer
+         %13 = OpTypeFunction %void %_ptr_Function_Buffer
+%_ptr_Function_float = OpTypePointer Function %float
+%UniformBuffers1 = OpTypeStruct %Buffer
+%_ptr_Function_UniformBuffers1 = OpTypePointer Function %UniformBuffers1
+         %17 = OpTypeFunction %void %_ptr_Function_UniformBuffers1
+%_ptr_Uniform_float = OpTypePointer Uniform %float
+   %Buffer_0 = OpTypeStruct %float %float %float
+%_ptr_Uniform_Buffer_0 = OpTypePointer Uniform %Buffer_0
+         %23 = OpTypeFunction %void
 %Buffer_Instance = OpVariable %_ptr_Uniform_Buffer_0 Uniform
-%Buffer_PreConstructor = OpFunction %void None %9
+%Buffer_PreConstructor = OpFunction %void None %13
        %self = OpFunctionParameter %_ptr_Function_Buffer
          %29 = OpLabel
          %30 = OpAccessChain %_ptr_Function_float %self %uint_0
@@ -73,13 +73,13 @@
                OpStore %34 %float_1
                OpReturn
                OpFunctionEnd
-%Buffer_DefaultConstructor = OpFunction %void None %9
+%Buffer_DefaultConstructor = OpFunction %void None %13
      %self_0 = OpFunctionParameter %_ptr_Function_Buffer
          %40 = OpLabel
          %41 = OpFunctionCall %void %Buffer_PreConstructor %self_0
                OpReturn
                OpFunctionEnd
-%UniformBuffers1_PreConstructor = OpFunction %void None %13
+%UniformBuffers1_PreConstructor = OpFunction %void None %17
      %self_1 = OpFunctionParameter %_ptr_Function_UniformBuffers1
          %46 = OpLabel
  %tempBuffer = OpVariable %_ptr_Function_Buffer Function
@@ -89,18 +89,18 @@
                OpStore %50 %49
                OpReturn
                OpFunctionEnd
-%UniformBuffers1_DefaultConstructor = OpFunction %void None %13
+%UniformBuffers1_DefaultConstructor = OpFunction %void None %17
      %self_2 = OpFunctionParameter %_ptr_Function_UniformBuffers1
          %56 = OpLabel
          %57 = OpFunctionCall %void %UniformBuffers1_PreConstructor %self_2
                OpReturn
                OpFunctionEnd
-       %Main = OpFunction %void None %13
+       %Main = OpFunction %void None %17
      %self_3 = OpFunctionParameter %_ptr_Function_UniformBuffers1
          %62 = OpLabel
                OpReturn
                OpFunctionEnd
-%UniformBuffers1_CopyInputs = OpFunction %void None %13
+%UniformBuffers1_CopyInputs = OpFunction %void None %17
      %self_4 = OpFunctionParameter %_ptr_Function_UniformBuffers1
          %67 = OpLabel
          %68 = OpAccessChain %_ptr_Function_Buffer %self_4 %uint_0
@@ -118,7 +118,7 @@
                OpStore %78 %79
                OpReturn
                OpFunctionEnd
-%UniformBuffers1_Main_EntryPoint = OpFunction %void None %19
+%UniformBuffers1_Main_EntryPoint = OpFunction %void None %23
          %84 = OpLabel
      %self_5 = OpVariable %_ptr_Function_UniformBuffers1 Function
          %86 = OpFunctionCall %void %UniformBuffers1_DefaultConstructor %self_5

--- a/CSShadersTests/Tests/StageInterface/UniformBuffers/UniformBuffers2.expected.spvtxt
+++ b/CSShadersTests/Tests/StageInterface/UniformBuffers/UniformBuffers2.expected.spvtxt
@@ -28,6 +28,8 @@
                OpMemberName %Buffer2_0 0 "Value"
                OpMemberName %Buffer2_0 1 "Value2"
                OpMemberName %Buffer2_0 2 "Value3"
+               OpName %Buffer1_Instance "Buffer1_Instance"
+               OpName %Buffer2_Instance "Buffer2_Instance"
                OpName %Buffer1_PreConstructor "Buffer1_PreConstructor"
                OpName %self "self"
                OpName %Buffer1_DefaultConstructor "Buffer1_DefaultConstructor"
@@ -48,8 +50,6 @@
                OpName %self_6 "self"
                OpName %UniformBuffers2_Main_EntryPoint "UniformBuffers2_Main_EntryPoint"
                OpName %self_7 "self"
-               OpName %Buffer1_Instance "Buffer1_Instance"
-               OpName %Buffer2_Instance "Buffer2_Instance"
                OpName %UniformBuffers2_Main_EntryPoint "UniformBuffers2_Main_EntryPoint"
                OpName %self_7 "self"
                OpDecorate %Buffer1_0 DescriptorSet 0
@@ -66,30 +66,30 @@
                OpMemberDecorate %Buffer2_0 2 Offset 8
        %uint = OpTypeInt 32 0
       %float = OpTypeFloat 32
+    %float_1 = OpConstant %float 1
+     %uint_0 = OpConstant %uint 0
+     %uint_1 = OpConstant %uint 1
+     %uint_2 = OpConstant %uint 2
     %Buffer1 = OpTypeStruct %float %float %float
        %void = OpTypeVoid
 %_ptr_Function_Buffer1 = OpTypePointer Function %Buffer1
-          %9 = OpTypeFunction %void %_ptr_Function_Buffer1
+         %13 = OpTypeFunction %void %_ptr_Function_Buffer1
 %_ptr_Function_float = OpTypePointer Function %float
     %Buffer2 = OpTypeStruct %float %float %float
 %_ptr_Function_Buffer2 = OpTypePointer Function %Buffer2
-         %13 = OpTypeFunction %void %_ptr_Function_Buffer2
+         %17 = OpTypeFunction %void %_ptr_Function_Buffer2
 %UniformBuffers2 = OpTypeStruct %Buffer1 %Buffer2
 %_ptr_Function_UniformBuffers2 = OpTypePointer Function %UniformBuffers2
-         %17 = OpTypeFunction %void %_ptr_Function_UniformBuffers2
+         %21 = OpTypeFunction %void %_ptr_Function_UniformBuffers2
 %_ptr_Uniform_float = OpTypePointer Uniform %float
   %Buffer1_0 = OpTypeStruct %float %float %float
 %_ptr_Uniform_Buffer1_0 = OpTypePointer Uniform %Buffer1_0
   %Buffer2_0 = OpTypeStruct %float %float %float
 %_ptr_Uniform_Buffer2_0 = OpTypePointer Uniform %Buffer2_0
-         %26 = OpTypeFunction %void
-    %float_1 = OpConstant %float 1
-     %uint_0 = OpConstant %uint 0
-     %uint_1 = OpConstant %uint 1
-     %uint_2 = OpConstant %uint 2
+         %30 = OpTypeFunction %void
 %Buffer1_Instance = OpVariable %_ptr_Uniform_Buffer1_0 Uniform
 %Buffer2_Instance = OpVariable %_ptr_Uniform_Buffer2_0 Uniform
-%Buffer1_PreConstructor = OpFunction %void None %9
+%Buffer1_PreConstructor = OpFunction %void None %13
        %self = OpFunctionParameter %_ptr_Function_Buffer1
          %37 = OpLabel
          %38 = OpAccessChain %_ptr_Function_float %self %uint_0
@@ -100,13 +100,13 @@
                OpStore %42 %float_1
                OpReturn
                OpFunctionEnd
-%Buffer1_DefaultConstructor = OpFunction %void None %9
+%Buffer1_DefaultConstructor = OpFunction %void None %13
      %self_0 = OpFunctionParameter %_ptr_Function_Buffer1
          %48 = OpLabel
          %49 = OpFunctionCall %void %Buffer1_PreConstructor %self_0
                OpReturn
                OpFunctionEnd
-%Buffer2_PreConstructor = OpFunction %void None %13
+%Buffer2_PreConstructor = OpFunction %void None %17
      %self_1 = OpFunctionParameter %_ptr_Function_Buffer2
          %54 = OpLabel
          %55 = OpAccessChain %_ptr_Function_float %self_1 %uint_0
@@ -117,13 +117,13 @@
                OpStore %59 %float_1
                OpReturn
                OpFunctionEnd
-%Buffer2_DefaultConstructor = OpFunction %void None %13
+%Buffer2_DefaultConstructor = OpFunction %void None %17
      %self_2 = OpFunctionParameter %_ptr_Function_Buffer2
          %65 = OpLabel
          %66 = OpFunctionCall %void %Buffer2_PreConstructor %self_2
                OpReturn
                OpFunctionEnd
-%UniformBuffers2_PreConstructor = OpFunction %void None %17
+%UniformBuffers2_PreConstructor = OpFunction %void None %21
      %self_3 = OpFunctionParameter %_ptr_Function_UniformBuffers2
          %71 = OpLabel
 %tempBuffer1 = OpVariable %_ptr_Function_Buffer1 Function
@@ -138,18 +138,18 @@
                OpStore %80 %79
                OpReturn
                OpFunctionEnd
-%UniformBuffers2_DefaultConstructor = OpFunction %void None %17
+%UniformBuffers2_DefaultConstructor = OpFunction %void None %21
      %self_4 = OpFunctionParameter %_ptr_Function_UniformBuffers2
          %86 = OpLabel
          %87 = OpFunctionCall %void %UniformBuffers2_PreConstructor %self_4
                OpReturn
                OpFunctionEnd
-       %Main = OpFunction %void None %17
+       %Main = OpFunction %void None %21
      %self_5 = OpFunctionParameter %_ptr_Function_UniformBuffers2
          %92 = OpLabel
                OpReturn
                OpFunctionEnd
-%UniformBuffers2_CopyInputs = OpFunction %void None %17
+%UniformBuffers2_CopyInputs = OpFunction %void None %21
      %self_6 = OpFunctionParameter %_ptr_Function_UniformBuffers2
          %97 = OpLabel
          %98 = OpAccessChain %_ptr_Function_Buffer1 %self_6 %uint_0
@@ -180,7 +180,7 @@
                OpStore %121 %122
                OpReturn
                OpFunctionEnd
-%UniformBuffers2_Main_EntryPoint = OpFunction %void None %26
+%UniformBuffers2_Main_EntryPoint = OpFunction %void None %30
         %127 = OpLabel
      %self_7 = OpVariable %_ptr_Function_UniformBuffers2 Function
         %129 = OpFunctionCall %void %UniformBuffers2_DefaultConstructor %self_7

--- a/CSShadersTests/Tests/StageInterface/UniformBuffers/UniformBuffers3.expected.spvtxt
+++ b/CSShadersTests/Tests/StageInterface/UniformBuffers/UniformBuffers3.expected.spvtxt
@@ -29,6 +29,9 @@
                OpMemberName %Buffer_2 0 "Value"
                OpMemberName %Buffer_2 1 "Value2"
                OpMemberName %Buffer_2 2 "Value3"
+               OpName %Buffer_Instance "Buffer_Instance"
+               OpName %Buffer_Instance_0 "Buffer_Instance"
+               OpName %Buffer_Instance_1 "Buffer_Instance"
                OpName %Buffer_PreConstructor "Buffer_PreConstructor"
                OpName %self "self"
                OpName %Buffer_DefaultConstructor "Buffer_DefaultConstructor"
@@ -46,9 +49,6 @@
                OpName %self_4 "self"
                OpName %UniformBuffers3_Main_EntryPoint "UniformBuffers3_Main_EntryPoint"
                OpName %self_5 "self"
-               OpName %Buffer_Instance "Buffer_Instance"
-               OpName %Buffer_Instance_0 "Buffer_Instance"
-               OpName %Buffer_Instance_1 "Buffer_Instance"
                OpName %UniformBuffers3_Main_EntryPoint "UniformBuffers3_Main_EntryPoint"
                OpName %self_5 "self"
                OpDecorate %Buffer_0 DescriptorSet 0
@@ -71,14 +71,18 @@
                OpMemberDecorate %Buffer_2 2 Offset 8
        %uint = OpTypeInt 32 0
       %float = OpTypeFloat 32
+    %float_1 = OpConstant %float 1
+     %uint_0 = OpConstant %uint 0
+     %uint_1 = OpConstant %uint 1
+     %uint_2 = OpConstant %uint 2
      %Buffer = OpTypeStruct %float %float %float
        %void = OpTypeVoid
 %_ptr_Function_Buffer = OpTypePointer Function %Buffer
-          %9 = OpTypeFunction %void %_ptr_Function_Buffer
+         %13 = OpTypeFunction %void %_ptr_Function_Buffer
 %_ptr_Function_float = OpTypePointer Function %float
 %UniformBuffers3 = OpTypeStruct %Buffer %Buffer %Buffer
 %_ptr_Function_UniformBuffers3 = OpTypePointer Function %UniformBuffers3
-         %13 = OpTypeFunction %void %_ptr_Function_UniformBuffers3
+         %17 = OpTypeFunction %void %_ptr_Function_UniformBuffers3
 %_ptr_Uniform_float = OpTypePointer Uniform %float
    %Buffer_0 = OpTypeStruct %float %float %float
 %_ptr_Uniform_Buffer_0 = OpTypePointer Uniform %Buffer_0
@@ -86,15 +90,11 @@
 %_ptr_Uniform_Buffer_1 = OpTypePointer Uniform %Buffer_1
    %Buffer_2 = OpTypeStruct %float %float %float
 %_ptr_Uniform_Buffer_2 = OpTypePointer Uniform %Buffer_2
-         %25 = OpTypeFunction %void
-    %float_1 = OpConstant %float 1
-     %uint_0 = OpConstant %uint 0
-     %uint_1 = OpConstant %uint 1
-     %uint_2 = OpConstant %uint 2
+         %29 = OpTypeFunction %void
 %Buffer_Instance = OpVariable %_ptr_Uniform_Buffer_0 Uniform
 %Buffer_Instance_0 = OpVariable %_ptr_Uniform_Buffer_1 Uniform
 %Buffer_Instance_1 = OpVariable %_ptr_Uniform_Buffer_2 Uniform
-%Buffer_PreConstructor = OpFunction %void None %9
+%Buffer_PreConstructor = OpFunction %void None %13
        %self = OpFunctionParameter %_ptr_Function_Buffer
          %37 = OpLabel
          %38 = OpAccessChain %_ptr_Function_float %self %uint_0
@@ -105,13 +105,13 @@
                OpStore %42 %float_1
                OpReturn
                OpFunctionEnd
-%Buffer_DefaultConstructor = OpFunction %void None %9
+%Buffer_DefaultConstructor = OpFunction %void None %13
      %self_0 = OpFunctionParameter %_ptr_Function_Buffer
          %48 = OpLabel
          %49 = OpFunctionCall %void %Buffer_PreConstructor %self_0
                OpReturn
                OpFunctionEnd
-%UniformBuffers3_PreConstructor = OpFunction %void None %13
+%UniformBuffers3_PreConstructor = OpFunction %void None %17
      %self_1 = OpFunctionParameter %_ptr_Function_UniformBuffers3
          %54 = OpLabel
  %tempBuffer = OpVariable %_ptr_Function_Buffer Function
@@ -131,18 +131,18 @@
                OpStore %68 %67
                OpReturn
                OpFunctionEnd
-%UniformBuffers3_DefaultConstructor = OpFunction %void None %13
+%UniformBuffers3_DefaultConstructor = OpFunction %void None %17
      %self_2 = OpFunctionParameter %_ptr_Function_UniformBuffers3
          %74 = OpLabel
          %75 = OpFunctionCall %void %UniformBuffers3_PreConstructor %self_2
                OpReturn
                OpFunctionEnd
-       %Main = OpFunction %void None %13
+       %Main = OpFunction %void None %17
      %self_3 = OpFunctionParameter %_ptr_Function_UniformBuffers3
          %80 = OpLabel
                OpReturn
                OpFunctionEnd
-%UniformBuffers3_CopyInputs = OpFunction %void None %13
+%UniformBuffers3_CopyInputs = OpFunction %void None %17
      %self_4 = OpFunctionParameter %_ptr_Function_UniformBuffers3
          %85 = OpLabel
          %86 = OpAccessChain %_ptr_Function_Buffer %self_4 %uint_0
@@ -186,7 +186,7 @@
                OpStore %122 %123
                OpReturn
                OpFunctionEnd
-%UniformBuffers3_Main_EntryPoint = OpFunction %void None %25
+%UniformBuffers3_Main_EntryPoint = OpFunction %void None %29
         %128 = OpLabel
      %self_5 = OpVariable %_ptr_Function_UniformBuffers3 Function
         %130 = OpFunctionCall %void %UniformBuffers3_DefaultConstructor %self_5

--- a/CSShadersTests/Tests/StageInterface/UniformBuffers/UniformBuffers4.expected.spvtxt
+++ b/CSShadersTests/Tests/StageInterface/UniformBuffers/UniformBuffers4.expected.spvtxt
@@ -34,6 +34,10 @@
                OpMemberName %Buffer_3 0 "Value"
                OpMemberName %Buffer_3 1 "Value2"
                OpMemberName %Buffer_3 2 "Value3"
+               OpName %Buffer_Instance "Buffer_Instance"
+               OpName %Buffer_Instance_0 "Buffer_Instance"
+               OpName %Buffer_Instance_1 "Buffer_Instance"
+               OpName %Buffer_Instance_2 "Buffer_Instance"
                OpName %Buffer_PreConstructor "Buffer_PreConstructor"
                OpName %self "self"
                OpName %Buffer_DefaultConstructor "Buffer_DefaultConstructor"
@@ -52,10 +56,6 @@
                OpName %self_4 "self"
                OpName %UniformBuffers4_Main_EntryPoint "UniformBuffers4_Main_EntryPoint"
                OpName %self_5 "self"
-               OpName %Buffer_Instance "Buffer_Instance"
-               OpName %Buffer_Instance_0 "Buffer_Instance"
-               OpName %Buffer_Instance_1 "Buffer_Instance"
-               OpName %Buffer_Instance_2 "Buffer_Instance"
                OpName %UniformBuffers4_Main_EntryPoint "UniformBuffers4_Main_EntryPoint"
                OpName %self_5 "self"
                OpDecorate %Buffer_0 DescriptorSet 0
@@ -84,14 +84,19 @@
                OpMemberDecorate %Buffer_3 2 Offset 8
        %uint = OpTypeInt 32 0
       %float = OpTypeFloat 32
+    %float_1 = OpConstant %float 1
+     %uint_0 = OpConstant %uint 0
+     %uint_1 = OpConstant %uint 1
+     %uint_2 = OpConstant %uint 2
+     %uint_3 = OpConstant %uint 3
      %Buffer = OpTypeStruct %float %float %float
        %void = OpTypeVoid
 %_ptr_Function_Buffer = OpTypePointer Function %Buffer
-          %9 = OpTypeFunction %void %_ptr_Function_Buffer
+         %14 = OpTypeFunction %void %_ptr_Function_Buffer
 %_ptr_Function_float = OpTypePointer Function %float
 %UniformBuffers4 = OpTypeStruct %Buffer %Buffer %Buffer %Buffer
 %_ptr_Function_UniformBuffers4 = OpTypePointer Function %UniformBuffers4
-         %13 = OpTypeFunction %void %_ptr_Function_UniformBuffers4
+         %18 = OpTypeFunction %void %_ptr_Function_UniformBuffers4
 %_ptr_Uniform_float = OpTypePointer Uniform %float
    %Buffer_0 = OpTypeStruct %float %float %float
 %_ptr_Uniform_Buffer_0 = OpTypePointer Uniform %Buffer_0
@@ -101,17 +106,12 @@
 %_ptr_Uniform_Buffer_2 = OpTypePointer Uniform %Buffer_2
    %Buffer_3 = OpTypeStruct %float %float %float
 %_ptr_Uniform_Buffer_3 = OpTypePointer Uniform %Buffer_3
-         %28 = OpTypeFunction %void
-    %float_1 = OpConstant %float 1
-     %uint_0 = OpConstant %uint 0
-     %uint_1 = OpConstant %uint 1
-     %uint_2 = OpConstant %uint 2
-     %uint_3 = OpConstant %uint 3
+         %33 = OpTypeFunction %void
 %Buffer_Instance = OpVariable %_ptr_Uniform_Buffer_0 Uniform
 %Buffer_Instance_0 = OpVariable %_ptr_Uniform_Buffer_1 Uniform
 %Buffer_Instance_1 = OpVariable %_ptr_Uniform_Buffer_2 Uniform
 %Buffer_Instance_2 = OpVariable %_ptr_Uniform_Buffer_3 Uniform
-%Buffer_PreConstructor = OpFunction %void None %9
+%Buffer_PreConstructor = OpFunction %void None %14
        %self = OpFunctionParameter %_ptr_Function_Buffer
          %42 = OpLabel
          %43 = OpAccessChain %_ptr_Function_float %self %uint_0
@@ -122,13 +122,13 @@
                OpStore %47 %float_1
                OpReturn
                OpFunctionEnd
-%Buffer_DefaultConstructor = OpFunction %void None %9
+%Buffer_DefaultConstructor = OpFunction %void None %14
      %self_0 = OpFunctionParameter %_ptr_Function_Buffer
          %53 = OpLabel
          %54 = OpFunctionCall %void %Buffer_PreConstructor %self_0
                OpReturn
                OpFunctionEnd
-%UniformBuffers4_PreConstructor = OpFunction %void None %13
+%UniformBuffers4_PreConstructor = OpFunction %void None %18
      %self_1 = OpFunctionParameter %_ptr_Function_UniformBuffers4
          %59 = OpLabel
  %tempBuffer = OpVariable %_ptr_Function_Buffer Function
@@ -153,18 +153,18 @@
                OpStore %78 %77
                OpReturn
                OpFunctionEnd
-%UniformBuffers4_DefaultConstructor = OpFunction %void None %13
+%UniformBuffers4_DefaultConstructor = OpFunction %void None %18
      %self_2 = OpFunctionParameter %_ptr_Function_UniformBuffers4
          %84 = OpLabel
          %85 = OpFunctionCall %void %UniformBuffers4_PreConstructor %self_2
                OpReturn
                OpFunctionEnd
-       %Main = OpFunction %void None %13
+       %Main = OpFunction %void None %18
      %self_3 = OpFunctionParameter %_ptr_Function_UniformBuffers4
          %90 = OpLabel
                OpReturn
                OpFunctionEnd
-%UniformBuffers4_CopyInputs = OpFunction %void None %13
+%UniformBuffers4_CopyInputs = OpFunction %void None %18
      %self_4 = OpFunctionParameter %_ptr_Function_UniformBuffers4
          %95 = OpLabel
          %96 = OpAccessChain %_ptr_Function_Buffer %self_4 %uint_0
@@ -221,7 +221,7 @@
                OpStore %145 %146
                OpReturn
                OpFunctionEnd
-%UniformBuffers4_Main_EntryPoint = OpFunction %void None %28
+%UniformBuffers4_Main_EntryPoint = OpFunction %void None %33
         %151 = OpLabel
      %self_5 = OpVariable %_ptr_Function_UniformBuffers4 Function
         %153 = OpFunctionCall %void %UniformBuffers4_DefaultConstructor %self_5

--- a/CSShadersTests/Tests/StageInterface/UniformBuffers/UniformBuffers5.expected.spvtxt
+++ b/CSShadersTests/Tests/StageInterface/UniformBuffers/UniformBuffers5.expected.spvtxt
@@ -26,6 +26,8 @@
                OpMemberName %UniformBuffers5_SharedMaterialBuffer 0 "Value"
                OpMemberName %UniformBuffers5_SharedMaterialBuffer 1 "Value2"
                OpMemberName %UniformBuffers5_SharedMaterialBuffer 2 "Value3"
+               OpName %Buffer_Instance "Buffer_Instance"
+               OpName %UniformBuffers5_SharedMaterialBuffer_Instance "UniformBuffers5_SharedMaterialBuffer_Instance"
                OpName %Buffer_PreConstructor "Buffer_PreConstructor"
                OpName %self "self"
                OpName %Buffer_DefaultConstructor "Buffer_DefaultConstructor"
@@ -41,8 +43,6 @@
                OpName %self_4 "self"
                OpName %UniformBuffers5_Main_EntryPoint "UniformBuffers5_Main_EntryPoint"
                OpName %self_5 "self"
-               OpName %Buffer_Instance "Buffer_Instance"
-               OpName %UniformBuffers5_SharedMaterialBuffer_Instance "UniformBuffers5_SharedMaterialBuffer_Instance"
                OpName %UniformBuffers5_Main_EntryPoint "UniformBuffers5_Main_EntryPoint"
                OpName %self_5 "self"
                OpDecorate %Buffer_0 DescriptorSet 0
@@ -59,28 +59,28 @@
                OpMemberDecorate %UniformBuffers5_SharedMaterialBuffer 2 Offset 8
        %uint = OpTypeInt 32 0
       %float = OpTypeFloat 32
-     %Buffer = OpTypeStruct %float %float %float
-       %void = OpTypeVoid
-%_ptr_Function_Buffer = OpTypePointer Function %Buffer
-          %9 = OpTypeFunction %void %_ptr_Function_Buffer
-%_ptr_Function_float = OpTypePointer Function %float
-%UniformBuffers5 = OpTypeStruct %Buffer %float %float %float
-%_ptr_Function_UniformBuffers5 = OpTypePointer Function %UniformBuffers5
-         %13 = OpTypeFunction %void %_ptr_Function_UniformBuffers5
-%_ptr_Uniform_float = OpTypePointer Uniform %float
-   %Buffer_0 = OpTypeStruct %float %float %float
-%_ptr_Uniform_Buffer_0 = OpTypePointer Uniform %Buffer_0
-%UniformBuffers5_SharedMaterialBuffer = OpTypeStruct %float %float %float
-%_ptr_Uniform_UniformBuffers5_SharedMaterialBuffer = OpTypePointer Uniform %UniformBuffers5_SharedMaterialBuffer
-         %22 = OpTypeFunction %void
     %float_1 = OpConstant %float 1
      %uint_0 = OpConstant %uint 0
      %uint_1 = OpConstant %uint 1
      %uint_2 = OpConstant %uint 2
      %uint_3 = OpConstant %uint 3
+     %Buffer = OpTypeStruct %float %float %float
+       %void = OpTypeVoid
+%_ptr_Function_Buffer = OpTypePointer Function %Buffer
+         %14 = OpTypeFunction %void %_ptr_Function_Buffer
+%_ptr_Function_float = OpTypePointer Function %float
+%UniformBuffers5 = OpTypeStruct %Buffer %float %float %float
+%_ptr_Function_UniformBuffers5 = OpTypePointer Function %UniformBuffers5
+         %18 = OpTypeFunction %void %_ptr_Function_UniformBuffers5
+%_ptr_Uniform_float = OpTypePointer Uniform %float
+   %Buffer_0 = OpTypeStruct %float %float %float
+%_ptr_Uniform_Buffer_0 = OpTypePointer Uniform %Buffer_0
+%UniformBuffers5_SharedMaterialBuffer = OpTypeStruct %float %float %float
+%_ptr_Uniform_UniformBuffers5_SharedMaterialBuffer = OpTypePointer Uniform %UniformBuffers5_SharedMaterialBuffer
+         %27 = OpTypeFunction %void
 %Buffer_Instance = OpVariable %_ptr_Uniform_Buffer_0 Uniform
 %UniformBuffers5_SharedMaterialBuffer_Instance = OpVariable %_ptr_Uniform_UniformBuffers5_SharedMaterialBuffer Uniform
-%Buffer_PreConstructor = OpFunction %void None %9
+%Buffer_PreConstructor = OpFunction %void None %14
        %self = OpFunctionParameter %_ptr_Function_Buffer
          %34 = OpLabel
          %35 = OpAccessChain %_ptr_Function_float %self %uint_0
@@ -91,13 +91,13 @@
                OpStore %39 %float_1
                OpReturn
                OpFunctionEnd
-%Buffer_DefaultConstructor = OpFunction %void None %9
+%Buffer_DefaultConstructor = OpFunction %void None %14
      %self_0 = OpFunctionParameter %_ptr_Function_Buffer
          %45 = OpLabel
          %46 = OpFunctionCall %void %Buffer_PreConstructor %self_0
                OpReturn
                OpFunctionEnd
-%UniformBuffers5_PreConstructor = OpFunction %void None %13
+%UniformBuffers5_PreConstructor = OpFunction %void None %18
      %self_1 = OpFunctionParameter %_ptr_Function_UniformBuffers5
          %51 = OpLabel
  %tempBuffer = OpVariable %_ptr_Function_Buffer Function
@@ -113,18 +113,18 @@
                OpStore %61 %float_1
                OpReturn
                OpFunctionEnd
-%UniformBuffers5_DefaultConstructor = OpFunction %void None %13
+%UniformBuffers5_DefaultConstructor = OpFunction %void None %18
      %self_2 = OpFunctionParameter %_ptr_Function_UniformBuffers5
          %67 = OpLabel
          %68 = OpFunctionCall %void %UniformBuffers5_PreConstructor %self_2
                OpReturn
                OpFunctionEnd
-       %Main = OpFunction %void None %13
+       %Main = OpFunction %void None %18
      %self_3 = OpFunctionParameter %_ptr_Function_UniformBuffers5
          %73 = OpLabel
                OpReturn
                OpFunctionEnd
-%UniformBuffers5_CopyInputs = OpFunction %void None %13
+%UniformBuffers5_CopyInputs = OpFunction %void None %18
      %self_4 = OpFunctionParameter %_ptr_Function_UniformBuffers5
          %78 = OpLabel
          %79 = OpAccessChain %_ptr_Function_Buffer %self_4 %uint_0
@@ -154,7 +154,7 @@
                OpStore %101 %102
                OpReturn
                OpFunctionEnd
-%UniformBuffers5_Main_EntryPoint = OpFunction %void None %22
+%UniformBuffers5_Main_EntryPoint = OpFunction %void None %27
         %107 = OpLabel
      %self_5 = OpVariable %_ptr_Function_UniformBuffers5 Function
         %109 = OpFunctionCall %void %UniformBuffers5_DefaultConstructor %self_5

--- a/CSShadersTests/Tests/StageInterface/UniformsConstants/UniformConstants.expected.spvtxt
+++ b/CSShadersTests/Tests/StageInterface/UniformsConstants/UniformConstants.expected.spvtxt
@@ -11,6 +11,10 @@
                OpSource Unknown 100
                OpName %FloatImage2d "FloatImage2d"
                OpName %FloatSampledImage2d "FloatSampledImage2d"
+               OpName %SampledImage0 "SampledImage0"
+               OpName %SampledImage1 "SampledImage1"
+               OpName %SampledImage2 "SampledImage2"
+               OpName %SampledImage3 "SampledImage3"
                OpName %DescriptorSetBindingIds "DescriptorSetBindingIds"
                OpName %DescriptorSetBindingIds_PreConstructor "DescriptorSetBindingIds_PreConstructor"
                OpName %self "self"
@@ -20,10 +24,6 @@
                OpName %self_1 "self"
                OpName %DescriptorSetBindingIds_Main_EntryPoint "DescriptorSetBindingIds_Main_EntryPoint"
                OpName %self_2 "self"
-               OpName %SampledImage0 "SampledImage0"
-               OpName %SampledImage1 "SampledImage1"
-               OpName %SampledImage2 "SampledImage2"
-               OpName %SampledImage3 "SampledImage3"
                OpName %DescriptorSetBindingIds_Main_EntryPoint "DescriptorSetBindingIds_Main_EntryPoint"
                OpName %self_2 "self"
                OpDecorate %SampledImage0 DescriptorSet 0
@@ -39,32 +39,32 @@
 %FloatImage2d = OpTypeImage %float 2D 0 0 0 1 Unknown
 %FloatSampledImage2d = OpTypeSampledImage %FloatImage2d
 %_ptr_UniformConstant_FloatSampledImage2d = OpTypePointer UniformConstant %FloatSampledImage2d
-%DescriptorSetBindingIds = OpTypeStruct
-       %void = OpTypeVoid
-%_ptr_Function_DescriptorSetBindingIds = OpTypePointer Function %DescriptorSetBindingIds
-         %14 = OpTypeFunction %void %_ptr_Function_DescriptorSetBindingIds
-         %16 = OpTypeFunction %void
 %SampledImage0 = OpVariable %_ptr_UniformConstant_FloatSampledImage2d UniformConstant
 %SampledImage1 = OpVariable %_ptr_UniformConstant_FloatSampledImage2d UniformConstant
 %SampledImage2 = OpVariable %_ptr_UniformConstant_FloatSampledImage2d UniformConstant
 %SampledImage3 = OpVariable %_ptr_UniformConstant_FloatSampledImage2d UniformConstant
-%DescriptorSetBindingIds_PreConstructor = OpFunction %void None %14
+%DescriptorSetBindingIds = OpTypeStruct
+       %void = OpTypeVoid
+%_ptr_Function_DescriptorSetBindingIds = OpTypePointer Function %DescriptorSetBindingIds
+         %18 = OpTypeFunction %void %_ptr_Function_DescriptorSetBindingIds
+         %20 = OpTypeFunction %void
+%DescriptorSetBindingIds_PreConstructor = OpFunction %void None %18
        %self = OpFunctionParameter %_ptr_Function_DescriptorSetBindingIds
          %25 = OpLabel
                OpReturn
                OpFunctionEnd
-%DescriptorSetBindingIds_DefaultConstructor = OpFunction %void None %14
+%DescriptorSetBindingIds_DefaultConstructor = OpFunction %void None %18
      %self_0 = OpFunctionParameter %_ptr_Function_DescriptorSetBindingIds
          %30 = OpLabel
          %31 = OpFunctionCall %void %DescriptorSetBindingIds_PreConstructor %self_0
                OpReturn
                OpFunctionEnd
-       %Main = OpFunction %void None %14
+       %Main = OpFunction %void None %18
      %self_1 = OpFunctionParameter %_ptr_Function_DescriptorSetBindingIds
          %36 = OpLabel
                OpReturn
                OpFunctionEnd
-%DescriptorSetBindingIds_Main_EntryPoint = OpFunction %void None %16
+%DescriptorSetBindingIds_Main_EntryPoint = OpFunction %void None %20
          %40 = OpLabel
      %self_2 = OpVariable %_ptr_Function_DescriptorSetBindingIds Function
          %42 = OpFunctionCall %void %DescriptorSetBindingIds_DefaultConstructor %self_2

--- a/CSShadersTests/Tests/StageInterface/VertexHardwareBuiltInInput/InstanceIndex.expected.spvtxt
+++ b/CSShadersTests/Tests/StageInterface/VertexHardwareBuiltInInput/InstanceIndex.expected.spvtxt
@@ -26,30 +26,30 @@
                OpDecorate %gl_InstanceIndex BuiltIn InstanceIndex
        %uint = OpTypeInt 32 0
         %int = OpTypeInt 32 1
+      %int_0 = OpConstant %int 0
+     %uint_0 = OpConstant %uint 0
 %InstanceIndexTest = OpTypeStruct %int
        %void = OpTypeVoid
 %_ptr_Function_InstanceIndexTest = OpTypePointer Function %InstanceIndexTest
-          %9 = OpTypeFunction %void %_ptr_Function_InstanceIndexTest
+         %11 = OpTypeFunction %void %_ptr_Function_InstanceIndexTest
 %_ptr_Function_int = OpTypePointer Function %int
 %_ptr_Input_int = OpTypePointer Input %int
-         %12 = OpTypeFunction %void
-      %int_0 = OpConstant %int 0
-     %uint_0 = OpConstant %uint 0
+         %14 = OpTypeFunction %void
 %gl_InstanceIndex = OpVariable %_ptr_Input_int Input
-%InstanceIndexTest_PreConstructor = OpFunction %void None %9
+%InstanceIndexTest_PreConstructor = OpFunction %void None %11
        %self = OpFunctionParameter %_ptr_Function_InstanceIndexTest
          %20 = OpLabel
          %21 = OpAccessChain %_ptr_Function_int %self %uint_0
                OpStore %21 %int_0
                OpReturn
                OpFunctionEnd
-%InstanceIndexTest_DefaultConstructor = OpFunction %void None %9
+%InstanceIndexTest_DefaultConstructor = OpFunction %void None %11
      %self_0 = OpFunctionParameter %_ptr_Function_InstanceIndexTest
          %27 = OpLabel
          %28 = OpFunctionCall %void %InstanceIndexTest_PreConstructor %self_0
                OpReturn
                OpFunctionEnd
-       %Main = OpFunction %void None %9
+       %Main = OpFunction %void None %11
      %self_1 = OpFunctionParameter %_ptr_Function_InstanceIndexTest
          %33 = OpLabel
       %index = OpVariable %_ptr_Function_int Function
@@ -58,7 +58,7 @@
                OpStore %index %36
                OpReturn
                OpFunctionEnd
-%InstanceIndexTest_CopyInputs = OpFunction %void None %9
+%InstanceIndexTest_CopyInputs = OpFunction %void None %11
      %self_2 = OpFunctionParameter %_ptr_Function_InstanceIndexTest
          %42 = OpLabel
          %43 = OpAccessChain %_ptr_Function_int %self_2 %uint_0
@@ -66,7 +66,7 @@
                OpStore %43 %44
                OpReturn
                OpFunctionEnd
-%InstanceIndexTest_Main_EntryPoint = OpFunction %void None %12
+%InstanceIndexTest_Main_EntryPoint = OpFunction %void None %14
          %49 = OpLabel
      %self_3 = OpVariable %_ptr_Function_InstanceIndexTest Function
          %51 = OpFunctionCall %void %InstanceIndexTest_DefaultConstructor %self_3

--- a/CSShadersTests/Tests/StageInterface/VertexHardwareBuiltInOutput/Position.expected.spvtxt
+++ b/CSShadersTests/Tests/StageInterface/VertexHardwareBuiltInOutput/Position.expected.spvtxt
@@ -26,32 +26,32 @@
                OpDecorate %gl_Position BuiltIn Position
        %uint = OpTypeInt 32 0
       %float = OpTypeFloat 32
-    %Vector4 = OpTypeVector %float 4
-   %Position = OpTypeStruct %Vector4
-       %void = OpTypeVoid
-%_ptr_Function_Position = OpTypePointer Function %Position
-         %11 = OpTypeFunction %void %_ptr_Function_Position
-%_ptr_Function_Vector4 = OpTypePointer Function %Vector4
-%_ptr_Output_Vector4 = OpTypePointer Output %Vector4
-         %14 = OpTypeFunction %void
     %float_1 = OpConstant %float 1
     %float_2 = OpConstant %float 2
     %float_3 = OpConstant %float 3
     %float_4 = OpConstant %float 4
      %uint_0 = OpConstant %uint 0
+    %Vector4 = OpTypeVector %float 4
+   %Position = OpTypeStruct %Vector4
+       %void = OpTypeVoid
+%_ptr_Function_Position = OpTypePointer Function %Position
+         %16 = OpTypeFunction %void %_ptr_Function_Position
+%_ptr_Function_Vector4 = OpTypePointer Function %Vector4
+%_ptr_Output_Vector4 = OpTypePointer Output %Vector4
+         %19 = OpTypeFunction %void
 %gl_Position = OpVariable %_ptr_Output_Vector4 Output
-%Position_PreConstructor = OpFunction %void None %11
+%Position_PreConstructor = OpFunction %void None %16
        %self = OpFunctionParameter %_ptr_Function_Position
          %25 = OpLabel
                OpReturn
                OpFunctionEnd
-%Position_DefaultConstructor = OpFunction %void None %11
+%Position_DefaultConstructor = OpFunction %void None %16
      %self_0 = OpFunctionParameter %_ptr_Function_Position
          %30 = OpLabel
          %31 = OpFunctionCall %void %Position_PreConstructor %self_0
                OpReturn
                OpFunctionEnd
-       %Main = OpFunction %void None %11
+       %Main = OpFunction %void None %16
      %self_1 = OpFunctionParameter %_ptr_Function_Position
          %36 = OpLabel
          %37 = OpCompositeConstruct %Vector4 %float_1 %float_2 %float_3 %float_4
@@ -59,7 +59,7 @@
                OpStore %38 %37
                OpReturn
                OpFunctionEnd
-%Position_CopyOutputs = OpFunction %void None %11
+%Position_CopyOutputs = OpFunction %void None %16
      %self_2 = OpFunctionParameter %_ptr_Function_Position
          %44 = OpLabel
          %45 = OpAccessChain %_ptr_Function_Vector4 %self_2 %uint_0
@@ -67,7 +67,7 @@
                OpStore %gl_Position %46
                OpReturn
                OpFunctionEnd
-%Position_Main_EntryPoint = OpFunction %void None %14
+%Position_Main_EntryPoint = OpFunction %void None %19
          %51 = OpLabel
      %self_3 = OpVariable %_ptr_Function_Position Function
          %53 = OpFunctionCall %void %Position_DefaultConstructor %self_3

--- a/CSShadersTests/Tests/StageInterface/VertexInputs/Vertex.expected.spvtxt
+++ b/CSShadersTests/Tests/StageInterface/VertexInputs/Vertex.expected.spvtxt
@@ -18,6 +18,10 @@
                OpMemberName %Vertex 1 "Value2"
                OpMemberName %Vertex 2 "V2"
                OpMemberName %Vertex 3 "TestStruct"
+               OpName %Value "Value"
+               OpName %Value2 "Value2"
+               OpName %V2 "V2"
+               OpName %TestStruct_0 "TestStruct"
                OpName %TestStruct_PreConstructor "TestStruct_PreConstructor"
                OpName %self "self"
                OpName %TestStruct_DefaultConstructor "TestStruct_DefaultConstructor"
@@ -33,10 +37,6 @@
                OpName %self_4 "self"
                OpName %Vertex_Main_EntryPoint "Vertex_Main_EntryPoint"
                OpName %self_5 "self"
-               OpName %Value "Value"
-               OpName %Value2 "Value2"
-               OpName %V2 "V2"
-               OpName %TestStruct_0 "TestStruct"
                OpName %Vertex_Main_EntryPoint "Vertex_Main_EntryPoint"
                OpName %self_5 "self"
                OpDecorate %Value Location 0
@@ -45,44 +45,44 @@
                OpDecorate %TestStruct_0 Location 3
        %uint = OpTypeInt 32 0
       %float = OpTypeFloat 32
-%TestVectorPrimitive = OpTypeVector %float 2
- %TestStruct = OpTypeStruct %TestVectorPrimitive %float
-       %void = OpTypeVoid
-%_ptr_Function_TestStruct = OpTypePointer Function %TestStruct
-         %11 = OpTypeFunction %void %_ptr_Function_TestStruct
-%_ptr_Function_float = OpTypePointer Function %float
-     %Vertex = OpTypeStruct %float %float %TestVectorPrimitive %TestStruct
-%_ptr_Function_Vertex = OpTypePointer Function %Vertex
-         %15 = OpTypeFunction %void %_ptr_Function_Vertex
-%_ptr_Input_float = OpTypePointer Input %float
-%_ptr_Function_TestVectorPrimitive = OpTypePointer Function %TestVectorPrimitive
-%_ptr_Input_TestVectorPrimitive = OpTypePointer Input %TestVectorPrimitive
-%_ptr_Input_TestStruct = OpTypePointer Input %TestStruct
-         %20 = OpTypeFunction %void
     %float_0 = OpConstant %float 0
      %uint_1 = OpConstant %uint 1
     %float_1 = OpConstant %float 1
      %uint_0 = OpConstant %uint 0
      %uint_3 = OpConstant %uint 3
      %uint_2 = OpConstant %uint 2
+%TestVectorPrimitive = OpTypeVector %float 2
+ %TestStruct = OpTypeStruct %TestVectorPrimitive %float
+       %void = OpTypeVoid
+%_ptr_Function_TestStruct = OpTypePointer Function %TestStruct
+         %17 = OpTypeFunction %void %_ptr_Function_TestStruct
+%_ptr_Function_float = OpTypePointer Function %float
+     %Vertex = OpTypeStruct %float %float %TestVectorPrimitive %TestStruct
+%_ptr_Function_Vertex = OpTypePointer Function %Vertex
+         %21 = OpTypeFunction %void %_ptr_Function_Vertex
+%_ptr_Input_float = OpTypePointer Input %float
+%_ptr_Function_TestVectorPrimitive = OpTypePointer Function %TestVectorPrimitive
+%_ptr_Input_TestVectorPrimitive = OpTypePointer Input %TestVectorPrimitive
+%_ptr_Input_TestStruct = OpTypePointer Input %TestStruct
+         %26 = OpTypeFunction %void
       %Value = OpVariable %_ptr_Input_float Input
      %Value2 = OpVariable %_ptr_Input_float Input
          %V2 = OpVariable %_ptr_Input_TestVectorPrimitive Input
 %TestStruct_0 = OpVariable %_ptr_Input_TestStruct Input
-%TestStruct_PreConstructor = OpFunction %void None %11
+%TestStruct_PreConstructor = OpFunction %void None %17
        %self = OpFunctionParameter %_ptr_Function_TestStruct
          %35 = OpLabel
          %36 = OpAccessChain %_ptr_Function_float %self %uint_1
                OpStore %36 %float_0
                OpReturn
                OpFunctionEnd
-%TestStruct_DefaultConstructor = OpFunction %void None %11
+%TestStruct_DefaultConstructor = OpFunction %void None %17
      %self_0 = OpFunctionParameter %_ptr_Function_TestStruct
          %42 = OpLabel
          %43 = OpFunctionCall %void %TestStruct_PreConstructor %self_0
                OpReturn
                OpFunctionEnd
-%Vertex_PreConstructor = OpFunction %void None %15
+%Vertex_PreConstructor = OpFunction %void None %21
      %self_1 = OpFunctionParameter %_ptr_Function_Vertex
          %48 = OpLabel
 %tempTestStruct = OpVariable %_ptr_Function_TestStruct Function
@@ -96,18 +96,18 @@
                OpStore %56 %55
                OpReturn
                OpFunctionEnd
-%Vertex_DefaultConstructor = OpFunction %void None %15
+%Vertex_DefaultConstructor = OpFunction %void None %21
      %self_2 = OpFunctionParameter %_ptr_Function_Vertex
          %62 = OpLabel
          %63 = OpFunctionCall %void %Vertex_PreConstructor %self_2
                OpReturn
                OpFunctionEnd
-       %Main = OpFunction %void None %15
+       %Main = OpFunction %void None %21
      %self_3 = OpFunctionParameter %_ptr_Function_Vertex
          %68 = OpLabel
                OpReturn
                OpFunctionEnd
-%Vertex_CopyInputs = OpFunction %void None %15
+%Vertex_CopyInputs = OpFunction %void None %21
      %self_4 = OpFunctionParameter %_ptr_Function_Vertex
          %73 = OpLabel
          %74 = OpAccessChain %_ptr_Function_float %self_4 %uint_0
@@ -124,7 +124,7 @@
                OpStore %83 %84
                OpReturn
                OpFunctionEnd
-%Vertex_Main_EntryPoint = OpFunction %void None %20
+%Vertex_Main_EntryPoint = OpFunction %void None %26
          %89 = OpLabel
      %self_5 = OpVariable %_ptr_Function_Vertex Function
          %91 = OpFunctionCall %void %Vertex_DefaultConstructor %self_5

--- a/CSShadersTests/Tests/StageInterface/VertexOutputs/Vertex.expected.spvtxt
+++ b/CSShadersTests/Tests/StageInterface/VertexOutputs/Vertex.expected.spvtxt
@@ -23,6 +23,7 @@
                OpMemberName %Vertex_Outputs 1 "Value2"
                OpMemberName %Vertex_Outputs 2 "V2"
                OpMemberName %Vertex_Outputs 3 "TestStruct"
+               OpName %Out "Out"
                OpName %TestStruct_PreConstructor "TestStruct_PreConstructor"
                OpName %self "self"
                OpName %TestStruct_DefaultConstructor "TestStruct_DefaultConstructor"
@@ -38,50 +39,49 @@
                OpName %self_4 "self"
                OpName %Vertex_Main_EntryPoint "Vertex_Main_EntryPoint"
                OpName %self_5 "self"
-               OpName %Out "Out"
                OpName %Vertex_Main_EntryPoint "Vertex_Main_EntryPoint"
                OpName %self_5 "self"
                OpDecorate %Out Location 0
                OpDecorate %Vertex_Outputs Block
        %uint = OpTypeInt 32 0
       %float = OpTypeFloat 32
-%TestVectorPrimitive = OpTypeVector %float 2
- %TestStruct = OpTypeStruct %TestVectorPrimitive %float
-       %void = OpTypeVoid
-%_ptr_Function_TestStruct = OpTypePointer Function %TestStruct
-         %11 = OpTypeFunction %void %_ptr_Function_TestStruct
-%_ptr_Function_float = OpTypePointer Function %float
-     %Vertex = OpTypeStruct %float %float %TestVectorPrimitive %TestStruct
-%_ptr_Function_Vertex = OpTypePointer Function %Vertex
-         %15 = OpTypeFunction %void %_ptr_Function_Vertex
-%_ptr_Output_float = OpTypePointer Output %float
-%Vertex_Outputs = OpTypeStruct %float %float %TestVectorPrimitive %TestStruct
-%_ptr_Output_Vertex_Outputs = OpTypePointer Output %Vertex_Outputs
-%_ptr_Output_TestVectorPrimitive = OpTypePointer Output %TestVectorPrimitive
-%_ptr_Function_TestVectorPrimitive = OpTypePointer Function %TestVectorPrimitive
-%_ptr_Output_TestStruct = OpTypePointer Output %TestStruct
-         %23 = OpTypeFunction %void
     %float_0 = OpConstant %float 0
      %uint_1 = OpConstant %uint 1
     %float_1 = OpConstant %float 1
      %uint_0 = OpConstant %uint 0
      %uint_3 = OpConstant %uint 3
      %uint_2 = OpConstant %uint 2
+%TestVectorPrimitive = OpTypeVector %float 2
+ %TestStruct = OpTypeStruct %TestVectorPrimitive %float
+       %void = OpTypeVoid
+%_ptr_Function_TestStruct = OpTypePointer Function %TestStruct
+         %17 = OpTypeFunction %void %_ptr_Function_TestStruct
+%_ptr_Function_float = OpTypePointer Function %float
+     %Vertex = OpTypeStruct %float %float %TestVectorPrimitive %TestStruct
+%_ptr_Function_Vertex = OpTypePointer Function %Vertex
+         %21 = OpTypeFunction %void %_ptr_Function_Vertex
+%_ptr_Output_float = OpTypePointer Output %float
+%Vertex_Outputs = OpTypeStruct %float %float %TestVectorPrimitive %TestStruct
+%_ptr_Output_Vertex_Outputs = OpTypePointer Output %Vertex_Outputs
+%_ptr_Output_TestVectorPrimitive = OpTypePointer Output %TestVectorPrimitive
+%_ptr_Function_TestVectorPrimitive = OpTypePointer Function %TestVectorPrimitive
+%_ptr_Output_TestStruct = OpTypePointer Output %TestStruct
+         %29 = OpTypeFunction %void
         %Out = OpVariable %_ptr_Output_Vertex_Outputs Output
-%TestStruct_PreConstructor = OpFunction %void None %11
+%TestStruct_PreConstructor = OpFunction %void None %17
        %self = OpFunctionParameter %_ptr_Function_TestStruct
          %35 = OpLabel
          %36 = OpAccessChain %_ptr_Function_float %self %uint_1
                OpStore %36 %float_0
                OpReturn
                OpFunctionEnd
-%TestStruct_DefaultConstructor = OpFunction %void None %11
+%TestStruct_DefaultConstructor = OpFunction %void None %17
      %self_0 = OpFunctionParameter %_ptr_Function_TestStruct
          %42 = OpLabel
          %43 = OpFunctionCall %void %TestStruct_PreConstructor %self_0
                OpReturn
                OpFunctionEnd
-%Vertex_PreConstructor = OpFunction %void None %15
+%Vertex_PreConstructor = OpFunction %void None %21
      %self_1 = OpFunctionParameter %_ptr_Function_Vertex
          %48 = OpLabel
 %tempTestStruct = OpVariable %_ptr_Function_TestStruct Function
@@ -95,18 +95,18 @@
                OpStore %56 %55
                OpReturn
                OpFunctionEnd
-%Vertex_DefaultConstructor = OpFunction %void None %15
+%Vertex_DefaultConstructor = OpFunction %void None %21
      %self_2 = OpFunctionParameter %_ptr_Function_Vertex
          %62 = OpLabel
          %63 = OpFunctionCall %void %Vertex_PreConstructor %self_2
                OpReturn
                OpFunctionEnd
-       %Main = OpFunction %void None %15
+       %Main = OpFunction %void None %21
      %self_3 = OpFunctionParameter %_ptr_Function_Vertex
          %68 = OpLabel
                OpReturn
                OpFunctionEnd
-%Vertex_CopyOutputs = OpFunction %void None %15
+%Vertex_CopyOutputs = OpFunction %void None %21
      %self_4 = OpFunctionParameter %_ptr_Function_Vertex
          %73 = OpLabel
          %74 = OpAccessChain %_ptr_Output_float %Out %uint_0
@@ -127,7 +127,7 @@
                OpStore %86 %88
                OpReturn
                OpFunctionEnd
-%Vertex_Main_EntryPoint = OpFunction %void None %23
+%Vertex_Main_EntryPoint = OpFunction %void None %29
          %93 = OpLabel
      %self_5 = OpVariable %_ptr_Function_Vertex Function
          %95 = OpFunctionCall %void %Vertex_DefaultConstructor %self_5

--- a/CSShadersTests/Tests/StageInterface/VertexUniforms/Vertex.expected.spvtxt
+++ b/CSShadersTests/Tests/StageInterface/VertexUniforms/Vertex.expected.spvtxt
@@ -23,6 +23,7 @@
                OpMemberName %Vertex_SharedMaterialBuffer 1 "Value2"
                OpMemberName %Vertex_SharedMaterialBuffer 2 "V2"
                OpMemberName %Vertex_SharedMaterialBuffer 3 "TestStruct"
+               OpName %Vertex_SharedMaterialBuffer_Instance "Vertex_SharedMaterialBuffer_Instance"
                OpName %TestStruct_PreConstructor "TestStruct_PreConstructor"
                OpName %self "self"
                OpName %TestStruct_DefaultConstructor "TestStruct_DefaultConstructor"
@@ -38,7 +39,6 @@
                OpName %self_4 "self"
                OpName %Vertex_Main_EntryPoint "Vertex_Main_EntryPoint"
                OpName %self_5 "self"
-               OpName %Vertex_SharedMaterialBuffer_Instance "Vertex_SharedMaterialBuffer_Instance"
                OpName %Vertex_Main_EntryPoint "Vertex_Main_EntryPoint"
                OpName %self_5 "self"
                OpDecorate %Vertex_SharedMaterialBuffer DescriptorSet 0
@@ -52,43 +52,43 @@
                OpMemberDecorate %Vertex_SharedMaterialBuffer 3 Offset 16
        %uint = OpTypeInt 32 0
       %float = OpTypeFloat 32
-%TestVectorPrimitive = OpTypeVector %float 2
- %TestStruct = OpTypeStruct %TestVectorPrimitive %float
-       %void = OpTypeVoid
-%_ptr_Function_TestStruct = OpTypePointer Function %TestStruct
-         %11 = OpTypeFunction %void %_ptr_Function_TestStruct
-%_ptr_Function_float = OpTypePointer Function %float
-     %Vertex = OpTypeStruct %float %float %TestVectorPrimitive %TestStruct
-%_ptr_Function_Vertex = OpTypePointer Function %Vertex
-         %15 = OpTypeFunction %void %_ptr_Function_Vertex
-%_ptr_Uniform_float = OpTypePointer Uniform %float
-%Vertex_SharedMaterialBuffer = OpTypeStruct %float %float %TestVectorPrimitive %TestStruct
-%_ptr_Uniform_Vertex_SharedMaterialBuffer = OpTypePointer Uniform %Vertex_SharedMaterialBuffer
-%_ptr_Uniform_TestVectorPrimitive = OpTypePointer Uniform %TestVectorPrimitive
-%_ptr_Function_TestVectorPrimitive = OpTypePointer Function %TestVectorPrimitive
-%_ptr_Uniform_TestStruct = OpTypePointer Uniform %TestStruct
-         %23 = OpTypeFunction %void
     %float_0 = OpConstant %float 0
      %uint_1 = OpConstant %uint 1
     %float_1 = OpConstant %float 1
      %uint_0 = OpConstant %uint 0
      %uint_3 = OpConstant %uint 3
      %uint_2 = OpConstant %uint 2
+%TestVectorPrimitive = OpTypeVector %float 2
+ %TestStruct = OpTypeStruct %TestVectorPrimitive %float
+       %void = OpTypeVoid
+%_ptr_Function_TestStruct = OpTypePointer Function %TestStruct
+         %17 = OpTypeFunction %void %_ptr_Function_TestStruct
+%_ptr_Function_float = OpTypePointer Function %float
+     %Vertex = OpTypeStruct %float %float %TestVectorPrimitive %TestStruct
+%_ptr_Function_Vertex = OpTypePointer Function %Vertex
+         %21 = OpTypeFunction %void %_ptr_Function_Vertex
+%_ptr_Uniform_float = OpTypePointer Uniform %float
+%Vertex_SharedMaterialBuffer = OpTypeStruct %float %float %TestVectorPrimitive %TestStruct
+%_ptr_Uniform_Vertex_SharedMaterialBuffer = OpTypePointer Uniform %Vertex_SharedMaterialBuffer
+%_ptr_Uniform_TestVectorPrimitive = OpTypePointer Uniform %TestVectorPrimitive
+%_ptr_Function_TestVectorPrimitive = OpTypePointer Function %TestVectorPrimitive
+%_ptr_Uniform_TestStruct = OpTypePointer Uniform %TestStruct
+         %29 = OpTypeFunction %void
 %Vertex_SharedMaterialBuffer_Instance = OpVariable %_ptr_Uniform_Vertex_SharedMaterialBuffer Uniform
-%TestStruct_PreConstructor = OpFunction %void None %11
+%TestStruct_PreConstructor = OpFunction %void None %17
        %self = OpFunctionParameter %_ptr_Function_TestStruct
          %35 = OpLabel
          %36 = OpAccessChain %_ptr_Function_float %self %uint_1
                OpStore %36 %float_0
                OpReturn
                OpFunctionEnd
-%TestStruct_DefaultConstructor = OpFunction %void None %11
+%TestStruct_DefaultConstructor = OpFunction %void None %17
      %self_0 = OpFunctionParameter %_ptr_Function_TestStruct
          %42 = OpLabel
          %43 = OpFunctionCall %void %TestStruct_PreConstructor %self_0
                OpReturn
                OpFunctionEnd
-%Vertex_PreConstructor = OpFunction %void None %15
+%Vertex_PreConstructor = OpFunction %void None %21
      %self_1 = OpFunctionParameter %_ptr_Function_Vertex
          %48 = OpLabel
 %tempTestStruct = OpVariable %_ptr_Function_TestStruct Function
@@ -102,18 +102,18 @@
                OpStore %56 %55
                OpReturn
                OpFunctionEnd
-%Vertex_DefaultConstructor = OpFunction %void None %15
+%Vertex_DefaultConstructor = OpFunction %void None %21
      %self_2 = OpFunctionParameter %_ptr_Function_Vertex
          %62 = OpLabel
          %63 = OpFunctionCall %void %Vertex_PreConstructor %self_2
                OpReturn
                OpFunctionEnd
-       %Main = OpFunction %void None %15
+       %Main = OpFunction %void None %21
      %self_3 = OpFunctionParameter %_ptr_Function_Vertex
          %68 = OpLabel
                OpReturn
                OpFunctionEnd
-%Vertex_CopyInputs = OpFunction %void None %15
+%Vertex_CopyInputs = OpFunction %void None %21
      %self_4 = OpFunctionParameter %_ptr_Function_Vertex
          %73 = OpLabel
          %74 = OpAccessChain %_ptr_Uniform_float %Vertex_SharedMaterialBuffer_Instance %uint_0
@@ -134,7 +134,7 @@
                OpStore %87 %88
                OpReturn
                OpFunctionEnd
-%Vertex_Main_EntryPoint = OpFunction %void None %23
+%Vertex_Main_EntryPoint = OpFunction %void None %29
          %93 = OpLabel
      %self_5 = OpVariable %_ptr_Function_Vertex Function
          %95 = OpFunctionCall %void %Vertex_DefaultConstructor %self_5

--- a/CSShadersTests/Tests/Types/NestedStructs.expected.spvtxt
+++ b/CSShadersTests/Tests/Types/NestedStructs.expected.spvtxt
@@ -40,43 +40,43 @@
                OpName %self_5 "self"
        %uint = OpTypeInt 32 0
         %int = OpTypeInt 32 1
-      %float = OpTypeFloat 32
-       %bool = OpTypeBool
-    %Struct1 = OpTypeStruct %int
-       %void = OpTypeVoid
-%_ptr_Function_Struct1 = OpTypePointer Function %Struct1
-         %13 = OpTypeFunction %void %_ptr_Function_Struct1
-%_ptr_Function_int = OpTypePointer Function %int
-    %Struct2 = OpTypeStruct %Struct1 %float
-%_ptr_Function_Struct2 = OpTypePointer Function %Struct2
-         %17 = OpTypeFunction %void %_ptr_Function_Struct2
-%_ptr_Function_float = OpTypePointer Function %float
-%NestedStructs = OpTypeStruct %bool %Struct2 %Struct1 %float
-%_ptr_Function_NestedStructs = OpTypePointer Function %NestedStructs
-         %21 = OpTypeFunction %void %_ptr_Function_NestedStructs
-%_ptr_Function_bool = OpTypePointer Function %bool
-         %23 = OpTypeFunction %void
       %int_0 = OpConstant %int 0
      %uint_0 = OpConstant %uint 0
+      %float = OpTypeFloat 32
     %float_0 = OpConstant %float 0
      %uint_1 = OpConstant %uint 1
+       %bool = OpTypeBool
       %false = OpConstantFalse %bool
      %uint_2 = OpConstant %uint 2
      %uint_3 = OpConstant %uint 3
-%Struct1_PreConstructor = OpFunction %void None %13
+    %Struct1 = OpTypeStruct %int
+       %void = OpTypeVoid
+%_ptr_Function_Struct1 = OpTypePointer Function %Struct1
+         %20 = OpTypeFunction %void %_ptr_Function_Struct1
+%_ptr_Function_int = OpTypePointer Function %int
+    %Struct2 = OpTypeStruct %Struct1 %float
+%_ptr_Function_Struct2 = OpTypePointer Function %Struct2
+         %24 = OpTypeFunction %void %_ptr_Function_Struct2
+%_ptr_Function_float = OpTypePointer Function %float
+%NestedStructs = OpTypeStruct %bool %Struct2 %Struct1 %float
+%_ptr_Function_NestedStructs = OpTypePointer Function %NestedStructs
+         %28 = OpTypeFunction %void %_ptr_Function_NestedStructs
+%_ptr_Function_bool = OpTypePointer Function %bool
+         %30 = OpTypeFunction %void
+%Struct1_PreConstructor = OpFunction %void None %20
        %self = OpFunctionParameter %_ptr_Function_Struct1
          %35 = OpLabel
          %36 = OpAccessChain %_ptr_Function_int %self %uint_0
                OpStore %36 %int_0
                OpReturn
                OpFunctionEnd
-%Struct1_DefaultConstructor = OpFunction %void None %13
+%Struct1_DefaultConstructor = OpFunction %void None %20
      %self_0 = OpFunctionParameter %_ptr_Function_Struct1
          %42 = OpLabel
          %43 = OpFunctionCall %void %Struct1_PreConstructor %self_0
                OpReturn
                OpFunctionEnd
-%Struct2_PreConstructor = OpFunction %void None %17
+%Struct2_PreConstructor = OpFunction %void None %24
      %self_1 = OpFunctionParameter %_ptr_Function_Struct2
          %48 = OpLabel
 %tempStruct1 = OpVariable %_ptr_Function_Struct1 Function
@@ -88,13 +88,13 @@
                OpStore %54 %float_0
                OpReturn
                OpFunctionEnd
-%Struct2_DefaultConstructor = OpFunction %void None %17
+%Struct2_DefaultConstructor = OpFunction %void None %24
      %self_2 = OpFunctionParameter %_ptr_Function_Struct2
          %60 = OpLabel
          %61 = OpFunctionCall %void %Struct2_PreConstructor %self_2
                OpReturn
                OpFunctionEnd
-%NestedStructs_PreConstructor = OpFunction %void None %21
+%NestedStructs_PreConstructor = OpFunction %void None %28
      %self_3 = OpFunctionParameter %_ptr_Function_NestedStructs
          %66 = OpLabel
 %tempStruct2 = OpVariable %_ptr_Function_Struct2 Function
@@ -113,13 +113,13 @@
                OpStore %79 %float_0
                OpReturn
                OpFunctionEnd
-%NestedStructs_DefaultConstructor = OpFunction %void None %21
+%NestedStructs_DefaultConstructor = OpFunction %void None %28
      %self_4 = OpFunctionParameter %_ptr_Function_NestedStructs
          %85 = OpLabel
          %86 = OpFunctionCall %void %NestedStructs_PreConstructor %self_4
                OpReturn
                OpFunctionEnd
-%NestedStructs_EntryPoint = OpFunction %void None %23
+%NestedStructs_EntryPoint = OpFunction %void None %30
          %90 = OpLabel
      %self_5 = OpVariable %_ptr_Function_NestedStructs Function
          %92 = OpFunctionCall %void %NestedStructs_DefaultConstructor %self_5

--- a/CSShadersTests/Tests/Types/StructWithPrimitiveFields.expected.spvtxt
+++ b/CSShadersTests/Tests/Types/StructWithPrimitiveFields.expected.spvtxt
@@ -23,26 +23,26 @@
                OpName %StructWithPrimitiveFields_EntryPoint "StructWithPrimitiveFields_EntryPoint"
                OpName %self_1 "self"
        %bool = OpTypeBool
+      %false = OpConstantFalse %bool
        %uint = OpTypeInt 32 0
+     %uint_0 = OpConstant %uint 0
         %int = OpTypeInt 32 1
+      %int_0 = OpConstant %int 0
+     %uint_1 = OpConstant %uint 1
+     %uint_2 = OpConstant %uint 2
       %float = OpTypeFloat 32
+    %float_0 = OpConstant %float 0
+     %uint_3 = OpConstant %uint 3
 %StructWithPrimitiveFields = OpTypeStruct %bool %int %uint %float
        %void = OpTypeVoid
 %_ptr_Function_StructWithPrimitiveFields = OpTypePointer Function %StructWithPrimitiveFields
-         %13 = OpTypeFunction %void %_ptr_Function_StructWithPrimitiveFields
+         %20 = OpTypeFunction %void %_ptr_Function_StructWithPrimitiveFields
 %_ptr_Function_bool = OpTypePointer Function %bool
 %_ptr_Function_int = OpTypePointer Function %int
 %_ptr_Function_uint = OpTypePointer Function %uint
 %_ptr_Function_float = OpTypePointer Function %float
-         %15 = OpTypeFunction %void
-      %false = OpConstantFalse %bool
-     %uint_0 = OpConstant %uint 0
-      %int_0 = OpConstant %int 0
-     %uint_1 = OpConstant %uint 1
-     %uint_2 = OpConstant %uint 2
-    %float_0 = OpConstant %float 0
-     %uint_3 = OpConstant %uint 3
-%StructWithPrimitiveFields_PreConstructor = OpFunction %void None %13
+         %22 = OpTypeFunction %void
+%StructWithPrimitiveFields_PreConstructor = OpFunction %void None %20
        %self = OpFunctionParameter %_ptr_Function_StructWithPrimitiveFields
          %27 = OpLabel
          %28 = OpAccessChain %_ptr_Function_bool %self %uint_0
@@ -55,13 +55,13 @@
                OpStore %34 %float_0
                OpReturn
                OpFunctionEnd
-%StructWithPrimitiveFields_DefaultConstructor = OpFunction %void None %13
+%StructWithPrimitiveFields_DefaultConstructor = OpFunction %void None %20
      %self_0 = OpFunctionParameter %_ptr_Function_StructWithPrimitiveFields
          %40 = OpLabel
          %41 = OpFunctionCall %void %StructWithPrimitiveFields_PreConstructor %self_0
                OpReturn
                OpFunctionEnd
-%StructWithPrimitiveFields_EntryPoint = OpFunction %void None %15
+%StructWithPrimitiveFields_EntryPoint = OpFunction %void None %22
          %45 = OpLabel
      %self_1 = OpVariable %_ptr_Function_StructWithPrimitiveFields Function
          %47 = OpFunctionCall %void %StructWithPrimitiveFields_DefaultConstructor %self_1


### PR DESCRIPTION
The order of types, constants, and globals is intermingled as types can reference constants and so on (e.g. fixed array).